### PR TITLE
fix(chat): add dependency-aware MCP mode orchestration

### DIFF
--- a/batch/mode-runner.mjs
+++ b/batch/mode-runner.mjs
@@ -31,8 +31,10 @@ const SPEC_LOADERS = {
   "reach-out": () => import("./specs/sections.mjs").then((m) => m.outreachSpec),
   negotiate: () => import("./specs/sections.mjs").then((m) => m.negotiateSpec),
   "tailor-cv": () => import("./specs/pdf.mjs").then((m) => m.tailorCvSpec),
+  latex: () => import("./specs/latex.mjs").then((m) => m.latexSpec),
   "cover-letter": () => import("./specs/pdf.mjs").then((m) => m.coverLetterSpec),
 };
+export const MODE_RUNNER_MODE_IDS = Object.freeze(Object.keys(SPEC_LOADERS));
 
 function normalizeModeId(modeId) {
   return modeId === "outreach" ? "reach-out" : modeId;

--- a/batch/specs/latex.mjs
+++ b/batch/specs/latex.mjs
@@ -1,0 +1,116 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { jdBlock, readOptional } from "../lib/inputs.mjs";
+import { resolveOfferSource } from "../lib/offer-source.mjs";
+import { findOfferRow, markOfferPdf } from "../lib/offers.mjs";
+import { extractSentinelPayload } from "../lib/output-parser.mjs";
+import { stripFrontMatter } from "../lib/report-file.mjs";
+import { companySlug, kebabName } from "../lib/slug.mjs";
+
+function defaultCompile(texPath, pdfPath, rootPath) {
+  execFileSync("node", ["cli/generate-latex.mjs", texPath, pdfPath], {
+    cwd: rootPath,
+    stdio: "inherit",
+  });
+}
+
+export const latexSpec = {
+  modeId: "latex",
+  timeoutMs: 600000,
+
+  async loadInputs(ctx) {
+    const offer = findOfferRow(ctx.rootPath, ctx.num);
+    if (!offer) throw new Error(`offer #${ctx.num} not found in data/applications.md`);
+    const cv = readFileSync(join(ctx.rootPath, "inputs/personalization/cv.md"), "utf-8");
+    const profileRaw = readFileSync(
+      join(ctx.rootPath, "inputs/personalization/profile.yml"),
+      "utf-8",
+    );
+    const profile = yaml.load(profileRaw) || {};
+    const narrative = readOptional(join(ctx.rootPath, "inputs/personalization/narrative.md"));
+    const modeBody = stripFrontMatter(
+      readFileSync(join(ctx.rootPath, "content/modes/latex.md"), "utf-8"),
+    );
+    const template = readFileSync(
+      join(ctx.rootPath, "content/templates/cv-template.tex"),
+      "utf-8",
+    );
+    const source = await resolveOfferSource(ctx.rootPath, offer);
+    return {
+      offer,
+      cv,
+      profileRaw,
+      profile,
+      narrative,
+      modeBody,
+      template,
+      source,
+      jd: source.jd,
+    };
+  },
+
+  buildPrompt(ctx, { offer, cv, profileRaw, narrative, modeBody, template, source, jd }) {
+    return `You are running the sur9e "latex" mode headlessly.
+Generate the complete final LaTeX CV. You have no file or shell tools; the app
+writes and compiles the document.
+
+OUTPUT FORMAT:
+- Output exactly one block bounded by <<<SUR9E_OUTPUT>>> and <<<SUR9E_END>>>.
+- Inside the block output only the complete LaTeX document, beginning with
+  \\documentclass and ending with \\end{document}.
+- Do not use markdown fences or commentary.
+
+==================== MODE CONTRACT ====================
+${modeBody}
+
+==================== LATEX TEMPLATE ====================
+${template}
+
+==================== CANDIDATE CV ====================
+${cv}
+
+==================== CANDIDATE PROFILE ====================
+${profileRaw}
+${narrative ? `\n==================== CANDIDATE NARRATIVE ====================\n${narrative}\n` : ""}
+==================== OFFER ====================
+- Offer #: ${offer.num}
+- Company: ${offer.company}
+- Role: ${offer.role}
+- Source: ${source.label}
+
+==================== JOB DESCRIPTION ====================
+${jdBlock(jd)}`;
+  },
+
+  parse(stdout) {
+    const tex = extractSentinelPayload(stdout, {
+      recover: { startRe: /^\\documentclass\b/ },
+    }).trim();
+    if (!tex.startsWith("\\documentclass") || !tex.includes("\\begin{document}")) {
+      throw new Error("payload does not contain a complete LaTeX document");
+    }
+    if (!tex.includes("\\end{document}")) {
+      throw new Error("LaTeX document is missing \\end{document}");
+    }
+    return tex;
+  },
+
+  async write(ctx, { offer, profile }, tex, { compile = defaultCompile } = {}) {
+    const candidate = kebabName(profile?.candidate?.full_name || profile?.name || "candidate");
+    const slug = companySlug(offer.company);
+    const today = new Date().toISOString().slice(0, 10);
+    const base = `cv-latex-${candidate}-${slug}-${ctx.num}-${today}`;
+    const texPath = join(ctx.rootPath, `artifacts/output/${base}.tex`);
+    const pdfPath = join(ctx.rootPath, `artifacts/output/${base}.pdf`);
+    mkdirSync(join(ctx.rootPath, "artifacts/output"), { recursive: true });
+    writeFileSync(texPath, tex, "utf-8");
+    compile(texPath, pdfPath, ctx.rootPath);
+    if (!existsSync(pdfPath)) throw new Error("LaTeX compiler produced no PDF");
+    markOfferPdf(ctx.rootPath, ctx.num);
+    return {
+      summary: `LaTeX CV written: artifacts/output/${base}.tex and artifacts/output/${base}.pdf`,
+    };
+  },
+};

--- a/cli/generate-latex.mjs
+++ b/cli/generate-latex.mjs
@@ -16,8 +16,10 @@
 
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync } from 'fs';
-import { copyFile, readFile, rm, stat } from 'fs/promises';
+import { copyFile, mkdtemp, readFile, rm, stat } from 'fs/promises';
+import { tmpdir } from 'os';
 import { basename, dirname, join, resolve } from 'path';
+import { buildLatexSandboxInvocation } from './lib/latex-sandbox.mjs';
 
 const REQUIRED_SECTIONS = [
   '\\\\section{Education}',
@@ -116,9 +118,8 @@ async function main() {
   }
 
   // --- Compile .tex → .pdf via pdflatex ---
-  const texDir = dirname(absPath);
   const texBase = basename(absPath, '.tex');
-  const defaultPdf = join(texDir, `${texBase}.pdf`);
+  const defaultPdf = join(dirname(absPath), `${texBase}.pdf`);
   const targetPdf = outputPath ? resolve(outputPath) : defaultPdf;
 
   // Ensure output directory exists
@@ -127,37 +128,28 @@ async function main() {
     mkdirSync(targetDir, { recursive: true });
   }
 
+  const sandboxDir = await mkdtemp(join(tmpdir(), 'sur9e-latex-'));
+  const sandboxTex = join(sandboxDir, 'document.tex');
+  const sandboxPdf = join(sandboxDir, 'document.pdf');
+  const sandboxLog = join(sandboxDir, 'document.log');
   try {
-    // Run pdflatex twice for cross-references (standard practice)
-    const pdflatexArgs = [
-      '-no-shell-escape',
-      '-interaction=nonstopmode',
-      '-halt-on-error',
-      `-output-directory=${texDir}`,
-      absPath,
-    ];
-
-    // First pass
-    execFileSync('pdflatex', pdflatexArgs, {
-      cwd: texDir,
+    await copyFile(absPath, sandboxTex);
+    const invocation = buildLatexSandboxInvocation({ sandboxDir });
+    const options = {
+      ...invocation.options,
       stdio: 'pipe',
       timeout: 120_000,
-    });
-
-    // Second pass (resolves references)
-    execFileSync('pdflatex', pdflatexArgs, {
-      cwd: texDir,
-      stdio: 'pipe',
-      timeout: 120_000,
-    });
-
+    };
+    // Run twice for cross-references. Only the isolated document and
+    // system TeX files are visible; the process environment is scrubbed.
+    execFileSync(invocation.command, invocation.args, options);
+    execFileSync(invocation.command, invocation.args, options);
     report.compiled = true;
   } catch (err) {
     // Try to extract useful error from pdflatex log
-    const logPath = join(texDir, `${texBase}.log`);
     let latexError = err.message;
     try {
-      const log = await readFile(logPath, 'utf-8');
+      const log = await readFile(sandboxLog, 'utf-8');
       const errorLines = log.split('\n').filter(l => l.startsWith('!'));
       if (errorLines.length > 0) {
         latexError = errorLines.join('\n');
@@ -173,12 +165,7 @@ async function main() {
   // Post-compile: move PDF and clean up (separate from compile errors)
   if (report.compiled) {
     try {
-      // Move PDF to target location if different
-      if (resolve(defaultPdf) !== resolve(targetPdf)) {
-        await copyFile(defaultPdf, targetPdf);
-        await rm(defaultPdf).catch(() => {});
-      }
-
+      await copyFile(sandboxPdf, targetPdf);
       const pdfStat = await stat(targetPdf);
       report.pdf = {
         path: targetPdf,
@@ -187,14 +174,9 @@ async function main() {
     } catch (err) {
       report.postCompileError = `Failed to finalize PDF: ${err.message}`;
     }
-
-    // Clean up auxiliary files (best-effort)
-    const auxExts = ['.aux', '.log', '.out', '.fls', '.fdb_latexmk', '.synctex.gz'];
-    for (const ext of auxExts) {
-      await rm(join(texDir, `${texBase}${ext}`)).catch(() => {});
-    }
   }
 
+  await rm(sandboxDir, { recursive: true, force: true });
   console.log(JSON.stringify(report, null, 2));
   // A post-compile failure (e.g. copyFile to the requested output path) means
   // the deliverable isn't where the caller asked — that's a failure too.

--- a/cli/lib/latex-sandbox.mjs
+++ b/cli/lib/latex-sandbox.mjs
@@ -1,0 +1,136 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+
+function findExecutable(name, envPath = process.env.PATH ?? '') {
+  for (const directory of envPath.split(delimiter)) {
+    if (!directory) continue;
+    const candidate = join(directory, name);
+    if (existsSync(candidate)) return realpathSync(candidate);
+  }
+  return null;
+}
+
+function sandboxLiteral(value) {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function minimalEnvironment(sandboxDir, executable) {
+  return {
+    HOME: sandboxDir,
+    LANG: 'C.UTF-8',
+    PATH: dirname(executable),
+    TEXMFOUTPUT: sandboxDir,
+    TMPDIR: sandboxDir,
+    openout_any: 'p',
+  };
+}
+
+export function buildLatexSandboxInvocation({
+  sandboxDir: rawSandboxDir,
+  platform = process.platform,
+  envPath = process.env.PATH ?? '',
+  sandboxExecPath = '/usr/bin/sandbox-exec',
+}) {
+  const sandboxDir = realpathSync(rawSandboxDir);
+  const pdflatex = findExecutable('pdflatex', envPath);
+  if (!pdflatex) throw new Error('pdflatex is required to generate a LaTeX PDF');
+
+  const pdflatexArgs = [
+    '-no-shell-escape',
+    '-interaction=nonstopmode',
+    '-halt-on-error',
+    '-output-directory=.',
+    'document.tex',
+  ];
+  const env = minimalEnvironment(sandboxDir, pdflatex);
+
+  if (platform === 'darwin') {
+    if (!existsSync(sandboxExecPath)) {
+      throw new Error('secure LaTeX sandbox unavailable: sandbox-exec is missing');
+    }
+    const readableRoots = [
+      '/System',
+      '/usr',
+      '/Library/TeX',
+      '/Library/Fonts',
+      '/opt/homebrew',
+      '/private/etc/fonts',
+      sandboxDir,
+    ];
+    const profile = [
+      '(version 1)',
+      '(deny default)',
+      '(deny network*)',
+      '(allow process*)',
+      '(allow sysctl-read)',
+      '(allow file-read-metadata)',
+      `(allow file-read* ${readableRoots.map(path => `(subpath ${sandboxLiteral(path)})`).join(' ')})`,
+      `(allow file-write* (subpath ${sandboxLiteral(sandboxDir)}))`,
+    ].join('\n');
+    return {
+      command: sandboxExecPath,
+      args: ['-p', profile, pdflatex, ...pdflatexArgs],
+      options: { cwd: sandboxDir, env },
+    };
+  }
+
+  if (platform === 'linux') {
+    const bwrap = findExecutable('bwrap', envPath);
+    if (!bwrap) {
+      throw new Error(
+        'secure LaTeX sandbox unavailable: install bubblewrap (bwrap) before generating PDFs',
+      );
+    }
+    const systemRoots = ['/usr', '/bin', '/lib', '/lib64', '/opt'].filter(existsSync);
+    const configRoots = ['/etc/fonts', '/etc/texmf'].filter(existsSync);
+    return {
+      command: bwrap,
+      args: [
+        '--die-with-parent',
+        '--new-session',
+        '--unshare-all',
+        '--clearenv',
+        '--proc',
+        '/proc',
+        '--dev',
+        '/dev',
+        '--tmpfs',
+        '/tmp',
+        '--dir',
+        '/etc',
+        '--dir',
+        '/work',
+        ...systemRoots.flatMap(path => ['--ro-bind', path, path]),
+        ...configRoots.flatMap(path => ['--ro-bind', path, path]),
+        '--bind',
+        sandboxDir,
+        '/work',
+        '--chdir',
+        '/work',
+        '--setenv',
+        'HOME',
+        '/work',
+        '--setenv',
+        'TMPDIR',
+        '/work',
+        '--setenv',
+        'TEXMFOUTPUT',
+        '/work',
+        '--setenv',
+        'openout_any',
+        'p',
+        '--setenv',
+        'PATH',
+        dirname(pdflatex),
+        '--setenv',
+        'LANG',
+        'C.UTF-8',
+        pdflatex,
+        ...pdflatexArgs,
+      ],
+      options: { cwd: sandboxDir, env },
+    };
+  }
+
+  throw new Error(`secure LaTeX sandbox unavailable on ${platform}`);
+}

--- a/cli/mcp-app-server.mjs
+++ b/cli/mcp-app-server.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 // cli/mcp-app-server.mjs — the sur9e-app MCP server (stdio transport).
 //
 // Bridges an AI agent (a web-chat turn or a terminal session) to the
@@ -16,7 +17,11 @@
 //
 // stdout carries ONLY JSON-RPC frames; all logging goes to stderr.
 
+import { createRequire } from 'node:module';
 import { createInterface } from 'node:readline';
+
+const require = createRequire(import.meta.url);
+const MODE_DATA = require('../src/lib/modes/catalog.json');
 
 const APP_URL = (process.env.SUR9E_APP_URL ?? 'http://localhost:3000').replace(/\/+$/, '');
 const TURN_ID = process.env.SUR9E_CHAT_TURN_ID ?? '';
@@ -25,6 +30,25 @@ const PROTOCOL_VERSION = '2025-06-18';
 const SERVER_INFO = { name: 'sur9e-app', version: '1.0.0' };
 
 const READ_TOOLS = [
+  {
+    name: 'list_modes',
+    description:
+      'List every canonical sur9e mode, alias, execution type, scope, and dependency capability. Read-only.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
+  {
+    name: 'get_mode_instructions',
+    description:
+      'Load the canonical instructions for one inline or handoff mode before running it in chat.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', minLength: 1, description: 'Canonical mode id or legacy alias' },
+      },
+      required: ['mode'],
+      additionalProperties: false,
+    },
+  },
   {
     name: 'get_tracker',
     description:
@@ -61,22 +85,19 @@ const READ_TOOLS = [
     description: 'Background jobs currently queued or running, grouped by job type. Read-only.',
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
   },
+  {
+    name: 'list_workflows',
+    description:
+      'List persisted multi-mode workflows and their child-step states. Also reconciles completed child jobs. Read-only.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+  },
 ];
 
-// Every job kind the chat can launch (spec §2 v1 capabilities).
-const JOB_KINDS = [
-  'evaluate',
-  'tailor-cv',
-  'cover-letter',
-  'research',
-  'interview-prep',
-  'reach-out',
-  'negotiate',
-  'scan',
-  'batch-evaluate',
-  'screen',
-  'screen-evaluate',
-];
+// Backward-compatible single-job surface. Multi-mode and composite work uses
+// start_workflow; screen-evaluate remains here only as a declared legacy path.
+const JOB_KINDS = Object.entries(MODE_DATA.modes)
+  .filter(([, mode]) => mode.singleJob === true)
+  .map(([id]) => id);
 
 const TERMINAL_APPROVED_DESC =
   'Terminal sessions only: set true ONLY after the user explicitly approved this exact ' +
@@ -84,9 +105,73 @@ const TERMINAL_APPROVED_DESC =
 
 const ACTION_TOOLS = [
   {
+    name: 'start_workflow',
+    description:
+      'Plan and start one dependency-aware workflow for one or many explicit offers. The server inserts prerequisites, serializes report writers, and parallelizes only safe work. Use this for multiple modes or selected-offer bulk actions. ALWAYS requires one user approval.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        targets: {
+          type: 'array',
+          minItems: 0,
+          items: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: { num: { type: 'integer', minimum: 1 } },
+                required: ['num'],
+                additionalProperties: false,
+              },
+              {
+                type: 'object',
+                properties: { url: { type: 'string', format: 'uri' } },
+                required: ['url'],
+                additionalProperties: false,
+              },
+            ],
+          },
+          description:
+            'Explicit tracked offers or URLs. Use [] only for scan, process-queue, or batch-evaluate.',
+        },
+        modes: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+          description: 'Canonical mode ids or supported legacy aliases',
+        },
+        guidance: {
+          type: 'string',
+          description: 'Optional concise guidance applied to every generated step',
+        },
+        terminalApproved: { type: 'boolean', description: TERMINAL_APPROVED_DESC },
+      },
+      required: ['targets', 'modes'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'cancel_workflow',
+    description:
+      'Cancel one exact workflow, including active children and queued descendants. First call list_workflows. ALWAYS requires user approval.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workflow_id: {
+          type: 'string',
+          pattern: '^[a-f0-9]{16}$',
+          description: 'Exact workflow id returned by list_workflows',
+        },
+        terminalApproved: { type: 'boolean', description: TERMINAL_APPROVED_DESC },
+      },
+      required: ['workflow_id'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'start_job',
     description:
       `Start a background job (${JOB_KINDS.join(', ')}). ` +
+      'Screening and evaluation are separate modes: use screen-evaluate only when the user explicitly asks for both; the server schedules two sequential jobs. ' +
       'ALWAYS requires user approval before anything runs or spends AI tokens — follow the instructions in the tool result.',
     inputSchema: {
       type: 'object',
@@ -126,8 +211,9 @@ const ACTION_TOOLS = [
     description:
       'Create or reuse a normal tracked offer from pasted job-description text, without a URL. ' +
       'If company or role is missing, ask the user first; use Unknown only when the information is genuinely absent from the text. ' +
-      'Unless the user already chose, ask whether they want: Create + screen + evaluate (recommended), Create + screen, or Create only. ' +
-      'Exact normalized text is deduplicated. Optionally start screen + evaluate, screen, evaluate, CV, cover letter, research, interview prep, outreach, or negotiation in the SAME approval. ' +
+      'Screening and evaluation are separate modes. Unless the user already chose, ask whether they want: Create + screen, Create + evaluate, or Create only. ' +
+      'Use screen-evaluate only when the user explicitly asks for both; the server schedules screening first and evaluation only after screening succeeds. ' +
+      'Exact normalized text is deduplicated. Optionally start screen, evaluate, CV, cover letter, research, interview prep, outreach, or negotiation in the SAME approval. ' +
       'ALWAYS requires user approval.',
     inputSchema: {
       type: 'object',
@@ -147,6 +233,7 @@ const ACTION_TOOLS = [
             'screen-evaluate',
             'evaluate',
             'tailor-cv',
+            'latex',
             'cover-letter',
             'research',
             'interview-prep',
@@ -154,7 +241,14 @@ const ACTION_TOOLS = [
             'negotiate',
           ],
           description:
-            'Optional job to start after creation; use screen-evaluate for the recommended Create + screen + evaluate workflow',
+            'Optional job after creation; use screen-evaluate only when the user explicitly asks for both screening and evaluation',
+        },
+        modes: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', minLength: 1 },
+          description:
+            'Optional dependency-aware workflow after creation. Do not combine with start_kind.',
         },
         terminalApproved: { type: 'boolean', description: TERMINAL_APPROVED_DESC },
       },
@@ -310,6 +404,29 @@ async function confirmGatedCall(path, body) {
 // Returns an MCP tool result, or null for a tool name not in TOOLS.
 async function callTool(name, args) {
   switch (name) {
+    case 'list_modes': {
+      const { status, body } = await appFetch('/api/chat/modes');
+      if (status !== 200) {
+        return errorResult(
+          `Failed to list modes (HTTP ${status}): ${body?.error ?? 'unknown error'}`,
+        );
+      }
+      return textResult(body);
+    }
+    case 'get_mode_instructions': {
+      if (typeof args?.mode !== 'string' || !args.mode.trim()) {
+        return errorResult('mode must be a canonical mode id or legacy alias.');
+      }
+      const { status, body } = await appFetch(
+        `/api/chat/modes/${encodeURIComponent(args.mode.trim())}`,
+      );
+      if (status !== 200) {
+        return errorResult(
+          `Failed to load mode instructions (HTTP ${status}): ${body?.error ?? 'unknown error'}`,
+        );
+      }
+      return textResult(body);
+    }
     case 'get_tracker': {
       const { status, body } = await appFetch('/api/applications');
       if (status !== 200) {
@@ -375,6 +492,27 @@ async function callTool(name, args) {
       }
       return textResult(body);
     }
+    case 'list_workflows': {
+      const { status, body } = await appFetch('/api/workflows');
+      if (status !== 200) {
+        return errorResult(
+          `Failed to list workflows (HTTP ${status}): ${body?.error ?? 'unknown error'}`,
+        );
+      }
+      return textResult(body);
+    }
+    case 'start_workflow':
+      return confirmGatedCall('/api/chat/actions/start-workflow', {
+        targets: args?.targets ?? [],
+        modes: args?.modes,
+        guidance: args?.guidance,
+        terminalApproved: args?.terminalApproved === true,
+      });
+    case 'cancel_workflow':
+      return confirmGatedCall('/api/chat/actions/cancel-workflow', {
+        workflowId: args?.workflow_id,
+        terminalApproved: args?.terminalApproved === true,
+      });
     case 'start_job':
       return confirmGatedCall('/api/chat/actions/start-job', {
         kind: args?.kind,
@@ -392,6 +530,7 @@ async function callTool(name, args) {
         company: args?.company,
         role: args?.role,
         startKind: args?.start_kind,
+        modes: args?.modes,
         terminalApproved: args?.terminalApproved === true,
       });
     case 'set_status':

--- a/content/modes/latex.md
+++ b/content/modes/latex.md
@@ -20,8 +20,8 @@ Export a tailored, ATS-optimized CV as a `.tex` file and compile it to PDF via `
 9. Reorder experience bullets by JD relevance
 10. Inject keywords naturally into existing achievements
 11. Generate the `.tex` file using `content/templates/cv-template.tex`
-12. Write to `artifacts/output/cv-{candidate}-{company}-{num}-{YYYY-MM-DD}.tex` (`{num}` = the offer's tracker number, so two offers at one company never overwrite each other)
-13. Run: `node generate-latex.mjs artifacts/output/cv-{candidate}-{company}-{num}-{YYYY-MM-DD}.tex artifacts/output/cv-{candidate}-{company}-{num}-{YYYY-MM-DD}.pdf`
+12. Write to `artifacts/output/cv-latex-{candidate}-{company}-{num}-{YYYY-MM-DD}.tex` (`{num}` = the offer's tracker number, and the `cv-latex` prefix keeps this export distinct from the standard tailored CV)
+13. Run: `node cli/generate-latex.mjs artifacts/output/cv-latex-{candidate}-{company}-{num}-{YYYY-MM-DD}.tex artifacts/output/cv-latex-{candidate}-{company}-{num}-{YYYY-MM-DD}.pdf`
 14. Report: .tex path, .pdf path, file sizes, section count, keyword coverage %
 
 **Requires:** `pdflatex` on PATH (MiKTeX or TeX Live). First compilation may auto-install missing LaTeX packages via MiKTeX.

--- a/src/app/api/chat/actions/cancel-workflow/route.ts
+++ b/src/app/api/chat/actions/cancel-workflow/route.ts
@@ -4,7 +4,7 @@ import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
 import { CancelWorkflowActionRequest } from '@/lib/schemas/chat-actions';
 import { createConfirm, describeCancelWorkflow } from '@/lib/server/chat/confirms';
-import { cancelWorkflow, getWorkflow } from '@/lib/server/workflows';
+import { cancelWorkflow, getWorkflow, isWorkflowTerminal } from '@/lib/server/workflows';
 
 export async function POST(request: Request) {
   const raw = await request.json().catch(() => null);
@@ -15,7 +15,7 @@ export async function POST(request: Request) {
   const { workflowId, terminalApproved } = parsed.data;
   const workflow = getWorkflow(ROOT, workflowId);
   if (!workflow) return jsonError(`workflow not found: ${workflowId}`, 404);
-  if (['done', 'partial', 'error', 'cancelled'].includes(workflow.status)) {
+  if (isWorkflowTerminal(workflow.status)) {
     return Response.json({ cancelled: false, workflow });
   }
   const { summary, meta } = describeCancelWorkflow(workflow);
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     return Response.json({ needsConfirm: true, summary, meta });
   }
   try {
-    return Response.json({ cancelled: true, workflow: cancelWorkflow(ROOT, workflowId) });
+    return Response.json(cancelWorkflow(ROOT, workflowId));
   } catch (error) {
     return jsonError(error instanceof Error ? error.message : 'failed to cancel workflow', 400);
   }

--- a/src/app/api/chat/actions/cancel-workflow/route.ts
+++ b/src/app/api/chat/actions/cancel-workflow/route.ts
@@ -1,0 +1,41 @@
+export const runtime = 'nodejs';
+
+import { jsonError } from '@/lib/http-errors';
+import { ROOT } from '@/lib/root';
+import { CancelWorkflowActionRequest } from '@/lib/schemas/chat-actions';
+import { createConfirm, describeCancelWorkflow } from '@/lib/server/chat/confirms';
+import { cancelWorkflow, getWorkflow } from '@/lib/server/workflows';
+
+export async function POST(request: Request) {
+  const raw = await request.json().catch(() => null);
+  const parsed = CancelWorkflowActionRequest.safeParse(raw);
+  if (!parsed.success) {
+    return jsonError(parsed.error.issues[0]?.message ?? 'invalid body', 400);
+  }
+  const { workflowId, terminalApproved } = parsed.data;
+  const workflow = getWorkflow(ROOT, workflowId);
+  if (!workflow) return jsonError(`workflow not found: ${workflowId}`, 404);
+  if (['done', 'partial', 'error', 'cancelled'].includes(workflow.status)) {
+    return Response.json({ cancelled: false, workflow });
+  }
+  const { summary, meta } = describeCancelWorkflow(workflow);
+  const turnId = request.headers.get('x-sur9e-turn');
+  if (turnId) {
+    const { token } = createConfirm(ROOT, {
+      turnId,
+      kind: 'cancel-workflow',
+      payload: { workflowId },
+      summary,
+      meta,
+    });
+    return Response.json({ needsConfirm: true, token, summary, meta });
+  }
+  if (terminalApproved !== true) {
+    return Response.json({ needsConfirm: true, summary, meta });
+  }
+  try {
+    return Response.json({ cancelled: true, workflow: cancelWorkflow(ROOT, workflowId) });
+  } catch (error) {
+    return jsonError(error instanceof Error ? error.message : 'failed to cancel workflow', 400);
+  }
+}

--- a/src/app/api/chat/actions/create-offer-from-text/route.ts
+++ b/src/app/api/chat/actions/create-offer-from-text/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: Request) {
     const turnId = request.headers.get('x-sur9e-turn');
     const preview =
       turnId || terminalApproved === true
-        ? reserveTextOfferPreview(ROOT, input.text)
+        ? await reserveTextOfferPreview(ROOT, input.text)
         : previewTextOffer(ROOT, input.text);
     if (input.modes) {
       const plan = planWorkflowForTargets(
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
     if (terminalApproved !== true) {
       return Response.json({ needsConfirm: true, summary, meta });
     }
-    const textOffer = createOrReuseTextOffer(ROOT, { ...input, reservedNum });
+    const textOffer = await createOrReuseTextOffer(ROOT, { ...input, reservedNum });
     const job = input.startKind
       ? startChatJob(ROOT, input.startKind, { num: textOffer.offer.num })
       : undefined;

--- a/src/app/api/chat/actions/create-offer-from-text/route.ts
+++ b/src/app/api/chat/actions/create-offer-from-text/route.ts
@@ -8,8 +8,10 @@ import {
   describeCreateOfferFromText,
   describeTextOfferResult,
 } from '@/lib/server/chat/confirms';
-import { startJob } from '@/lib/server/jobs';
+import { startChatJob } from '@/lib/server/chat/job-start';
+import { getJob } from '@/lib/server/jobs';
 import { createOrReuseTextOffer, previewTextOffer } from '@/lib/server/text-offers';
+import { assertWorkflowStartable, createWorkflow, planWorkflow } from '@/lib/server/workflows';
 import { revalidatePath } from '@/server/revalidate';
 
 export async function POST(request: Request) {
@@ -21,6 +23,15 @@ export async function POST(request: Request) {
   const { terminalApproved, ...input } = parsed.data;
   try {
     const preview = previewTextOffer(ROOT, input.text);
+    if (input.modes) {
+      const previewNum = preview.offer?.num ?? Number.MAX_SAFE_INTEGER;
+      const plan = planWorkflow({
+        targets: [{ num: previewNum }],
+        modes: input.modes,
+        evaluatedOfferNums: new Set(),
+      });
+      assertWorkflowStartable(ROOT, plan);
+    }
     const { summary, meta } = describeCreateOfferFromText(preview, input);
     const turnId = request.headers.get('x-sur9e-turn');
     if (turnId) {
@@ -38,15 +49,29 @@ export async function POST(request: Request) {
     }
     const textOffer = createOrReuseTextOffer(ROOT, input);
     const job = input.startKind
-      ? startJob(ROOT, { kind: input.startKind, params: { num: textOffer.offer.num } })
+      ? startChatJob(ROOT, input.startKind, { num: textOffer.offer.num })
       : undefined;
-    const presentation = describeTextOfferResult(textOffer, input.startKind, job);
+    const workflow = input.modes
+      ? createWorkflow(ROOT, {
+          targets: [{ num: textOffer.offer.num }],
+          modes: input.modes,
+        })
+      : undefined;
+    const jobs = workflow
+      ? workflow.steps.flatMap(step => {
+          if (!step.jobId) return [];
+          const child = getJob(ROOT, step.jobId);
+          return child ? [child] : [];
+        })
+      : undefined;
+    const presentation = describeTextOfferResult(textOffer, input.startKind, job, workflow);
     revalidatePath('/offers');
     return Response.json({
       created: !textOffer.reused,
       reused: textOffer.reused,
       offer: textOffer.offer,
       ...(job ? { job } : {}),
+      ...(workflow ? { workflow, jobs } : {}),
       ...presentation,
     });
   } catch (error) {

--- a/src/app/api/chat/actions/create-offer-from-text/route.ts
+++ b/src/app/api/chat/actions/create-offer-from-text/route.ts
@@ -9,7 +9,11 @@ import {
   describeTextOfferResult,
 } from '@/lib/server/chat/confirms';
 import { startChatJob } from '@/lib/server/chat/job-start';
-import { createOrReuseTextOffer, previewTextOffer } from '@/lib/server/text-offers';
+import {
+  createOrReuseTextOffer,
+  previewTextOffer,
+  reserveTextOfferPreview,
+} from '@/lib/server/text-offers';
 import {
   assertWorkflowStartable,
   createWorkflow,
@@ -26,7 +30,11 @@ export async function POST(request: Request) {
   }
   const { terminalApproved, ...input } = parsed.data;
   try {
-    const preview = previewTextOffer(ROOT, input.text);
+    const turnId = request.headers.get('x-sur9e-turn');
+    const preview =
+      turnId || terminalApproved === true
+        ? reserveTextOfferPreview(ROOT, input.text)
+        : previewTextOffer(ROOT, input.text);
     if (input.modes) {
       const plan = planWorkflowForTargets(
         ROOT,
@@ -42,12 +50,12 @@ export async function POST(request: Request) {
       assertWorkflowStartable(ROOT, plan);
     }
     const { summary, meta } = describeCreateOfferFromText(preview, input);
-    const turnId = request.headers.get('x-sur9e-turn');
+    const reservedNum = preview.reused ? undefined : preview.anticipatedNum;
     if (turnId) {
       const { token } = createConfirm(ROOT, {
         turnId,
         kind: 'create-offer-from-text',
-        payload: input,
+        payload: { ...input, reservedNum },
         summary,
         meta,
       });
@@ -56,7 +64,7 @@ export async function POST(request: Request) {
     if (terminalApproved !== true) {
       return Response.json({ needsConfirm: true, summary, meta });
     }
-    const textOffer = createOrReuseTextOffer(ROOT, input);
+    const textOffer = createOrReuseTextOffer(ROOT, { ...input, reservedNum });
     const job = input.startKind
       ? startChatJob(ROOT, input.startKind, { num: textOffer.offer.num })
       : undefined;

--- a/src/app/api/chat/actions/create-offer-from-text/route.ts
+++ b/src/app/api/chat/actions/create-offer-from-text/route.ts
@@ -9,9 +9,13 @@ import {
   describeTextOfferResult,
 } from '@/lib/server/chat/confirms';
 import { startChatJob } from '@/lib/server/chat/job-start';
-import { getJob } from '@/lib/server/jobs';
 import { createOrReuseTextOffer, previewTextOffer } from '@/lib/server/text-offers';
-import { assertWorkflowStartable, createWorkflow, planWorkflow } from '@/lib/server/workflows';
+import {
+  assertWorkflowStartable,
+  createWorkflow,
+  planWorkflowForTargets,
+  workflowChildJobs,
+} from '@/lib/server/workflows';
 import { revalidatePath } from '@/server/revalidate';
 
 export async function POST(request: Request) {
@@ -24,12 +28,17 @@ export async function POST(request: Request) {
   try {
     const preview = previewTextOffer(ROOT, input.text);
     if (input.modes) {
-      const previewNum = preview.offer?.num ?? Number.MAX_SAFE_INTEGER;
-      const plan = planWorkflow({
-        targets: [{ num: previewNum }],
-        modes: input.modes,
-        evaluatedOfferNums: new Set(),
-      });
+      const plan = planWorkflowForTargets(
+        ROOT,
+        {
+          targets: [{ num: preview.anticipatedNum }],
+          modes: input.modes,
+        },
+        undefined,
+        {
+          allowMissingOfferNums: preview.reused ? undefined : new Set([preview.anticipatedNum]),
+        },
+      );
       assertWorkflowStartable(ROOT, plan);
     }
     const { summary, meta } = describeCreateOfferFromText(preview, input);
@@ -57,13 +66,7 @@ export async function POST(request: Request) {
           modes: input.modes,
         })
       : undefined;
-    const jobs = workflow
-      ? workflow.steps.flatMap(step => {
-          if (!step.jobId) return [];
-          const child = getJob(ROOT, step.jobId);
-          return child ? [child] : [];
-        })
-      : undefined;
+    const jobs = workflow ? workflowChildJobs(ROOT, workflow) : undefined;
     const presentation = describeTextOfferResult(textOffer, input.startKind, job, workflow);
     revalidatePath('/offers');
     return Response.json({

--- a/src/app/api/chat/actions/start-job/route.ts
+++ b/src/app/api/chat/actions/start-job/route.ts
@@ -4,7 +4,8 @@ import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
 import { StartJobActionRequest } from '@/lib/schemas/chat-actions';
 import { createConfirm, describeStartedJob, describeStartJob } from '@/lib/server/chat/confirms';
-import { JOB_KIND_BY_NUM, startJob } from '@/lib/server/jobs';
+import { startChatJob } from '@/lib/server/chat/job-start';
+import { JOB_KIND_BY_NUM } from '@/lib/server/jobs';
 
 export async function POST(request: Request) {
   const raw = await request.json().catch(() => null);
@@ -43,7 +44,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = startJob(ROOT, { kind, params });
+    const result = startChatJob(ROOT, kind, params);
     if ('conflict' in result) {
       return Response.json({ started: false, conflict: true, message: result.message });
     }

--- a/src/app/api/chat/actions/start-workflow/route.ts
+++ b/src/app/api/chat/actions/start-workflow/route.ts
@@ -3,27 +3,17 @@ export const runtime = 'nodejs';
 import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
 import { StartWorkflowActionRequest } from '@/lib/schemas/chat-actions';
-import { findByNum, normalizeStatus } from '@/lib/server/applications';
 import {
   createConfirm,
   describeStartedWorkflow,
   describeStartWorkflow,
 } from '@/lib/server/chat/confirms';
-import { getJob } from '@/lib/server/jobs';
-import { assertWorkflowStartable, createWorkflow, planWorkflow } from '@/lib/server/workflows';
-
-function validatePlan(targets: Array<{ num: number } | { url: string }>, modes: string[]) {
-  const evaluated = new Set<number>();
-  for (const target of targets) {
-    if (!('num' in target)) continue;
-    const row = findByNum(ROOT, target.num);
-    if (!row) throw new Error(`num not found: ${target.num}`);
-    if (row.reportPath && !['screened', 'discarded'].includes(normalizeStatus(row.status))) {
-      evaluated.add(target.num);
-    }
-  }
-  return planWorkflow({ targets, modes, evaluatedOfferNums: evaluated });
-}
+import {
+  assertWorkflowStartable,
+  createWorkflow,
+  planWorkflowForTargets,
+  workflowChildJobs,
+} from '@/lib/server/workflows';
 
 export async function POST(request: Request) {
   const raw = await request.json().catch(() => null);
@@ -33,7 +23,7 @@ export async function POST(request: Request) {
   }
   const { terminalApproved, ...input } = parsed.data;
   try {
-    const plan = validatePlan(input.targets, input.modes);
+    const plan = planWorkflowForTargets(ROOT, input);
     assertWorkflowStartable(ROOT, plan);
     const { summary, meta } = describeStartWorkflow(input, plan);
     const turnId = request.headers.get('x-sur9e-turn');
@@ -51,11 +41,7 @@ export async function POST(request: Request) {
       return Response.json({ needsConfirm: true, summary, meta });
     }
     const workflow = createWorkflow(ROOT, input);
-    const jobs = workflow.steps.flatMap(step => {
-      if (!step.jobId) return [];
-      const job = getJob(ROOT, step.jobId);
-      return job ? [job] : [];
-    });
+    const jobs = workflowChildJobs(ROOT, workflow);
     return Response.json({
       started: true,
       workflow,

--- a/src/app/api/chat/actions/start-workflow/route.ts
+++ b/src/app/api/chat/actions/start-workflow/route.ts
@@ -1,0 +1,68 @@
+export const runtime = 'nodejs';
+
+import { jsonError } from '@/lib/http-errors';
+import { ROOT } from '@/lib/root';
+import { StartWorkflowActionRequest } from '@/lib/schemas/chat-actions';
+import { findByNum, normalizeStatus } from '@/lib/server/applications';
+import {
+  createConfirm,
+  describeStartedWorkflow,
+  describeStartWorkflow,
+} from '@/lib/server/chat/confirms';
+import { getJob } from '@/lib/server/jobs';
+import { assertWorkflowStartable, createWorkflow, planWorkflow } from '@/lib/server/workflows';
+
+function validatePlan(targets: Array<{ num: number } | { url: string }>, modes: string[]) {
+  const evaluated = new Set<number>();
+  for (const target of targets) {
+    if (!('num' in target)) continue;
+    const row = findByNum(ROOT, target.num);
+    if (!row) throw new Error(`num not found: ${target.num}`);
+    if (row.reportPath && !['screened', 'discarded'].includes(normalizeStatus(row.status))) {
+      evaluated.add(target.num);
+    }
+  }
+  return planWorkflow({ targets, modes, evaluatedOfferNums: evaluated });
+}
+
+export async function POST(request: Request) {
+  const raw = await request.json().catch(() => null);
+  const parsed = StartWorkflowActionRequest.safeParse(raw);
+  if (!parsed.success) {
+    return jsonError(parsed.error.issues[0]?.message ?? 'invalid body', 400);
+  }
+  const { terminalApproved, ...input } = parsed.data;
+  try {
+    const plan = validatePlan(input.targets, input.modes);
+    assertWorkflowStartable(ROOT, plan);
+    const { summary, meta } = describeStartWorkflow(input, plan);
+    const turnId = request.headers.get('x-sur9e-turn');
+    if (turnId) {
+      const { token } = createConfirm(ROOT, {
+        turnId,
+        kind: 'start-workflow',
+        payload: input,
+        summary,
+        meta,
+      });
+      return Response.json({ needsConfirm: true, token, summary, meta });
+    }
+    if (terminalApproved !== true) {
+      return Response.json({ needsConfirm: true, summary, meta });
+    }
+    const workflow = createWorkflow(ROOT, input);
+    const jobs = workflow.steps.flatMap(step => {
+      if (!step.jobId) return [];
+      const job = getJob(ROOT, step.jobId);
+      return job ? [job] : [];
+    });
+    return Response.json({
+      started: true,
+      workflow,
+      jobs,
+      ...describeStartedWorkflow(workflow),
+    });
+  } catch (error) {
+    return jsonError(error instanceof Error ? error.message : 'failed to start workflow', 400);
+  }
+}

--- a/src/app/api/chat/confirms/[token]/route.ts
+++ b/src/app/api/chat/confirms/[token]/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: Request, { params }: Params) {
   if (!parsed.success) {
     return jsonError('body must be { approve: boolean }', 400);
   }
-  const resolved = resolveConfirm(ROOT, token, parsed.data.approve);
+  const resolved = await resolveConfirm(ROOT, token, parsed.data.approve);
   // An approved report edit wrote a new body to disk — revalidate the report
   // page (whole dynamic segment) and the offers view that renders its summary,
   // mirroring the editor save route (api/reports/[filename]/body).

--- a/src/app/api/chat/modes/[mode]/route.ts
+++ b/src/app/api/chat/modes/[mode]/route.ts
@@ -1,0 +1,35 @@
+export const runtime = 'nodejs';
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { jsonError } from '@/lib/http-errors';
+import { MODE_CATALOG, resolveModeId } from '@/lib/modes/catalog';
+import { ROOT } from '@/lib/root';
+
+const HANDOFFS: Readonly<Record<string, string>> = {
+  apply: '/sur9e apply <offer-number>',
+  enrich: '/sur9e enrich',
+};
+
+export async function GET(_request: Request, context: { params: Promise<{ mode: string }> }) {
+  const { mode: rawMode } = await context.params;
+  const mode = resolveModeId(rawMode);
+  if (!mode) return jsonError(`unknown mode: ${rawMode}`, 404);
+  const definition = MODE_CATALOG[mode];
+  let instructions = '';
+  try {
+    const modePath = join(ROOT, 'content', 'modes', `${mode}.md`);
+    const shared =
+      mode === 'screen' ? '' : readFileSync(join(ROOT, 'content', 'modes', '_shared.md'), 'utf-8');
+    instructions = `${shared}${shared ? '\n\n' : ''}${readFileSync(modePath, 'utf-8')}`;
+  } catch {
+    // Synthetic composites such as screen-evaluate intentionally have no
+    // prompt file; the catalog's expandsTo contract is their instruction.
+  }
+  return Response.json({
+    ...definition,
+    canonicalMode: mode,
+    instructions,
+    ...(HANDOFFS[mode] ? { handoff: HANDOFFS[mode] } : {}),
+  });
+}

--- a/src/app/api/chat/modes/[mode]/route.ts
+++ b/src/app/api/chat/modes/[mode]/route.ts
@@ -17,14 +17,11 @@ export async function GET(_request: Request, context: { params: Promise<{ mode: 
   if (!mode) return jsonError(`unknown mode: ${rawMode}`, 404);
   const definition = MODE_CATALOG[mode];
   let instructions = '';
-  try {
+  if (mode !== 'screen-evaluate') {
     const modePath = join(ROOT, 'content', 'modes', `${mode}.md`);
     const shared =
       mode === 'screen' ? '' : readFileSync(join(ROOT, 'content', 'modes', '_shared.md'), 'utf-8');
     instructions = `${shared}${shared ? '\n\n' : ''}${readFileSync(modePath, 'utf-8')}`;
-  } catch {
-    // Synthetic composites such as screen-evaluate intentionally have no
-    // prompt file; the catalog's expandsTo contract is their instruction.
   }
   return Response.json({
     ...definition,

--- a/src/app/api/chat/modes/route.ts
+++ b/src/app/api/chat/modes/route.ts
@@ -1,0 +1,10 @@
+export const runtime = 'nodejs';
+
+import { MODE_ALIASES, MODE_CATALOG } from '@/lib/modes/catalog';
+
+export async function GET() {
+  return Response.json({
+    modes: Object.values(MODE_CATALOG),
+    aliases: MODE_ALIASES,
+  });
+}

--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -1,0 +1,16 @@
+export const runtime = 'nodejs';
+
+import { jsonError } from '@/lib/http-errors';
+import { ROOT } from '@/lib/root';
+import { advanceWorkflow, getWorkflow } from '@/lib/server/workflows';
+
+export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const workflow = getWorkflow(ROOT, id);
+  if (!workflow) return jsonError(`workflow not found: ${id}`, 404);
+  return Response.json(
+    workflow.status === 'queued' || workflow.status === 'running'
+      ? advanceWorkflow(ROOT, id)
+      : workflow,
+  );
+}

--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -2,15 +2,11 @@ export const runtime = 'nodejs';
 
 import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
-import { advanceWorkflow, getWorkflow } from '@/lib/server/workflows';
+import { getWorkflow } from '@/lib/server/workflows';
 
 export async function GET(_request: Request, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
   const workflow = getWorkflow(ROOT, id);
   if (!workflow) return jsonError(`workflow not found: ${id}`, 404);
-  return Response.json(
-    workflow.status === 'queued' || workflow.status === 'running'
-      ? advanceWorkflow(ROOT, id)
-      : workflow,
-  );
+  return Response.json(workflow);
 }

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,0 +1,8 @@
+export const runtime = 'nodejs';
+
+import { ROOT } from '@/lib/root';
+import { reconcileWorkflows } from '@/lib/server/workflows';
+
+export async function GET() {
+  return Response.json({ workflows: reconcileWorkflows(ROOT) });
+}

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,8 +1,8 @@
 export const runtime = 'nodejs';
 
 import { ROOT } from '@/lib/root';
-import { reconcileWorkflows } from '@/lib/server/workflows';
+import { listWorkflows } from '@/lib/server/workflows';
 
 export async function GET() {
-  return Response.json({ workflows: reconcileWorkflows(ROOT) });
+  return Response.json({ workflows: listWorkflows(ROOT) });
 }

--- a/src/features/chat/confirm-card.tsx
+++ b/src/features/chat/confirm-card.tsx
@@ -21,7 +21,9 @@ export type ConfirmOutcome = 'pending' | 'approved' | 'cancelled' | 'expired';
 // the kind field existed (foldEvents leaves `action` undefined there).
 const APPROVED_LABEL_BY_ACTION: Record<ConfirmActionKind, string> = {
   'start-job': '✓ Started — running in the jobs strip',
+  'start-workflow': '✓ Workflow started — child jobs are running',
   'cancel-job': '✓ Job cancelled',
+  'cancel-workflow': '✓ Workflow cancelled',
   'create-offer-from-text': '✓ Offer ready',
   'set-status': '✓ Status updated',
   'edit-report': '✓ Report updated',
@@ -37,6 +39,7 @@ function resolvedLabel(
   if (execution === 'failed') return '✕ Action failed';
   if (execution === 'unchanged') {
     if (action === 'cancel-job') return 'Job already finished';
+    if (action === 'cancel-workflow') return 'Workflow already finished';
     if (action === 'start-job') return 'Job not started';
     return 'No changes made';
   }
@@ -65,6 +68,8 @@ interface ConfirmResponseResult {
   ok?: boolean;
   error?: string;
   job?: ConfirmResponseJob;
+  workflow?: { id?: string; status?: string };
+  jobs?: ConfirmResponseJob[];
   textOffer?: { offer?: { num?: number } };
   cancellation?: { job?: ConfirmResponseJob };
   message?: string;
@@ -147,6 +152,12 @@ export function ConfirmCard({
               ? started.params.num
               : data.result.textOffer?.offer?.num;
           useChatJobsStore.getState().startJob(started.id, started.type, num);
+        }
+        for (const child of data.result.jobs ?? []) {
+          if (child.id && child.type && (child.status === 'queued' || child.status === 'running')) {
+            const num = typeof child.params?.num === 'number' ? child.params.num : undefined;
+            useChatJobsStore.getState().startJob(child.id, child.type, num);
+          }
         }
         const cancelled = data.result.cancellation?.job;
         if (cancelled?.id && cancelled.status === 'cancelled') {

--- a/src/features/chat/fold-events.ts
+++ b/src/features/chat/fold-events.ts
@@ -11,7 +11,9 @@ import type { ChatActionLink, ChatTurnEvent } from '@/lib/schemas/chat';
 // client-safe module never imports the server-only confirms store).
 export type ConfirmActionKind =
   | 'start-job'
+  | 'start-workflow'
   | 'cancel-job'
+  | 'cancel-workflow'
   | 'create-offer-from-text'
   | 'set-status'
   | 'edit-report';

--- a/src/features/chat/slash-popover.tsx
+++ b/src/features/chat/slash-popover.tsx
@@ -2,7 +2,7 @@
 
 import { useRef } from 'react';
 import { useActiveOptionScroll } from '@/hooks/use-active-option-scroll';
-import { CHAT_DISCOVERABLE_MODES } from '@/lib/modes/catalog';
+import { CHAT_DISCOVERABLE_MODES, type ModeId } from '@/lib/modes/catalog';
 
 export interface SlashItem {
   command: string;
@@ -10,7 +10,7 @@ export interface SlashItem {
   description: string;
 }
 
-const MODE_HINTS: Readonly<Record<string, string>> = {
+const MODE_HINTS: Partial<Record<ModeId, string>> = {
   apply: '<num>',
   'cover-letter': '<num>',
   'evaluate-offer': '<url-or-num>',
@@ -29,7 +29,7 @@ const MODE_HINTS: Readonly<Record<string, string>> = {
  * prompt, so adding or reclassifying a mode cannot leave slash commands stale. */
 export const SLASH_ITEMS: SlashItem[] = CHAT_DISCOVERABLE_MODES.map(mode => ({
   command: mode.id,
-  hint: MODE_HINTS[mode.id],
+  hint: MODE_HINTS[mode.id as ModeId],
   description: mode.description,
 }));
 

--- a/src/features/chat/slash-popover.tsx
+++ b/src/features/chat/slash-popover.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from 'react';
 import { useActiveOptionScroll } from '@/hooks/use-active-option-scroll';
+import { CHAT_DISCOVERABLE_MODES } from '@/lib/modes/catalog';
 
 export interface SlashItem {
   command: string;
@@ -9,23 +10,28 @@ export interface SlashItem {
   description: string;
 }
 
-/** The 8 interactive chat modes + job commands (spec §2 v1 list). Hardcoded
- * by design — the backend routes modes from message text; this list only
- * powers discovery. Keep provider-neutral, one line each. */
-export const SLASH_ITEMS: SlashItem[] = [
-  { command: 'enrich', description: 'Strengthen your CV through a guided interview' },
-  { command: 'offers', description: 'Compare your active offers side by side' },
-  { command: 'tracker', description: 'Ask about application statuses and history' },
-  { command: 'patterns', description: 'Analyze rejection patterns and targeting' },
-  { command: 'follow-up', description: 'Review follow-up cadence for open applications' },
-  { command: 'process-queue', description: 'Process pending saved job URLs' },
-  { command: 'training', description: 'Evaluate a course or certification' },
-  { command: 'project', description: 'Evaluate a portfolio project idea' },
-  { command: 'evaluate', hint: '<num>', description: 'Run a deep evaluation for an offer' },
-  { command: 'screen', hint: '<url>', description: 'Screen a job posting URL' },
-  { command: 'research', hint: '<num>', description: 'Research the company behind an offer' },
-  { command: 'scan', description: 'Scan portals and job boards for new offers' },
-];
+const MODE_HINTS: Readonly<Record<string, string>> = {
+  apply: '<num>',
+  'cover-letter': '<num>',
+  'evaluate-offer': '<url-or-num>',
+  evaluate: '<num>',
+  'interview-prep': '<num>',
+  latex: '<num>',
+  negotiate: '<num>',
+  'reach-out': '<num>',
+  research: '<num>',
+  screen: '<url-or-num>',
+  'screen-evaluate': '<url-or-num>',
+  'tailor-cv': '<num>',
+};
+
+/** Discovery is generated from the same catalog used by MCP and the chat
+ * prompt, so adding or reclassifying a mode cannot leave slash commands stale. */
+export const SLASH_ITEMS: SlashItem[] = CHAT_DISCOVERABLE_MODES.map(mode => ({
+  command: mode.id,
+  hint: MODE_HINTS[mode.id],
+  description: mode.description,
+}));
 
 /** Prefix matches first, then substring matches — stable within each tier. */
 export function filterSlashItems(filter: string): SlashItem[] {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,8 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   const { startScheduler } = await import('./lib/server/jobs/scheduler');
+  const { reconcileWorkflows } = await import('./lib/server/workflows');
   const { ROOT } = await import('./lib/root');
+  reconcileWorkflows(ROOT);
   startScheduler(ROOT);
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -10,6 +10,10 @@ export async function register() {
   const { startScheduler } = await import('./lib/server/jobs/scheduler');
   const { reconcileWorkflows } = await import('./lib/server/workflows');
   const { ROOT } = await import('./lib/root');
-  reconcileWorkflows(ROOT);
+  try {
+    reconcileWorkflows(ROOT);
+  } catch (error) {
+    console.error('Failed to reconcile workflows during startup:', error);
+  }
   startScheduler(ROOT);
 }

--- a/src/lib/job-types.ts
+++ b/src/lib/job-types.ts
@@ -64,6 +64,18 @@ export const JOB_TYPES: JobType[] = [
     estimateS: 240,
   },
   {
+    type: 'latex',
+    menuTitle: null,
+    menuTitleBusy: null,
+    menuSub: null,
+    menuIcon: null,
+    pillTitle: 'Generating LaTeX CV…',
+    pillTitleNum: 'Generating LaTeX CV for #{num}…',
+    failMsg: 'LaTeX CV generation failed — retry from the offer',
+    refreshOnDone: true,
+    estimateS: 300,
+  },
+  {
     type: 'cover-letter',
     menuTitle: null,
     menuTitleBusy: null,

--- a/src/lib/modes/catalog.json
+++ b/src/lib/modes/catalog.json
@@ -1,0 +1,173 @@
+{
+  "modes": {
+    "apply": {
+      "label": "Apply",
+      "description": "Hand off a live application form without submitting it",
+      "execution": "handoff",
+      "scope": "offer"
+    },
+    "batch-evaluate": {
+      "label": "Batch evaluate",
+      "description": "Evaluate screened offers above the configured threshold",
+      "execution": "background",
+      "scope": "system",
+      "singleJob": true
+    },
+    "cover-letter": {
+      "label": "Cover letter",
+      "description": "Generate a tailored cover-letter PDF",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "singleJob": true
+    },
+    "enrich": {
+      "label": "Enrich profile",
+      "description": "Hand off a guided CV and profile enrichment interview",
+      "execution": "handoff",
+      "scope": "conversation"
+    },
+    "evaluate-offer": {
+      "label": "Evaluate offer",
+      "description": "Screen a new offer, then evaluate it",
+      "execution": "composite",
+      "scope": "offer",
+      "expandsTo": ["screen", "evaluate"]
+    },
+    "evaluate": {
+      "label": "Evaluate",
+      "description": "Run a full evaluation for one offer",
+      "execution": "background",
+      "scope": "offer",
+      "mutatesReport": true,
+      "singleJob": true
+    },
+    "follow-up": {
+      "label": "Follow up",
+      "description": "Review follow-up cadence and draft the next message",
+      "execution": "inline",
+      "scope": "conversation"
+    },
+    "interview-prep": {
+      "label": "Interview prep",
+      "description": "Build a company-specific interview brief",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "mutatesReport": true,
+      "singleJob": true
+    },
+    "latex": {
+      "label": "LaTeX CV",
+      "description": "Export a tailored CV as LaTeX and PDF",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "singleJob": true
+    },
+    "negotiate": {
+      "label": "Negotiate",
+      "description": "Build a compensation negotiation strategy",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "mutatesReport": true,
+      "singleJob": true
+    },
+    "offers": {
+      "label": "Compare offers",
+      "description": "Compare several tracked offers",
+      "execution": "inline",
+      "scope": "conversation"
+    },
+    "patterns": {
+      "label": "Patterns",
+      "description": "Analyze rejection and targeting patterns",
+      "execution": "inline",
+      "scope": "conversation"
+    },
+    "process-queue": {
+      "label": "Process queue",
+      "description": "Screen every pending saved URL",
+      "execution": "composite",
+      "scope": "system",
+      "expandsTo": ["screen"]
+    },
+    "project": {
+      "label": "Project",
+      "description": "Evaluate a portfolio project",
+      "execution": "inline",
+      "scope": "conversation"
+    },
+    "reach-out": {
+      "label": "Reach out",
+      "description": "Research contacts and draft outreach",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "mutatesReport": true,
+      "singleJob": true
+    },
+    "research": {
+      "label": "Research",
+      "description": "Research a company deeply",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "mutatesReport": true,
+      "singleJob": true
+    },
+    "scan": {
+      "label": "Scan",
+      "description": "Scan configured portals and sources for new offers",
+      "execution": "background",
+      "scope": "system",
+      "singleJob": true
+    },
+    "screen": {
+      "label": "Screen",
+      "description": "Run a quick fit screen for an offer",
+      "execution": "background",
+      "scope": "offer",
+      "singleJob": true
+    },
+    "screen-evaluate": {
+      "label": "Screen then evaluate",
+      "description": "Run separate screening and evaluation jobs in sequence",
+      "execution": "composite",
+      "scope": "offer",
+      "expandsTo": ["screen", "evaluate"],
+      "legacyStartJob": true,
+      "singleJob": true
+    },
+    "tailor-cv": {
+      "label": "Tailor CV",
+      "description": "Generate a tailored CV PDF",
+      "execution": "background",
+      "scope": "offer",
+      "requiresEvaluation": true,
+      "singleJob": true
+    },
+    "tracker": {
+      "label": "Tracker",
+      "description": "Review or update application status",
+      "execution": "inline",
+      "scope": "conversation"
+    },
+    "training": {
+      "label": "Training",
+      "description": "Evaluate a course or certification",
+      "execution": "inline",
+      "scope": "conversation"
+    }
+  },
+  "aliases": {
+    "auto-pipeline": "evaluate-offer",
+    "contact": "reach-out",
+    "deep": "research",
+    "followup": "follow-up",
+    "outreach": "reach-out",
+    "pdf": "tailor-cv",
+    "pipeline": "process-queue"
+  }
+}

--- a/src/lib/modes/catalog.ts
+++ b/src/lib/modes/catalog.ts
@@ -1,0 +1,65 @@
+import catalogData from './catalog.json';
+
+export type ModeExecution = 'background' | 'inline' | 'handoff' | 'composite';
+export type ModeScope = 'offer' | 'system' | 'conversation';
+
+export interface ModeDefinition {
+  id: string;
+  label: string;
+  description: string;
+  execution: ModeExecution;
+  scope: ModeScope;
+  requiresEvaluation?: boolean;
+  mutatesReport?: boolean;
+  expandsTo?: readonly string[];
+  legacyStartJob?: boolean;
+  singleJob?: boolean;
+}
+
+export type ModeId = keyof typeof catalogData.modes;
+export type JobModeId = Extract<
+  ModeId,
+  | 'batch-evaluate'
+  | 'cover-letter'
+  | 'evaluate'
+  | 'interview-prep'
+  | 'latex'
+  | 'negotiate'
+  | 'reach-out'
+  | 'research'
+  | 'scan'
+  | 'screen'
+  | 'screen-evaluate'
+  | 'tailor-cv'
+>;
+
+/** Canonical public mode registry. The JSON data is also imported directly
+ * by the zero-dependency MCP stdio server, while this typed adapter serves
+ * the application, prompt, planner, and slash-command UI. */
+export const MODE_CATALOG = Object.freeze(
+  Object.fromEntries(
+    Object.entries(catalogData.modes).map(([id, definition]) => [
+      id,
+      { id, ...definition } as ModeDefinition,
+    ]),
+  ),
+) as Readonly<Record<ModeId, Readonly<ModeDefinition>>>;
+
+export const MODE_ALIASES = Object.freeze(catalogData.aliases as Readonly<Record<string, ModeId>>);
+
+export function resolveModeId(value: string): ModeId | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized in MODE_CATALOG) return normalized as ModeId;
+  return MODE_ALIASES[normalized] ?? null;
+}
+
+export const CHAT_DISCOVERABLE_MODES: readonly ModeDefinition[] = Object.freeze(
+  Object.values(MODE_CATALOG),
+);
+
+/** Modes accepted by the backward-compatible single-job surface. */
+export const JOB_MODE_IDS: readonly JobModeId[] = Object.freeze(
+  Object.values(MODE_CATALOG)
+    .filter(mode => mode.singleJob === true)
+    .map(mode => mode.id as JobModeId),
+);

--- a/src/lib/schemas/chat-actions.ts
+++ b/src/lib/schemas/chat-actions.ts
@@ -14,6 +14,7 @@ export const TextOfferStartKind = z.enum([
   'screen-evaluate',
   'evaluate',
   'tailor-cv',
+  'latex',
   'cover-letter',
   'research',
   'interview-prep',
@@ -21,6 +22,25 @@ export const TextOfferStartKind = z.enum([
   'negotiate',
 ]);
 export type TextOfferStartKind = z.infer<typeof TextOfferStartKind>;
+
+export const WorkflowTargetInput = z.union([
+  z.object({ num: z.number().int().positive() }).strict(),
+  z.object({ url: z.string().url() }).strict(),
+]);
+
+export const StartWorkflowActionRequest = z.object({
+  targets: z.array(WorkflowTargetInput),
+  modes: z.array(z.string().trim().min(1)).min(1),
+  guidance: z.string().trim().min(1).max(2_000).optional(),
+  terminalApproved: z.boolean().optional(),
+});
+export type StartWorkflowActionRequest = z.infer<typeof StartWorkflowActionRequest>;
+
+export const CancelWorkflowActionRequest = z.object({
+  workflowId: z.string().regex(/^[a-f0-9]{16}$/),
+  terminalApproved: z.boolean().optional(),
+});
+export type CancelWorkflowActionRequest = z.infer<typeof CancelWorkflowActionRequest>;
 
 export const StartJobActionRequest = z.object({
   kind: JobType,
@@ -36,13 +56,18 @@ export const CancelJobActionRequest = z.object({
 });
 export type CancelJobActionRequest = z.infer<typeof CancelJobActionRequest>;
 
-export const CreateOfferFromTextActionRequest = z.object({
-  text: z.string().trim().min(1).max(32_000),
-  company: z.string().trim().min(1).max(160).optional(),
-  role: z.string().trim().min(1).max(240).optional(),
-  startKind: TextOfferStartKind.optional(),
-  terminalApproved: z.boolean().optional(),
-});
+export const CreateOfferFromTextActionRequest = z
+  .object({
+    text: z.string().trim().min(1).max(32_000),
+    company: z.string().trim().min(1).max(160).optional(),
+    role: z.string().trim().min(1).max(240).optional(),
+    startKind: TextOfferStartKind.optional(),
+    modes: z.array(z.string().trim().min(1)).min(1).optional(),
+    terminalApproved: z.boolean().optional(),
+  })
+  .refine(input => !(input.startKind && input.modes), {
+    message: 'startKind and modes cannot be combined',
+  });
 export type CreateOfferFromTextActionRequest = z.infer<typeof CreateOfferFromTextActionRequest>;
 
 export const SetStatusActionRequest = z.object({

--- a/src/lib/schemas/chat-actions.ts
+++ b/src/lib/schemas/chat-actions.ts
@@ -9,6 +9,13 @@ import { z } from 'zod';
 import { ApplicationStatus } from './applications';
 import { JobType } from './jobs';
 
+const HttpUrl = z
+  .string()
+  .url()
+  .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
+    message: 'URL must use http or https',
+  });
+
 export const TextOfferStartKind = z.enum([
   'screen',
   'screen-evaluate',
@@ -25,7 +32,7 @@ export type TextOfferStartKind = z.infer<typeof TextOfferStartKind>;
 
 export const WorkflowTargetInput = z.union([
   z.object({ num: z.number().int().positive() }).strict(),
-  z.object({ url: z.string().url() }).strict(),
+  z.object({ url: HttpUrl }).strict(),
 ]);
 
 export const StartWorkflowActionRequest = z.object({

--- a/src/lib/schemas/chat-actions.ts
+++ b/src/lib/schemas/chat-actions.ts
@@ -8,13 +8,7 @@
 import { z } from 'zod';
 import { ApplicationStatus } from './applications';
 import { JobType } from './jobs';
-
-const HttpUrl = z
-  .string()
-  .url()
-  .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
-    message: 'URL must use http or https',
-  });
+import { HttpUrl } from './urls';
 
 export const TextOfferStartKind = z.enum([
   'screen',

--- a/src/lib/schemas/chat.ts
+++ b/src/lib/schemas/chat.ts
@@ -116,7 +116,15 @@ export const ChatTurnEvent = z.discriminatedUnion('type', [
     // so confirm events persisted before this field existed still parse; the
     // card falls back to a generic "Confirmed" label when it's absent.
     kind: z
-      .enum(['start-job', 'cancel-job', 'create-offer-from-text', 'set-status', 'edit-report'])
+      .enum([
+        'start-job',
+        'start-workflow',
+        'cancel-job',
+        'cancel-workflow',
+        'create-offer-from-text',
+        'set-status',
+        'edit-report',
+      ])
       .optional(),
   }),
   z.object({

--- a/src/lib/schemas/jobs.ts
+++ b/src/lib/schemas/jobs.ts
@@ -7,6 +7,7 @@
 // Next.js routes.
 
 import { z } from 'zod';
+import { JOB_MODE_IDS, type JobModeId } from '../modes/catalog';
 import { ProviderId } from './providers';
 
 export const JobStatus = z.enum(['queued', 'running', 'done', 'error', 'cancelled']);
@@ -23,19 +24,7 @@ export const ResolvedFrom = z.enum([
 ]);
 export type ResolvedFrom = z.infer<typeof ResolvedFrom>;
 
-export const JOB_TYPES = [
-  'evaluate',
-  'tailor-cv',
-  'cover-letter',
-  'research',
-  'interview-prep',
-  'reach-out',
-  'negotiate',
-  'scan',
-  'batch-evaluate',
-  'screen',
-  'screen-evaluate',
-] as const;
+export const JOB_TYPES = [...JOB_MODE_IDS] as [JobModeId, ...JobModeId[]];
 
 const CanonicalJobType = z.enum(JOB_TYPES);
 export type JobType = z.infer<typeof CanonicalJobType>;
@@ -67,6 +56,7 @@ export const JobParams = z.preprocess(
       generate_cover_letter: z.boolean().optional(),
     }),
     z.object({ type: z.literal('tailor-cv'), num: z.number().int().positive() }),
+    z.object({ type: z.literal('latex'), num: z.number().int().positive() }),
     z.object({ type: z.literal('cover-letter'), num: z.number().int().positive() }),
     z.object({ type: z.literal('research'), num: z.number().int().positive() }),
     z.object({ type: z.literal('interview-prep'), num: z.number().int().positive() }),
@@ -120,6 +110,11 @@ export const JobRecord = z.object({
   output: z.string().default(''),
   error: z.string().nullable(),
   exitCode: z.number().int().nullable(),
+  // Optional workflow parent metadata. Legacy standalone records omit it;
+  // workflow children carry both ids so the UI and recovery path can group
+  // and advance them without parsing the free-form params bag.
+  workflowId: z.string().length(16).optional(),
+  workflowStepId: z.string().min(1).optional(),
   // Pid of the spawned worker process, stamped by the runner on the running
   // record. Drives reap-on-read liveness detection (jobs/stale.ts): a
   // 'running' record whose pid no longer exists was orphaned by a server

--- a/src/lib/schemas/urls.ts
+++ b/src/lib/schemas/urls.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const HttpUrl = z
+  .string()
+  .url()
+  .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
+    message: 'URL must use http or https',
+  });

--- a/src/lib/schemas/urls.ts
+++ b/src/lib/schemas/urls.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 export const HttpUrl = z
-  .string()
   .url()
   .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
     message: 'URL must use http or https',

--- a/src/lib/schemas/workflows.ts
+++ b/src/lib/schemas/workflows.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { HttpUrl } from './urls';
 
 export const WorkflowStatus = z.enum([
   'queued',
@@ -24,12 +25,7 @@ export type WorkflowStepStatus = z.infer<typeof WorkflowStepStatus>;
 export const WorkflowTarget = z.union([
   z
     .object({
-      url: z
-        .string()
-        .url()
-        .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
-          message: 'URL must use http or https',
-        }),
+      url: HttpUrl,
       num: z.number().int().positive().optional(),
     })
     .strict(),

--- a/src/lib/schemas/workflows.ts
+++ b/src/lib/schemas/workflows.ts
@@ -22,11 +22,18 @@ export const WorkflowStepStatus = z.enum([
 export type WorkflowStepStatus = z.infer<typeof WorkflowStepStatus>;
 
 export const WorkflowTarget = z.union([
-  z.object({ num: z.number().int().positive() }),
-  z.object({
-    url: z.string().url(),
-    num: z.number().int().positive().optional(),
-  }),
+  z
+    .object({
+      url: z
+        .string()
+        .url()
+        .refine(value => value.startsWith('http://') || value.startsWith('https://'), {
+          message: 'URL must use http or https',
+        }),
+      num: z.number().int().positive().optional(),
+    })
+    .strict(),
+  z.object({ num: z.number().int().positive() }).strict(),
 ]);
 export type WorkflowTarget = z.infer<typeof WorkflowTarget>;
 
@@ -43,7 +50,7 @@ export const WorkflowStep = z.object({
 export type WorkflowStep = z.infer<typeof WorkflowStep>;
 
 export const WorkflowRecord = z.object({
-  id: z.string().length(16),
+  id: z.string().regex(/^[a-f0-9]{16}$/),
   status: WorkflowStatus,
   targets: z.array(WorkflowTarget),
   requestedModes: z.array(z.string().min(1)),

--- a/src/lib/schemas/workflows.ts
+++ b/src/lib/schemas/workflows.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+export const WorkflowStatus = z.enum([
+  'queued',
+  'running',
+  'done',
+  'partial',
+  'error',
+  'cancelled',
+]);
+export type WorkflowStatus = z.infer<typeof WorkflowStatus>;
+
+export const WorkflowStepStatus = z.enum([
+  'blocked',
+  'queued',
+  'running',
+  'done',
+  'error',
+  'cancelled',
+  'skipped',
+]);
+export type WorkflowStepStatus = z.infer<typeof WorkflowStepStatus>;
+
+export const WorkflowTarget = z.union([
+  z.object({ num: z.number().int().positive() }),
+  z.object({
+    url: z.string().url(),
+    num: z.number().int().positive().optional(),
+  }),
+]);
+export type WorkflowTarget = z.infer<typeof WorkflowTarget>;
+
+export const WorkflowStep = z.object({
+  id: z.string().min(1),
+  targetIndex: z.number().int().nonnegative().nullable(),
+  mode: z.string().min(1),
+  dependsOn: z.array(z.string()),
+  params: z.record(z.string(), z.unknown()),
+  status: WorkflowStepStatus,
+  jobId: z.string().optional(),
+  error: z.string().nullable().default(null),
+});
+export type WorkflowStep = z.infer<typeof WorkflowStep>;
+
+export const WorkflowRecord = z.object({
+  id: z.string().length(16),
+  status: WorkflowStatus,
+  targets: z.array(WorkflowTarget),
+  requestedModes: z.array(z.string().min(1)),
+  guidance: z.string().optional(),
+  maxParallel: z.number().int().positive().max(4),
+  steps: z.array(WorkflowStep),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  finishedAt: z.string().nullable(),
+});
+export type WorkflowRecord = z.infer<typeof WorkflowRecord>;

--- a/src/lib/server/__tests__/jobs-api.test.ts
+++ b/src/lib/server/__tests__/jobs-api.test.ts
@@ -84,6 +84,19 @@ describe('jobs/api — schema boundary', () => {
     await waitForTerminal(root, job.id);
   });
 
+  it('stamps parent workflow metadata onto child job records', async () => {
+    const job = createJob(root, 'evaluate', {
+      num: 42,
+      workflow_id: '0123456789abcdef',
+      workflow_step_id: 'target-0-0-evaluate',
+    });
+
+    expect(job).toMatchObject({
+      workflowId: '0123456789abcdef',
+      workflowStepId: 'target-0-0-evaluate',
+    });
+  });
+
   it('createJob with invalid num persists an error record', async () => {
     const job = createJob(root, 'tailor-cv', { num: 'oops' as unknown as number });
     // Poll instead of a fixed sleep — under full-suite parallel load a 50ms

--- a/src/lib/server/__tests__/jobs-command-registry.test.ts
+++ b/src/lib/server/__tests__/jobs-command-registry.test.ts
@@ -165,15 +165,18 @@ describe('jobs/command-registry', () => {
       },
     );
 
-    it.each(['tailor-cv', 'cover-letter'] as const)('%s — routes through mode-runner', type => {
-      const cmd = buildCommand(type, { num: 42 }, root);
-      expect(cmd).not.toBeNull();
-      expect(() => JobCommand.parse(cmd)).not.toThrow();
-      // Input loading + provider spawn moved into batch/mode-runner.mjs;
-      // the registry branch is now a thin script that calls it.
-      expect(cmd?.args[1]).toContain(`node batch/mode-runner.mjs ${type} --num 42`);
-      expect(cmd?.args[1]).toContain('set -o pipefail');
-    });
+    it.each(['tailor-cv', 'cover-letter', 'latex'] as const)(
+      '%s — routes through mode-runner',
+      type => {
+        const cmd = buildCommand(type, { num: 42 }, root);
+        expect(cmd).not.toBeNull();
+        expect(() => JobCommand.parse(cmd)).not.toThrow();
+        // Input loading + provider spawn moved into batch/mode-runner.mjs;
+        // the registry branch is now a thin script that calls it.
+        expect(cmd?.args[1]).toContain(`node batch/mode-runner.mjs ${type} --num 42`);
+        expect(cmd?.args[1]).toContain('set -o pipefail');
+      },
+    );
   });
 
   describe('buildCommand returns null for invalid params', () => {

--- a/src/lib/server/__tests__/text-offer-reservations.test.ts
+++ b/src/lib/server/__tests__/text-offer-reservations.test.ts
@@ -1,9 +1,10 @@
 import { execFile } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { afterEach, describe, expect, it } from 'vitest';
+import { reserveTextOfferNumber } from '../text-offer-reservations';
 
 const execFileAsync = promisify(execFile);
 const roots: string[] = [];
@@ -17,8 +18,8 @@ async function reserveInProcess(root: string, hash: string): Promise<number> {
   const modulePath = join(process.cwd(), 'src/lib/server/text-offer-reservations.ts');
   const script = [
     `import { reserveTextOfferNumber } from ${JSON.stringify(modulePath)};`,
-    'process.stdout.write(String(reserveTextOfferNumber(',
-    'process.env.TEST_ROOT, process.env.TEST_HASH, 1)));',
+    'void (async () => { process.stdout.write(String(await reserveTextOfferNumber(',
+    'process.env.TEST_ROOT, process.env.TEST_HASH, 1))); })();',
   ].join('');
   const { stdout } = await execFileAsync(tsx, ['-e', script], {
     env: { ...process.env, TEST_ROOT: root, TEST_HASH: hash },
@@ -49,5 +50,35 @@ describe('text offer number reservations', () => {
     ]);
 
     expect(numbers).toEqual([1, 1]);
+  });
+
+  it('waits for a held lock without blocking the event loop', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sur9e-text-reservations-'));
+    roots.push(root);
+    const lock = join(root, 'data/text-offer-reservations/.allocation.lock');
+    mkdirSync(lock, { recursive: true });
+    setTimeout(() => rmSync(lock, { recursive: true, force: true }), 50);
+
+    await expect(reserveTextOfferNumber(root, 'd'.repeat(64), 1)).resolves.toBe(1);
+  });
+
+  it('removes abandoned reservations after their confirmation lifetime', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sur9e-text-reservations-'));
+    roots.push(root);
+    const dir = join(root, 'data/text-offer-reservations');
+    const abandoned = join(dir, `${'e'.repeat(64)}.json`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      abandoned,
+      JSON.stringify({
+        jdHash: 'e'.repeat(64),
+        num: 1,
+        createdAt: new Date(Date.now() - 31 * 60 * 1000).toISOString(),
+      }),
+      'utf-8',
+    );
+
+    await expect(reserveTextOfferNumber(root, 'f'.repeat(64), 1)).resolves.toBe(1);
+    expect(existsSync(abandoned)).toBe(false);
   });
 });

--- a/src/lib/server/__tests__/text-offer-reservations.test.ts
+++ b/src/lib/server/__tests__/text-offer-reservations.test.ts
@@ -1,0 +1,53 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+async function reserveInProcess(root: string, hash: string): Promise<number> {
+  const tsx = join(process.cwd(), 'node_modules/.bin/tsx');
+  const modulePath = join(process.cwd(), 'src/lib/server/text-offer-reservations.ts');
+  const script = [
+    `import { reserveTextOfferNumber } from ${JSON.stringify(modulePath)};`,
+    'process.stdout.write(String(reserveTextOfferNumber(',
+    'process.env.TEST_ROOT, process.env.TEST_HASH, 1)));',
+  ].join('');
+  const { stdout } = await execFileAsync(tsx, ['-e', script], {
+    env: { ...process.env, TEST_ROOT: root, TEST_HASH: hash },
+  });
+  return Number(stdout);
+}
+
+describe('text offer number reservations', () => {
+  it('allocates distinct numbers atomically across concurrent processes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sur9e-text-reservations-'));
+    roots.push(root);
+
+    const numbers = await Promise.all([
+      reserveInProcess(root, 'a'.repeat(64)),
+      reserveInProcess(root, 'b'.repeat(64)),
+    ]);
+
+    expect([...numbers].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it('reuses one reservation for concurrent requests with the same JD hash', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'sur9e-text-reservations-'));
+    roots.push(root);
+
+    const numbers = await Promise.all([
+      reserveInProcess(root, 'c'.repeat(64)),
+      reserveInProcess(root, 'c'.repeat(64)),
+    ]);
+
+    expect(numbers).toEqual([1, 1]);
+  });
+});

--- a/src/lib/server/__tests__/text-offers.test.ts
+++ b/src/lib/server/__tests__/text-offers.test.ts
@@ -15,6 +15,7 @@ import {
   createOrReuseTextOffer,
   hashJobDescription,
   normalizeJobDescription,
+  reserveTextOfferPreview,
 } from '../text-offers';
 
 const TRACKER = [
@@ -99,6 +100,20 @@ describe('text offers', () => {
     expect(
       readFileSync(join(root, 'data/applications.md'), 'utf-8').match(/^\| 1 \|/gm),
     ).toHaveLength(1);
+  });
+
+  it('creates with the exact number reserved during confirmation planning', () => {
+    const root = seedRoot();
+    roots.push(root);
+    const preview = reserveTextOfferPreview(root, 'Build a reliable platform.');
+    const created = createOrReuseTextOffer(root, {
+      company: 'Acme',
+      role: 'Platform Engineer',
+      text: 'Build a reliable platform.',
+      reservedNum: preview.anticipatedNum,
+    });
+
+    expect(created.offer.num).toBe(preview.anticipatedNum);
   });
 
   it('uses explicit Unknown labels when identity is genuinely absent', () => {

--- a/src/lib/server/__tests__/text-offers.test.ts
+++ b/src/lib/server/__tests__/text-offers.test.ts
@@ -49,10 +49,10 @@ describe('text offers', () => {
     expect(hashJobDescription(unix)).toBe(hashJobDescription(windows));
   });
 
-  it('saves the JD, creates a Screened/N/A report, and merges a normal tracker row', () => {
+  it('saves the JD, creates a Screened/N/A report, and merges a normal tracker row', async () => {
     const root = seedRoot();
     roots.push(root);
-    const created = createOrReuseTextOffer(root, {
+    const created = await createOrReuseTextOffer(root, {
       company: 'Acme',
       role: 'Senior Engineer',
       text: 'Own the platform and mentor engineers.',
@@ -80,15 +80,15 @@ describe('text offers', () => {
     expect(tracker).toContain('| Acme | Senior Engineer | N/A | Screened |');
   });
 
-  it('reuses the exact normalized JD instead of creating a duplicate offer', () => {
+  it('reuses the exact normalized JD instead of creating a duplicate offer', async () => {
     const root = seedRoot();
     roots.push(root);
-    const first = createOrReuseTextOffer(root, {
+    const first = await createOrReuseTextOffer(root, {
       company: 'Acme',
       role: 'Senior Engineer',
       text: 'Own the platform.\n',
     });
-    const second = createOrReuseTextOffer(root, {
+    const second = await createOrReuseTextOffer(root, {
       company: 'Acme Incorporated',
       role: 'Platform Lead',
       text: '\r\nOwn the platform.   \r\n',
@@ -102,11 +102,11 @@ describe('text offers', () => {
     ).toHaveLength(1);
   });
 
-  it('creates with the exact number reserved during confirmation planning', () => {
+  it('creates with the exact number reserved during confirmation planning', async () => {
     const root = seedRoot();
     roots.push(root);
-    const preview = reserveTextOfferPreview(root, 'Build a reliable platform.');
-    const created = createOrReuseTextOffer(root, {
+    const preview = await reserveTextOfferPreview(root, 'Build a reliable platform.');
+    const created = await createOrReuseTextOffer(root, {
       company: 'Acme',
       role: 'Platform Engineer',
       text: 'Build a reliable platform.',
@@ -116,18 +116,38 @@ describe('text offers', () => {
     expect(created.offer.num).toBe(preview.anticipatedNum);
   });
 
-  it('uses explicit Unknown labels when identity is genuinely absent', () => {
+  it('releases the reserved number when offer creation fails', async () => {
     const root = seedRoot();
     roots.push(root);
-    const created = createOrReuseTextOffer(root, { text: 'Build something useful.' });
+    const preview = await reserveTextOfferPreview(root, 'Build a reliable platform.');
+    writeFileSync(join(root, 'inputs'), 'block the inputs directory', 'utf-8');
+
+    await expect(
+      createOrReuseTextOffer(root, {
+        company: 'Acme',
+        role: 'Platform Engineer',
+        text: 'Build a reliable platform.',
+        reservedNum: preview.anticipatedNum,
+      }),
+    ).rejects.toThrow();
+
+    rmSync(join(root, 'inputs'), { force: true });
+    const next = await reserveTextOfferPreview(root, 'Build a different reliable platform.');
+    expect(next.anticipatedNum).toBe(preview.anticipatedNum);
+  });
+
+  it('uses explicit Unknown labels when identity is genuinely absent', async () => {
+    const root = seedRoot();
+    roots.push(root);
+    const created = await createOrReuseTextOffer(root, { text: 'Build something useful.' });
     expect(created.offer.company).toBe('Unknown');
     expect(created.offer.role).toBe('Unknown role');
   });
 
-  it('deleting the offer also removes its saved pasted JD', () => {
+  it('deleting the offer also removes its saved pasted JD', async () => {
     const root = seedRoot();
     roots.push(root);
-    const created = createOrReuseTextOffer(root, {
+    const created = await createOrReuseTextOffer(root, {
       company: 'Acme',
       role: 'Engineer',
       text: 'Build something useful.',

--- a/src/lib/server/chat/__tests__/confirms-edit-report.test.ts
+++ b/src/lib/server/chat/__tests__/confirms-edit-report.test.ts
@@ -51,12 +51,12 @@ function parkEdit(oldText: string, newText: string) {
 }
 
 describe("resolveConfirm 'edit-report'", () => {
-  it('approve applies the edit to the file and returns { ok, report }', () => {
+  it('approve applies the edit to the file and returns { ok, report }', async () => {
     const { token } = parkEdit(
       'The comp band looks below market.',
       'The comp band is competitive.',
     );
-    const res = resolveConfirm(dir, token, true);
+    const res = await resolveConfirm(dir, token, true);
 
     expect(res.outcome).toBe('approved');
     expect(res.result).toEqual({ ok: true, report: { num: 7 } });
@@ -68,13 +68,13 @@ describe("resolveConfirm 'edit-report'", () => {
     expect(after).toContain('company: Acme');
   });
 
-  it('approve with a vanished old_text yields { ok:false, error } and leaves the file alone', () => {
+  it('approve with a vanished old_text yields { ok:false, error } and leaves the file alone', async () => {
     const { token } = parkEdit('The comp band looks below market.', 'edited.');
     // Race: the source text is gone by the time the user approves.
     const mutated = REPORT.replace('The comp band looks below market.', 'Rewritten out of band.');
     writeFileSync(filePath, mutated, 'utf8');
 
-    const res = resolveConfirm(dir, token, true);
+    const res = await resolveConfirm(dir, token, true);
     expect(res.outcome).toBe('approved');
     expect(res.result?.ok).toBe(false);
     if (res.result?.ok === false) {
@@ -84,9 +84,9 @@ describe("resolveConfirm 'edit-report'", () => {
     expect(readFileSync(filePath, 'utf8')).toContain('Rewritten out of band.');
   });
 
-  it('cancel writes nothing', () => {
+  it('cancel writes nothing', async () => {
     const { token } = parkEdit('The comp band looks below market.', 'should not be written');
-    const res = resolveConfirm(dir, token, false);
+    const res = await resolveConfirm(dir, token, false);
     expect(res.outcome).toBe('cancelled');
     expect(res.result).toBeUndefined();
     expect(readFileSync(filePath, 'utf8')).toBe(REPORT);

--- a/src/lib/server/chat/confirms.ts
+++ b/src/lib/server/chat/confirms.ts
@@ -19,17 +19,12 @@ import type { TextOfferStartKind } from '../../schemas/chat-actions';
 import type { JobType } from '../../schemas/jobs';
 import type { WorkflowRecord } from '../../schemas/workflows';
 import { updateStatus } from '../applications';
-import {
-  getJob,
-  type JobConflictPayload,
-  type JobRecord,
-  type JobSetupRequiredPayload,
-} from '../jobs';
+import { type JobConflictPayload, type JobRecord, type JobSetupRequiredPayload } from '../jobs';
 import { type CancelJobResult, cancelJob } from '../jobs/lifecycle';
 import { resolveModeRuntime } from '../providers/registry';
 import { applyReportBodyEdit, parseFrontmatter, saveReport } from '../reports';
 import { createOrReuseTextOffer, type TextOfferResult } from '../text-offers';
-import { cancelWorkflow, createWorkflow, getWorkflow, type WorkflowPlan } from '../workflows';
+import { cancelWorkflow, createWorkflow, type WorkflowPlan, workflowChildJobs } from '../workflows';
 import { startChatJob } from './job-start';
 import { appendConfirmResolution } from './store';
 import { emitTurnEvent } from './turn-runner';
@@ -220,11 +215,7 @@ function executionFor(
 }
 
 function jobsForWorkflow(root: string, workflow: WorkflowRecord): JobRecord[] {
-  return workflow.steps.flatMap(step => {
-    if (!step.jobId) return [];
-    const job = getJob(root, step.jobId);
-    return job ? [job] : [];
-  });
+  return workflowChildJobs(root, workflow);
 }
 
 /**
@@ -275,20 +266,21 @@ export function resolveConfirm(
         result = { ok: true, cancellation: cancelJob(root, p.jobId) };
       } else if (rec.kind === 'cancel-workflow') {
         const p = rec.payload as CancelWorkflowPayload;
-        const before = getWorkflow(root, p.workflowId);
-        if (!before) throw new Error(`workflow not found: ${p.workflowId}`);
-        const wasActive = before.status === 'queued' || before.status === 'running';
-        const workflow = cancelWorkflow(root, p.workflowId);
+        const cancellation = cancelWorkflow(root, p.workflowId);
+        const { workflow } = cancellation;
         result = {
           ok: true,
           workflow,
-          cancelledWorkflow: wasActive,
-          message: wasActive
+          cancelledWorkflow: cancellation.cancelled,
+          message: cancellation.cancelled
             ? `Workflow ${workflow.id} cancelled.`
             : `Workflow ${workflow.id} was already ${workflow.status}.`,
         };
       } else if (rec.kind === 'create-offer-from-text') {
         const p = rec.payload as CreateOfferFromTextPayload;
+        if (p.startKind && p.modes) {
+          throw new Error('startKind and modes cannot be combined');
+        }
         const textOffer = createOrReuseTextOffer(root, p);
         const job = p.startKind
           ? startChatJob(root, p.startKind, { num: textOffer.offer.num })

--- a/src/lib/server/chat/confirms.ts
+++ b/src/lib/server/chat/confirms.ts
@@ -70,6 +70,7 @@ export interface CreateOfferFromTextPayload {
   role?: string;
   startKind?: TextOfferStartKind;
   modes?: string[];
+  reservedNum?: number;
 }
 
 export interface EditReportPayload {

--- a/src/lib/server/chat/confirms.ts
+++ b/src/lib/server/chat/confirms.ts
@@ -225,11 +225,11 @@ function jobsForWorkflow(root: string, workflow: WorkflowRecord): JobRecord[] {
  * — single source of effects). Unknown, already-resolved, and past-TTL
  * tokens all resolve to 'expired' and execute nothing.
  */
-export function resolveConfirm(
+export async function resolveConfirm(
   root: string,
   token: string,
   approve: boolean,
-): ResolveConfirmResult {
+): Promise<ResolveConfirmResult> {
   const rec = confirms.get(token);
   if (!rec) {
     // Unknown/swept token: nothing to execute, but if the owning message is
@@ -282,7 +282,7 @@ export function resolveConfirm(
         if (p.startKind && p.modes) {
           throw new Error('startKind and modes cannot be combined');
         }
-        const textOffer = createOrReuseTextOffer(root, p);
+        const textOffer = await createOrReuseTextOffer(root, p);
         const job = p.startKind
           ? startChatJob(root, p.startKind, { num: textOffer.offer.num })
           : undefined;

--- a/src/lib/server/chat/confirms.ts
+++ b/src/lib/server/chat/confirms.ts
@@ -17,17 +17,20 @@ import { jobEstimateLabel } from '../../job-types';
 import type { ApplicationRow } from '../../schemas/applications';
 import type { TextOfferStartKind } from '../../schemas/chat-actions';
 import type { JobType } from '../../schemas/jobs';
+import type { WorkflowRecord } from '../../schemas/workflows';
 import { updateStatus } from '../applications';
 import {
+  getJob,
   type JobConflictPayload,
   type JobRecord,
   type JobSetupRequiredPayload,
-  startJob,
 } from '../jobs';
 import { type CancelJobResult, cancelJob } from '../jobs/lifecycle';
 import { resolveModeRuntime } from '../providers/registry';
 import { applyReportBodyEdit, parseFrontmatter, saveReport } from '../reports';
 import { createOrReuseTextOffer, type TextOfferResult } from '../text-offers';
+import { cancelWorkflow, createWorkflow, getWorkflow, type WorkflowPlan } from '../workflows';
+import { startChatJob } from './job-start';
 import { appendConfirmResolution } from './store';
 import { emitTurnEvent } from './turn-runner';
 
@@ -35,7 +38,9 @@ const TTL_MS = 15 * 60 * 1000;
 
 export type ConfirmKind =
   | 'start-job'
+  | 'start-workflow'
   | 'cancel-job'
+  | 'cancel-workflow'
   | 'create-offer-from-text'
   | 'set-status'
   | 'edit-report';
@@ -43,6 +48,16 @@ export type ConfirmKind =
 export interface StartJobPayload {
   kind: JobType;
   params?: Record<string, unknown>;
+}
+
+export interface StartWorkflowPayload {
+  targets: Array<{ num: number } | { url: string }>;
+  modes: string[];
+  guidance?: string;
+}
+
+export interface CancelWorkflowPayload {
+  workflowId: string;
 }
 
 export interface SetStatusPayload {
@@ -59,6 +74,7 @@ export interface CreateOfferFromTextPayload {
   company?: string;
   role?: string;
   startKind?: TextOfferStartKind;
+  modes?: string[];
 }
 
 export interface EditReportPayload {
@@ -72,7 +88,9 @@ export interface EditReportPayload {
 
 type ConfirmPayload =
   | StartJobPayload
+  | StartWorkflowPayload
   | CancelJobPayload
+  | CancelWorkflowPayload
   | CreateOfferFromTextPayload
   | SetStatusPayload
   | EditReportPayload;
@@ -153,12 +171,16 @@ export interface ConfirmResultPresentation {
 
 type ConfirmExecutionPayload =
   | { job: JobRecord | JobConflictPayload | JobSetupRequiredPayload }
+  | { workflow: WorkflowRecord; jobs: JobRecord[] }
+  | { workflow: WorkflowRecord; cancelledWorkflow: boolean }
   | { updated: ApplicationRow | undefined }
   | { report: { num: number } }
   | { cancellation: CancelJobResult }
   | {
       textOffer: TextOfferResult;
       job?: JobRecord | JobConflictPayload | JobSetupRequiredPayload;
+      workflow?: WorkflowRecord;
+      jobs?: JobRecord[];
     };
 
 export type ConfirmExecutionResult =
@@ -185,10 +207,24 @@ function executionFor(
     const status = result.job && 'status' in result.job ? result.job.status : undefined;
     return status === 'queued' || status === 'running' ? 'succeeded' : 'unchanged';
   }
+  if (kind === 'start-workflow' && 'workflow' in result && result.workflow) {
+    return result.workflow.status === 'error' ? 'failed' : 'succeeded';
+  }
+  if (kind === 'cancel-workflow' && 'cancelledWorkflow' in result) {
+    return result.cancelledWorkflow ? 'succeeded' : 'unchanged';
+  }
   if (kind === 'set-status' && 'updated' in result) {
     return result.updated ? 'succeeded' : 'unchanged';
   }
   return 'succeeded';
+}
+
+function jobsForWorkflow(root: string, workflow: WorkflowRecord): JobRecord[] {
+  return workflow.steps.flatMap(step => {
+    if (!step.jobId) return [];
+    const job = getJob(root, step.jobId);
+    return job ? [job] : [];
+  });
 }
 
 /**
@@ -222,22 +258,51 @@ export function resolveConfirm(
     try {
       if (rec.kind === 'start-job') {
         const p = rec.payload as StartJobPayload;
-        const job = startJob(root, { kind: p.kind, params: p.params });
+        const job = startChatJob(root, p.kind, p.params);
         result = { ok: true, job, ...describeStartedJob(p.kind, p.params, job) };
+      } else if (rec.kind === 'start-workflow') {
+        const p = rec.payload as StartWorkflowPayload;
+        const workflow = createWorkflow(root, p);
+        const jobs = jobsForWorkflow(root, workflow);
+        result = {
+          ok: true,
+          workflow,
+          jobs,
+          ...describeStartedWorkflow(workflow),
+        };
       } else if (rec.kind === 'cancel-job') {
         const p = rec.payload as CancelJobPayload;
         result = { ok: true, cancellation: cancelJob(root, p.jobId) };
+      } else if (rec.kind === 'cancel-workflow') {
+        const p = rec.payload as CancelWorkflowPayload;
+        const before = getWorkflow(root, p.workflowId);
+        if (!before) throw new Error(`workflow not found: ${p.workflowId}`);
+        const wasActive = before.status === 'queued' || before.status === 'running';
+        const workflow = cancelWorkflow(root, p.workflowId);
+        result = {
+          ok: true,
+          workflow,
+          cancelledWorkflow: wasActive,
+          message: wasActive
+            ? `Workflow ${workflow.id} cancelled.`
+            : `Workflow ${workflow.id} was already ${workflow.status}.`,
+        };
       } else if (rec.kind === 'create-offer-from-text') {
         const p = rec.payload as CreateOfferFromTextPayload;
         const textOffer = createOrReuseTextOffer(root, p);
         const job = p.startKind
-          ? startJob(root, { kind: p.startKind, params: { num: textOffer.offer.num } })
+          ? startChatJob(root, p.startKind, { num: textOffer.offer.num })
           : undefined;
+        const workflow = p.modes
+          ? createWorkflow(root, { targets: [{ num: textOffer.offer.num }], modes: p.modes })
+          : undefined;
+        const jobs = workflow ? jobsForWorkflow(root, workflow) : undefined;
         result = {
           ok: true,
           textOffer,
           ...(job ? { job } : {}),
-          ...describeTextOfferResult(textOffer, p.startKind, job),
+          ...(workflow ? { workflow, jobs } : {}),
+          ...describeTextOfferResult(textOffer, p.startKind, job, workflow),
         };
       } else if (rec.kind === 'edit-report') {
         const p = rec.payload as EditReportPayload;
@@ -313,6 +378,7 @@ function persistResolution(
 const KIND_LABELS: Record<JobType, string> = {
   evaluate: 'evaluation',
   'tailor-cv': 'CV tailoring',
+  latex: 'LaTeX CV generation',
   'cover-letter': 'cover letter',
   research: 'company research',
   'interview-prep': 'interview prep',
@@ -321,11 +387,28 @@ const KIND_LABELS: Record<JobType, string> = {
   scan: 'portal scan',
   'batch-evaluate': 'batch evaluation',
   screen: 'screening',
-  'screen-evaluate': 'screen + evaluate',
+  'screen-evaluate': 'screening → evaluation',
 };
 
 function offerLink(num: number): ConfirmResultLink[] {
   return [{ label: `Offer #${num}`, href: `/report/${num}` }];
+}
+
+function workflowLinks(workflow: WorkflowRecord): ConfirmResultLink[] {
+  return workflow.targets.flatMap(target =>
+    'num' in target && typeof target.num === 'number' && Number.isInteger(target.num)
+      ? offerLink(target.num)
+      : [],
+  );
+}
+
+export function describeStartedWorkflow(workflow: WorkflowRecord): ConfirmResultPresentation {
+  const targetCount = workflow.targets.length;
+  const modeCount = workflow.requestedModes.length;
+  return {
+    message: `Workflow started: ${modeCount} mode${modeCount === 1 ? '' : 's'} across ${targetCount || 1} target${targetCount === 1 ? '' : 's'}.`,
+    links: workflowLinks(workflow),
+  };
 }
 
 export function describeStartedJob(
@@ -336,6 +419,15 @@ export function describeStartedJob(
   const num = Number.isInteger(params?.num) ? (params?.num as number) : null;
   const links = num == null ? undefined : offerLink(num);
   if (job && 'conflict' in job) return { message: job.message, ...(links ? { links } : {}) };
+  if (kind === 'screen-evaluate') {
+    return {
+      message:
+        num == null
+          ? 'Screening started; evaluation will start after screening succeeds.'
+          : `Screening started for offer #${num}; evaluation will start after screening succeeds.`,
+      ...(links ? { links } : {}),
+    };
+  }
   const label = KIND_LABELS[kind] ?? kind;
   return {
     message:
@@ -350,14 +442,17 @@ export function describeTextOfferResult(
   textOffer: TextOfferResult,
   startKind?: TextOfferStartKind,
   job?: JobRecord | JobConflictPayload | JobSetupRequiredPayload,
+  workflow?: WorkflowRecord,
 ): ConfirmResultPresentation {
   const num = textOffer.offer.num;
   const created = textOffer.reused ? 'reused' : 'created';
   let followup = '';
-  if (startKind && job && 'conflict' in job) {
+  if (workflow) {
+    followup = ` Workflow started with ${workflow.requestedModes.join(' → ')}.`;
+  } else if (startKind && job && 'conflict' in job) {
     followup = ` ${job.message}`;
   } else if (startKind === 'screen-evaluate') {
-    followup = ' Screening and evaluation started.';
+    followup = ' Screening started; evaluation will start after screening succeeds.';
   } else if (startKind === 'screen') {
     followup = ' Screening started.';
   } else if (startKind) {
@@ -366,6 +461,56 @@ export function describeTextOfferResult(
   return {
     message: `Offer #${num} ${created}.${followup}`,
     links: offerLink(num),
+  };
+}
+
+export function describeStartWorkflow(
+  input: StartWorkflowPayload,
+  plan?: WorkflowPlan,
+): {
+  summary: string;
+  meta: string;
+} {
+  const targetCount = input.targets.length || 1;
+  const modeCount = input.modes.length;
+  const labels = input.modes.map(mode => KIND_LABELS[mode as JobType] ?? mode);
+  let phaseLabel = labels.join(' → ');
+  if (plan) {
+    const depths = new Map<string, number>();
+    const phases = new Map<number, string[]>();
+    for (const step of plan.steps) {
+      const depth =
+        step.dependsOn.length === 0
+          ? 0
+          : Math.max(...step.dependsOn.map(id => depths.get(id) ?? 0)) + 1;
+      depths.set(step.id, depth);
+      const label = KIND_LABELS[step.mode as JobType] ?? step.mode;
+      const phase = phases.get(depth) ?? [];
+      if (!phase.includes(label)) phase.push(label);
+      phases.set(depth, phase);
+    }
+    phaseLabel = [...phases.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, phase]) => phase.join(' + '))
+      .join(' → ');
+  }
+  return {
+    summary: `Run ${modeCount} mode${modeCount === 1 ? '' : 's'} for ${targetCount} target${targetCount === 1 ? '' : 's'}`,
+    meta: `${phaseLabel}${targetCount > 1 ? ` · ${targetCount} targets in parallel` : ''} · dependency-aware · max 4 parallel`,
+  };
+}
+
+export function describeCancelWorkflow(workflow: WorkflowRecord): {
+  summary: string;
+  meta: string;
+} {
+  const active = workflow.steps.filter(step => step.status === 'running').length;
+  const queued = workflow.steps.filter(
+    step => step.status === 'queued' || step.status === 'blocked',
+  ).length;
+  return {
+    summary: `Cancel workflow ${workflow.id}`,
+    meta: `${active} active · ${queued} queued · partial output kept`,
   };
 }
 
@@ -414,13 +559,22 @@ export function describeCancelJob(job: JobRecord): { summary: string; meta: stri
 
 export function describeCreateOfferFromText(
   preview: { reused: boolean; offer: ApplicationRow | null },
-  input: { company?: string; role?: string; startKind?: TextOfferStartKind },
+  input: {
+    company?: string;
+    role?: string;
+    startKind?: TextOfferStartKind;
+    modes?: string[];
+  },
 ): { summary: string; meta: string } {
   const identity = [input.company?.trim(), input.role?.trim()].filter(Boolean).join(' · ');
   const action = preview.reused
     ? `Reuse offer #${preview.offer?.num}`
     : `Create offer from pasted text`;
-  const next = input.startKind ? ` · then start ${KIND_LABELS[input.startKind]}` : '';
+  const next = input.modes
+    ? ` · then run ${input.modes.join(' → ')}`
+    : input.startKind
+      ? ` · then start ${KIND_LABELS[input.startKind]}`
+      : '';
   return {
     summary: identity ? `${action} — ${identity}` : action,
     meta: `${preview.reused ? 'exact text match' : 'local tracker write'}${next}`,

--- a/src/lib/server/chat/job-start.ts
+++ b/src/lib/server/chat/job-start.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+import type { JobType } from '../../schemas/jobs';
+import {
+  type JobConflictPayload,
+  type JobRecord,
+  type JobSetupRequiredPayload,
+  startJob,
+} from '../jobs';
+
+type ChatJobStartResult = JobRecord | JobConflictPayload | JobSetupRequiredPayload;
+
+/**
+ * Chat keeps screening and evaluation as separate jobs. `screen-evaluate`
+ * remains the compact MCP request for an explicitly requested pair, but is
+ * expanded here into a screen job whose successful completion queues a
+ * separate evaluation job.
+ */
+export function startChatJob(
+  root: string,
+  kind: JobType,
+  params?: Record<string, unknown>,
+): ChatJobStartResult {
+  const {
+    then: _untrustedThen,
+    next_job_id: _untrustedNextJobId,
+    continuation_error: _untrustedContinuationError,
+    ...safeParams
+  } = params ?? {};
+  if (kind !== 'screen-evaluate') return startJob(root, { kind, params: safeParams });
+  return startJob(root, {
+    kind: 'screen',
+    params: { ...safeParams, then: 'evaluate' },
+  });
+}

--- a/src/lib/server/chat/prompt.ts
+++ b/src/lib/server/chat/prompt.ts
@@ -9,9 +9,14 @@
 // new user message (+ optional context line).
 
 import 'server-only';
+import { MODE_CATALOG } from '../../modes/catalog';
 import type { ChatAttachment, ChatMessage } from '../../schemas/chat';
 import { reportPathForNum } from '../reports';
 import { resolveChatUploadPath } from './uploads';
+
+const MODE_ROUTING = Object.values(MODE_CATALOG)
+  .map(mode => `- ${mode.id} — ${mode.description} (${mode.execution}; ${mode.scope})`)
+  .join('\n');
 
 // Lean persona — data arrives on demand via the sur9e-app MCP tools, NOT
 // via fat context injection. Keep this static: anything per-turn belongs
@@ -24,44 +29,30 @@ sur9e evaluates job offers against the user's real career profile, tailors CVs, 
 - Answer from tool reads, not from memory. When the user asks about their tracker, reports, profile, or pipeline, call the matching read tool first and cite what it returned.
 
 ## Tools
-- Use the sur9e app tools (mcp__sur9e-app__*) for all app data and actions: read the tracker, reports, pipeline, and profile summary; start jobs; change statuses; navigate the UI.
+- Use the sur9e app tools (mcp__sur9e-app__*) for all app data and actions: read the tracker, reports, pipeline, profile summary, mode catalog, and workflows; start jobs or workflows; change statuses; navigate the UI.
 - File tools (Read, Glob, Grep) and web tools (WebFetch, WebSearch) are read-only helpers. You cannot run shell commands or edit files from chat.
 - Every job start and every status change goes through the matching app tool and requires the user's explicit confirmation. State what you intend to do, call the tool, and let the confirmation card do the gating — never claim an action happened before the tool result says so.
 - To stop work, call list_jobs first and cancel_job with ONE exact job id. If the request could refer to multiple active jobs, ask which job; never guess, cancel all, or pick the newest. Cancellation also requires confirmation.
+- To stop an entire workflow, call list_workflows first and cancel_workflow with ONE exact workflow id. Never substitute cancel_job when the user asked to stop all remaining steps.
 - When the user pastes a job description without a URL and wants an offer, CV, cover letter, evaluation, or related artifact, call create_offer_from_text. Do not tell them a tracker URL is required.
 - Before create_offer_from_text, identify company and role from the conversation or pasted text. If either is unclear, ask the user. Use "Unknown" only when the information is genuinely absent.
-- Unless the user already chose a workflow, ask whether they want: Create + screen + evaluate (recommended), Create + screen, or Create only. Do not create an empty placeholder without offering the useful follow-up work.
-- Use start_kind: screen-evaluate for Create + screen + evaluate, start_kind: screen for Create + screen, and omit start_kind for Create only. This keeps creation and processing behind one approval card. Exact pasted text may reuse an existing offer.
+- Treat screening and evaluation as separate modes. If the user asks for only one, offer and start only that mode.
+- Unless the user already chose a workflow, ask whether they want: Create + screen, Create + evaluate, or Create only. Do not create an empty placeholder without offering useful follow-up work.
+- Use screen-evaluate only when the user explicitly asks for both screening and evaluation in the same request. Start it with start_workflow, which expands it into two sequential jobs: screening first, then evaluation only after screening succeeds. Exact pasted text may reuse an existing offer.
+- Use start_job for one background mode on one target. Use start_workflow for multiple modes, multiple explicit offer targets, or a composite mode. The server creates a dependency-aware plan, safely parallelizes independent branches, and gates the full plan behind one confirmation.
+- Before starting a workflow, use list_modes when you need discovery and get_mode_instructions when the user chose an inline or handoff mode. Use list_workflows to inspect durable workflow state.
+- For pasted text plus multiple modes, pass modes to create_offer_from_text. Do not combine modes with the legacy start_kind field.
 - A newly created pasted-text offer currently has \`source_kind: text\`, status Screened, and \`score: N/A\` as a tracker placeholder. That means it has NOT been screened yet. If the user asks to screen it, call start_job with kind screen and screen with params.num; a saved pasted-text offer does not require a URL.
 
 ## Hard rules
 - Never auto-submit a job application. sur9e fills, drafts, and prepares — the human clicks Submit. If asked to submit for the user, decline and explain why.
-- Applying happens in the terminal: tell the user to run /sur9e apply <num> in their AI CLI. Chat does not fill application forms.
+- Apply is a handoff mode: load its canonical instructions with get_mode_instructions, explain the terminal handoff, and never submit or claim submission.
+- Enrich is a handoff mode when protected personalization files must be rewritten. Load its canonical instructions and explain the handoff without claiming files changed in chat.
 - First-run setup also happens in the terminal (npm run setup); if profile data is missing, point there.
 
 ## Mode routing
-Run these as in-chat conversations using your tools when the user asks:
-- enrich — the user wants to strengthen their CV or profile through a guided interview.
-- offers — the user wants two or more offers compared side by side.
-- tracker — the user asks about application status, counts, or history.
-- patterns — the user asks about rejection patterns or how to improve targeting.
-- follow-up — the user asks which applications need a follow-up or what cadence to use.
-- process-queue — the user wants pending saved URLs screened and triaged.
-- training — the user wants a course or certification evaluated against their goals.
-- project — the user wants a portfolio project idea evaluated.
-
-Start these as background jobs (start_job tool, confirmation required) instead of doing the work inline:
-- evaluate — deep-evaluate one tracked offer (needs the offer number).
-- screen — cheap-screen one offer: use params.num for a tracked pasted-text offer or params.url for a URL offer.
-- screen-evaluate — screen then evaluate one offer; use params.num for tracked pasted text or params.url for a URL.
-- research — company research for one tracked offer.
-- tailor-cv — tailored CV PDF for one offer.
-- cover-letter — cover letter PDF for one offer.
-- interview-prep — interview preparation brief for one offer.
-- reach-out — outreach message drafts for one offer.
-- negotiate — negotiation brief for one offer.
-- scan — scan the configured job sources for new offers.
-- batch-evaluate — evaluate every screened offer above the score threshold.
+The canonical catalog below is authoritative. Inline modes run as chat conversations after loading get_mode_instructions. Handoff modes load their instructions and explain the protected terminal handoff. Background modes use start_job for a single mode/target or start_workflow for bulk and multi-mode work. Composite modes always use start_workflow.
+${MODE_ROUTING}
 
 ## Editing & regenerating reports
 - Small change to an existing report → edit_report (a surgical find/replace on the report BODY; frontmatter is never touched, no AI spend). Read the report first with get_report and copy the exact text to change; old_text must match uniquely. A confirmation card gates the write.

--- a/src/lib/server/jobs/__tests__/cancel.test.ts
+++ b/src/lib/server/jobs/__tests__/cancel.test.ts
@@ -99,4 +99,27 @@ describe('cancelJob', () => {
     expect(result).toMatchObject({ cancelled: false, job: { status: 'done' } });
     expect(signal).not.toHaveBeenCalled();
   });
+
+  it('notifies a parent workflow when a child is cancelled directly', () => {
+    writeFileSync(
+      join(root, 'data/jobs', `${JOB_ID}.json`),
+      JSON.stringify(
+        {
+          ...record('queued'),
+          params: { num: 1, workflow_id: 'workflow-1', workflow_step_id: 'step-1' },
+        },
+        null,
+        2,
+      ),
+    );
+    const advanceWorkflow = vi.fn();
+
+    cancelJob(root, JOB_ID, {
+      signal: vi.fn(),
+      scheduleForce: vi.fn(),
+      advanceWorkflow,
+    });
+
+    expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
+  });
 });

--- a/src/lib/server/jobs/__tests__/cancel.test.ts
+++ b/src/lib/server/jobs/__tests__/cancel.test.ts
@@ -136,14 +136,17 @@ describe('cancelJob', () => {
       ),
     );
 
+    const advanceWorkflow = vi.fn(() => {
+      throw new Error('damaged workflow');
+    });
+
     expect(() =>
       cancelJob(root, JOB_ID, {
         signal: vi.fn(),
         scheduleForce: vi.fn(),
-        advanceWorkflow: () => {
-          throw new Error('damaged workflow');
-        },
+        advanceWorkflow,
       }),
     ).not.toThrow();
+    expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
   });
 });

--- a/src/lib/server/jobs/__tests__/cancel.test.ts
+++ b/src/lib/server/jobs/__tests__/cancel.test.ts
@@ -122,4 +122,28 @@ describe('cancelJob', () => {
 
     expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
   });
+
+  it('contains a workflow notification failure after cancellation', () => {
+    writeFileSync(
+      join(root, 'data/jobs', `${JOB_ID}.json`),
+      JSON.stringify(
+        {
+          ...record('queued'),
+          params: { num: 1, workflow_id: '0123456789abcdef', workflow_step_id: 'step-1' },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(() =>
+      cancelJob(root, JOB_ID, {
+        signal: vi.fn(),
+        scheduleForce: vi.fn(),
+        advanceWorkflow: () => {
+          throw new Error('damaged workflow');
+        },
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/lib/server/jobs/__tests__/command-registry-claude-parity.test.ts
+++ b/src/lib/server/jobs/__tests__/command-registry-claude-parity.test.ts
@@ -114,6 +114,13 @@ describe('command-registry Claude parity (lock command shape across the refactor
     expect(built!.args[1]).toContain('node batch/mode-runner.mjs cover-letter --num 42');
   });
 
+  it('latex — routes through mode-runner', () => {
+    const built = buildCommand('latex', { num: 42 }, root);
+    expect(built).not.toBeNull();
+    expect(built!.args[1]).toContain('set -o pipefail');
+    expect(built!.args[1]).toContain('node batch/mode-runner.mjs latex --num 42');
+  });
+
   it('screen-evaluate — routes through screen + mode-runner + merge-tracker', () => {
     const built = buildCommand(
       'screen-evaluate',

--- a/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
@@ -312,14 +312,16 @@ describe('spawnJob cancellation interleaving', () => {
     };
     persistJobRecord(root, job);
     const child = fakeChild();
+    const advanceWorkflow = vi.fn().mockRejectedValue(new Error('damaged workflow'));
 
     await spawnJob(root, job, {
       spawnProcess: vi.fn(() => child),
-      advanceWorkflow: vi.fn().mockRejectedValue(new Error('damaged workflow')),
+      advanceWorkflow,
     });
     child.emit('close', 0);
     await new Promise<void>(resolve => setImmediate(resolve));
 
     expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
+    expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
   });
 });

--- a/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
@@ -291,4 +291,35 @@ describe('spawnJob cancellation interleaving', () => {
 
     expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
   });
+
+  it('contains a rejected workflow notification after job completion', async () => {
+    const job: JobRecord = {
+      id: JOB_ID,
+      type: 'evaluate',
+      status: 'queued',
+      params: {
+        num: 1,
+        workflow_id: '0123456789abcdef',
+        workflow_step_id: 'step-1',
+      },
+      workflowId: '0123456789abcdef',
+      workflowStepId: 'step-1',
+      startedAt: '2026-07-28T10:00:00.000Z',
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    };
+    persistJobRecord(root, job);
+    const child = fakeChild();
+
+    await spawnJob(root, job, {
+      spawnProcess: vi.fn(() => child),
+      advanceWorkflow: vi.fn().mockRejectedValue(new Error('damaged workflow')),
+    });
+    child.emit('close', 0);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
+  });
 });

--- a/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-cancel-race.test.ts
@@ -191,4 +191,104 @@ describe('spawnJob cancellation interleaving', () => {
       output: expect.stringContaining('[USAGE]'),
     });
   });
+
+  it('starts evaluation as a separate job only after screening succeeds', async () => {
+    const job: JobRecord = {
+      id: JOB_ID,
+      type: 'screen',
+      status: 'queued',
+      params: { num: 1, then: 'evaluate' },
+      startedAt: '2026-07-28T10:00:00.000Z',
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    };
+    persistJobRecord(root, job);
+    const child = fakeChild();
+    const startNextJob = vi.fn(() => ({
+      id: 'fedcba9876543210',
+      type: 'evaluate',
+      status: 'queued',
+      params: { num: 1 },
+      startedAt: '2026-07-28T10:01:00.000Z',
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    }));
+
+    await spawnJob(root, job, {
+      spawnProcess: vi.fn(() => child),
+      startNextJob,
+    } as Parameters<typeof spawnJob>[2]);
+    child.emit('close', 0);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(startNextJob).toHaveBeenCalledWith(root, 'evaluate', { num: 1 });
+    expect(readJobRecord(root, JOB_ID)).toMatchObject({
+      status: 'done',
+      params: {
+        num: 1,
+        then: 'evaluate',
+        next_job_id: 'fedcba9876543210',
+      },
+    });
+  });
+
+  it('does not start evaluation when screening fails', async () => {
+    const job: JobRecord = {
+      id: JOB_ID,
+      type: 'screen',
+      status: 'queued',
+      params: { num: 1, then: 'evaluate' },
+      startedAt: '2026-07-28T10:00:00.000Z',
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    };
+    persistJobRecord(root, job);
+    const child = fakeChild();
+    const startNextJob = vi.fn();
+
+    await spawnJob(root, job, {
+      spawnProcess: vi.fn(() => child),
+      startNextJob,
+    } as Parameters<typeof spawnJob>[2]);
+    child.emit('close', 1);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(startNextJob).not.toHaveBeenCalled();
+    expect(readJobRecord(root, JOB_ID)).toMatchObject({
+      status: 'error',
+      params: { num: 1, then: 'evaluate' },
+    });
+  });
+
+  it('notifies the workflow runner after a child reaches a terminal state', async () => {
+    const job: JobRecord = {
+      id: JOB_ID,
+      type: 'evaluate',
+      status: 'queued',
+      params: { num: 1, workflow_id: 'workflow-1', workflow_step_id: 'step-1' },
+      startedAt: '2026-07-28T10:00:00.000Z',
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    };
+    persistJobRecord(root, job);
+    const child = fakeChild();
+    const advanceWorkflow = vi.fn();
+
+    await spawnJob(root, job, {
+      spawnProcess: vi.fn(() => child),
+      advanceWorkflow,
+    } as Parameters<typeof spawnJob>[2]);
+    child.emit('close', 0);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(advanceWorkflow).toHaveBeenCalledWith(root, JOB_ID);
+  });
 });

--- a/src/lib/server/jobs/api.ts
+++ b/src/lib/server/jobs/api.ts
@@ -81,17 +81,22 @@ export function createJob(
 ): JobRecord {
   const canonicalType = validateType(type);
   const id = randomBytes(8).toString('hex');
+  const rawParams = params || {};
   mkdirSync(jobsDir(rootPath), { recursive: true });
   const job = JobRecord.parse({
     id,
     type: canonicalType,
     status: 'queued',
-    params: params || {},
+    params: rawParams,
     startedAt: new Date().toISOString(),
     finishedAt: null,
     output: '',
     error: null,
     exitCode: null,
+    ...(typeof rawParams.workflow_id === 'string' ? { workflowId: rawParams.workflow_id } : {}),
+    ...(typeof rawParams.workflow_step_id === 'string'
+      ? { workflowStepId: rawParams.workflow_step_id }
+      : {}),
   });
   persist(rootPath, job);
 
@@ -113,6 +118,14 @@ export function createJob(
         error: err instanceof Error ? err.message : String(err),
         finishedAt: new Date().toISOString(),
       });
+      if (job.workflowId) {
+        void import('../workflows')
+          .then(({ advanceWorkflowsForJob }) => advanceWorkflowsForJob(rootPath, job.id))
+          .catch(() => {
+            // The persisted child error remains authoritative; boot/list
+            // reconciliation will retry advancing the parent workflow.
+          });
+      }
     });
   });
   return job;

--- a/src/lib/server/jobs/command-registry.ts
+++ b/src/lib/server/jobs/command-registry.ts
@@ -294,10 +294,11 @@ function _buildCommand(
     ].join(' && ');
     return { cmd: '/bin/bash', args: ['-c', script] };
   }
-  if (type === 'tailor-cv' || type === 'cover-letter') {
+  if (type === 'tailor-cv' || type === 'cover-letter' || type === 'latex') {
     const num = params && params.num;
     if (!Number.isInteger(num)) return null;
-    const label = type === 'tailor-cv' ? 'tailored CV' : 'cover letter';
+    const label =
+      type === 'tailor-cv' ? 'tailored CV' : type === 'latex' ? 'LaTeX CV' : 'cover letter';
     const script = [
       `set -o pipefail`,
       `printf "[1/2] Generating ${label} for offer #${num}\\n"`,

--- a/src/lib/server/jobs/lifecycle.ts
+++ b/src/lib/server/jobs/lifecycle.ts
@@ -88,6 +88,7 @@ function signalTree(job: JobRecordType, signal: SignalName): void {
 export interface CancellationDeps {
   signal?: (job: JobRecordType, signal: SignalName) => void;
   scheduleForce?: (fn: () => void, ms: number) => void;
+  advanceWorkflow?: (rootPath: string, jobId: string) => void;
 }
 
 export type CancelJobResult =
@@ -123,6 +124,19 @@ function stopProcess(job: JobRecordType, deps: CancellationDeps): void {
   }
 }
 
+function notifyWorkflow(rootPath: string, job: JobRecordType, deps: CancellationDeps): void {
+  if (!job.workflowId && typeof job.params.workflow_id !== 'string') return;
+  if (deps.advanceWorkflow) {
+    deps.advanceWorkflow(rootPath, job.id);
+    return;
+  }
+  setImmediate(() => {
+    void import('../workflows/api').then(({ advanceWorkflowsForJob }) => {
+      advanceWorkflowsForJob(rootPath, job.id);
+    });
+  });
+}
+
 /**
  * Cancel one exact persisted job. The cancelled record is written before any
  * signal so pollers stop immediately; partial output and worker writes remain.
@@ -149,5 +163,6 @@ export function cancelJob(
         };
   persistJobRecord(rootPath, cancelled);
   stopProcess(cancelled, deps);
+  notifyWorkflow(rootPath, cancelled, deps);
   return { cancelled: current.status !== 'cancelled', job: cancelled };
 }

--- a/src/lib/server/jobs/lifecycle.ts
+++ b/src/lib/server/jobs/lifecycle.ts
@@ -127,13 +127,21 @@ function stopProcess(job: JobRecordType, deps: CancellationDeps): void {
 function notifyWorkflow(rootPath: string, job: JobRecordType, deps: CancellationDeps): void {
   if (!job.workflowId && typeof job.params.workflow_id !== 'string') return;
   if (deps.advanceWorkflow) {
-    deps.advanceWorkflow(rootPath, job.id);
+    try {
+      deps.advanceWorkflow(rootPath, job.id);
+    } catch {
+      // The cancelled child is persisted; reconciliation can retry the parent.
+    }
     return;
   }
   setImmediate(() => {
-    void import('../workflows/api').then(({ advanceWorkflowsForJob }) => {
-      advanceWorkflowsForJob(rootPath, job.id);
-    });
+    void import('../workflows/api')
+      .then(({ advanceWorkflowsForJob }) => {
+        advanceWorkflowsForJob(rootPath, job.id);
+      })
+      .catch(() => {
+        // The cancelled child is persisted; reconciliation can retry the parent.
+      });
   });
 }
 

--- a/src/lib/server/jobs/runner.ts
+++ b/src/lib/server/jobs/runner.ts
@@ -278,7 +278,12 @@ async function advanceWorkflowForJob(rootPath: string, jobId: string): Promise<v
 async function notifyWorkflow(rootPath: string, job: JobRecord, deps: SpawnJobDeps): Promise<void> {
   const persisted = readJobRecord(rootPath, job.id);
   if (!persisted?.workflowId && typeof persisted?.params.workflow_id !== 'string') return;
-  await (deps.advanceWorkflow ?? advanceWorkflowForJob)(rootPath, job.id);
+  try {
+    await (deps.advanceWorkflow ?? advanceWorkflowForJob)(rootPath, job.id);
+  } catch {
+    // The child job record is authoritative. Boot/list reconciliation retries
+    // advancing its parent without turning this completed child into a crash.
+  }
 }
 
 export async function spawnJob(

--- a/src/lib/server/jobs/runner.ts
+++ b/src/lib/server/jobs/runner.ts
@@ -249,6 +249,36 @@ interface SpawnJobDeps {
   spawnProcess?: (command: string, args: string[], options: SpawnOptions) => SpawnedJobProcess;
   cancel?: typeof cancelJob;
   trackUsage?: TrackUsage;
+  startNextJob?: (
+    rootPath: string,
+    kind: 'evaluate',
+    params: Record<string, unknown>,
+  ) =>
+    | JobRecord
+    | { conflict: true; message: string }
+    | Promise<JobRecord | { conflict: true; message: string }>;
+  advanceWorkflow?: (rootPath: string, jobId: string) => unknown | Promise<unknown>;
+}
+
+async function startNextJob(
+  rootPath: string,
+  kind: 'evaluate',
+  params: Record<string, unknown>,
+): Promise<JobRecord | { conflict: true; message: string }> {
+  // Dynamic import avoids a static runner → start → api → runner cycle.
+  const { startJob } = await import('./start');
+  return startJob(rootPath, { kind, params });
+}
+
+async function advanceWorkflowForJob(rootPath: string, jobId: string): Promise<void> {
+  const { advanceWorkflowsForJob } = await import('../workflows/api');
+  advanceWorkflowsForJob(rootPath, jobId);
+}
+
+async function notifyWorkflow(rootPath: string, job: JobRecord, deps: SpawnJobDeps): Promise<void> {
+  const persisted = readJobRecord(rootPath, job.id);
+  if (!persisted?.workflowId && typeof persisted?.params.workflow_id !== 'string') return;
+  await (deps.advanceWorkflow ?? advanceWorkflowForJob)(rootPath, job.id);
 }
 
 export async function spawnJob(
@@ -271,6 +301,7 @@ export async function spawnJob(
       finishedAt: new Date().toISOString(),
     };
     persist(rootPath, failed);
+    await notifyWorkflow(rootPath, failed, deps);
     return;
   }
   if (!built) {
@@ -281,6 +312,7 @@ export async function spawnJob(
       finishedAt: new Date().toISOString(),
     };
     persist(rootPath, failed);
+    await notifyWorkflow(rootPath, failed, deps);
     return;
   }
 
@@ -339,6 +371,7 @@ export async function spawnJob(
       finishedAt: new Date().toISOString(),
     };
     persist(rootPath, failed);
+    await notifyWorkflow(rootPath, failed, deps);
     return;
   }
   let providerVersion: string | undefined;
@@ -591,6 +624,49 @@ export async function spawnJob(
       current = { ...current, fixes: fixLog };
     }
     persistCurrentPreservingCancellation();
+
+    // Chat's explicit "screen and evaluate" request is represented as two
+    // real jobs, not the legacy monolithic screen-evaluate command. The screen
+    // record carries `then: evaluate`; only a successful screen may create the
+    // successor. stampScreenJobNum above resolves the tracker number for URL
+    // screens before this hand-off.
+    if (
+      current.status === 'done' &&
+      current.type === 'screen' &&
+      current.params.then === 'evaluate' &&
+      typeof current.params.next_job_id !== 'string'
+    ) {
+      const num = current.params.num;
+      try {
+        if (!Number.isInteger(num)) {
+          throw new Error('screening finished without a tracker offer number');
+        }
+        const next = await (deps.startNextJob ?? startNextJob)(rootPath, 'evaluate', {
+          num: num as number,
+        });
+        current =
+          'conflict' in next
+            ? {
+                ...current,
+                params: { ...current.params, continuation_error: next.message },
+              }
+            : {
+                ...current,
+                params: { ...current.params, next_job_id: next.id },
+              };
+      } catch (error) {
+        current = {
+          ...current,
+          params: {
+            ...current.params,
+            continuation_error:
+              error instanceof Error ? error.message : 'failed to start evaluation',
+          },
+        };
+      }
+      persistCurrentPreservingCancellation();
+    }
+    await notifyWorkflow(rootPath, current, deps);
   });
 
   child.on('error', (err: Error) => {
@@ -615,6 +691,7 @@ export async function spawnJob(
             finishedAt: new Date().toISOString(),
           };
     persist(rootPath, current);
+    void notifyWorkflow(rootPath, current, deps);
   });
 }
 

--- a/src/lib/server/jobs/start.ts
+++ b/src/lib/server/jobs/start.ts
@@ -12,6 +12,7 @@ import { createJob, findActiveJob, type JobRecord, type JobType, listActiveJobs 
 export const JOB_KIND_BY_NUM = new Set<JobType>([
   'evaluate',
   'tailor-cv',
+  'latex',
   'cover-letter',
   'research',
   'interview-prep',
@@ -66,6 +67,49 @@ export interface StartJobInput {
   params?: Record<string, unknown>;
 }
 
+/** Read-only active-job preflight shared by standalone starts and workflow
+ * confirmation planning. An identical conflict can be reattached by the
+ * workflow executor; incompatible singleton work must be rejected before
+ * the user approves a plan that cannot start. */
+export function findJobConflict(
+  rootPath: string,
+  kind: JobType,
+  params: Record<string, unknown>,
+): JobConflictPayload | null {
+  if (JOB_KIND_BY_NUM.has(kind)) {
+    const num = params.num;
+    const duplicate = listActiveJobs(rootPath, kind).find(
+      job => Number((job.params as Record<string, unknown> | undefined)?.num) === num,
+    );
+    if (duplicate) {
+      const label = kind.replace(/-/g, ' ');
+      return {
+        conflict: true,
+        message: `a ${label} job for offer #${num} is already running`,
+        job: duplicate,
+      };
+    }
+  }
+
+  if (JOB_KIND_SINGLETON.has(kind)) {
+    const kindsToCheck: JobType[] = ['scan', 'screen', 'screen-evaluate', 'batch-evaluate'];
+    for (const activeKind of kindsToCheck) {
+      const active = findActiveJob(rootPath, activeKind);
+      if (active) {
+        const noun =
+          activeKind === 'scan'
+            ? 'scan'
+            : activeKind === 'batch-evaluate'
+              ? 'batch evaluation'
+              : 'screen';
+        return { conflict: true, message: `a ${noun} is already running`, job: active };
+      }
+    }
+  }
+
+  return null;
+}
+
 /**
  * Start a background job. Returns the freshly-created JobRecord on success.
  *
@@ -101,39 +145,6 @@ export function startJob(
     if (!findByNum(rootPath, num as number)) {
       throw new Error(`num not found: ${num}`);
     }
-    // Block a duplicate of the SAME per-offer kind for the SAME offer. Two
-    // concurrent cover-letter / evaluate / tailor-cv / … runs on one offer are
-    // wasted paid work and race on the same report/output files. (Singleton
-    // kinds get their own family guard below; this covers the per-offer kinds.)
-    const duplicate = listActiveJobs(rootPath, kind).find(
-      j => Number((j.params as Record<string, unknown> | undefined)?.num) === num,
-    );
-    if (duplicate) {
-      const label = (kind as string).replace(/-/g, ' ');
-      return {
-        conflict: true,
-        message: `a ${label} job for offer #${num} is already running`,
-        job: duplicate,
-      };
-    }
-  }
-
-  if (JOB_KIND_SINGLETON.has(kind)) {
-    // scan, batch-evaluate, and the screen pair all run the screen.mjs +
-    // merge-tracker chain over the same unlocked state (pipeline.md,
-    // screened-urls.txt, tracker-additions/), so scan/batch-evaluate block
-    // the whole family; a single-url screen only blocks its screen sibling.
-    const kindsToCheck: JobType[] =
-      kind === 'screen' || kind === 'screen-evaluate'
-        ? ['screen', 'screen-evaluate']
-        : ['scan', 'screen', 'screen-evaluate', 'batch-evaluate'];
-    for (const k of kindsToCheck) {
-      const active = findActiveJob(rootPath, k);
-      if (active) {
-        const noun = k === 'scan' ? 'scan' : k === 'batch-evaluate' ? 'batch evaluation' : 'screen';
-        return { conflict: true, message: `a ${noun} is already running`, job: active };
-      }
-    }
   }
 
   if (kind === 'screen' || kind === 'screen-evaluate') {
@@ -161,6 +172,9 @@ export function startJob(
       min_score: Number.isFinite(params.min_score) ? params.min_score : 3,
     };
   }
+
+  const conflict = findJobConflict(rootPath, kind, finalParams);
+  if (conflict) return conflict;
 
   return createJob(rootPath, kind, finalParams);
 }

--- a/src/lib/server/jobs/start.ts
+++ b/src/lib/server/jobs/start.ts
@@ -27,7 +27,7 @@ export const JOB_KIND_BY_NUM = new Set<JobType>([
 // both write reports + TSVs to the same paths, then race on the
 // merge-tracker rename (the second hits ENOENT because the first
 // already moved the TSV). Serializing fixes the data corruption.
-const JOB_KIND_SINGLETON = new Set<JobType>([
+export const JOB_KIND_SINGLETON = new Set<JobType>([
   'scan',
   'batch-evaluate',
   'screen',
@@ -92,8 +92,7 @@ export function findJobConflict(
   }
 
   if (JOB_KIND_SINGLETON.has(kind)) {
-    const kindsToCheck: JobType[] = ['scan', 'screen', 'screen-evaluate', 'batch-evaluate'];
-    for (const activeKind of kindsToCheck) {
+    for (const activeKind of JOB_KIND_SINGLETON) {
       const active = findActiveJob(rootPath, activeKind);
       if (active) {
         const noun =

--- a/src/lib/server/text-offer-reservations.ts
+++ b/src/lib/server/text-offer-reservations.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const LOCK_TIMEOUT_MS = 10_000;
+const LOCK_POLL_MS = 25;
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function reservationsDir(root: string): string {
+  return join(root, 'data', 'text-offer-reservations');
+}
+
+function reservationPath(root: string, jdHash: string): string {
+  return join(reservationsDir(root), `${jdHash}.json`);
+}
+
+function withLock<T>(root: string, name: string, operation: () => T): T {
+  const dir = reservationsDir(root);
+  const lock = join(dir, `.${name}.lock`);
+  mkdirSync(dir, { recursive: true });
+  const startedAt = Date.now();
+  while (true) {
+    try {
+      mkdirSync(lock);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) {
+        throw new Error('timed out reserving an offer number');
+      }
+      Atomics.wait(waitBuffer, 0, 0, LOCK_POLL_MS);
+    }
+  }
+  try {
+    return operation();
+  } finally {
+    rmSync(lock, { recursive: true, force: true });
+  }
+}
+
+function readReservation(root: string, jdHash: string): number | null {
+  try {
+    const parsed = JSON.parse(readFileSync(reservationPath(root, jdHash), 'utf-8')) as {
+      num?: unknown;
+    };
+    return Number.isInteger(parsed.num) && Number(parsed.num) > 0 ? Number(parsed.num) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function reserveTextOfferNumber(root: string, jdHash: string, minimumNext: number): number {
+  return withLock(root, 'allocation', () => {
+    const existing = readReservation(root, jdHash);
+    if (existing !== null) return existing;
+
+    const reserved = new Set<number>();
+    for (const name of readdirSync(reservationsDir(root))) {
+      if (!name.endsWith('.json')) continue;
+      try {
+        const value = JSON.parse(readFileSync(join(reservationsDir(root), name), 'utf-8')) as {
+          num?: unknown;
+        };
+        if (Number.isInteger(value.num) && Number(value.num) > 0) {
+          reserved.add(Number(value.num));
+        }
+      } catch {
+        // A damaged reservation cannot safely contribute a number.
+      }
+    }
+
+    let num = minimumNext;
+    while (reserved.has(num)) num += 1;
+    writeFileSync(
+      reservationPath(root, jdHash),
+      JSON.stringify({ jdHash, num, createdAt: new Date().toISOString() }, null, 2),
+      'utf-8',
+    );
+    return num;
+  });
+}
+
+export function releaseTextOfferNumber(root: string, jdHash: string, num: number): void {
+  withLock(root, 'allocation', () => {
+    if (readReservation(root, jdHash) === num) {
+      rmSync(reservationPath(root, jdHash), { force: true });
+    }
+  });
+}
+
+export function withTextOfferCreationLock<T>(root: string, operation: () => T): T {
+  return withLock(root, 'creation', operation);
+}

--- a/src/lib/server/text-offer-reservations.ts
+++ b/src/lib/server/text-offer-reservations.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 const LOCK_TIMEOUT_MS = 10_000;
 const LOCK_POLL_MS = 25;
-const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+const RESERVATION_TTL_MS = 30 * 60 * 1000;
 
 function reservationsDir(root: string): string {
   return join(root, 'data', 'text-offer-reservations');
@@ -13,7 +13,15 @@ function reservationPath(root: string, jdHash: string): string {
   return join(reservationsDir(root), `${jdHash}.json`);
 }
 
-function withLock<T>(root: string, name: string, operation: () => T): T {
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withLock<T>(
+  root: string,
+  name: string,
+  operation: () => T | Promise<T>,
+): Promise<T> {
   const dir = reservationsDir(root);
   const lock = join(dir, `.${name}.lock`);
   mkdirSync(dir, { recursive: true });
@@ -25,33 +33,45 @@ function withLock<T>(root: string, name: string, operation: () => T): T {
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) {
-        throw new Error('timed out reserving an offer number');
+        throw new Error(`timed out acquiring the ${name} text-offer lock`);
       }
-      Atomics.wait(waitBuffer, 0, 0, LOCK_POLL_MS);
+      await delay(LOCK_POLL_MS);
     }
   }
   try {
-    return operation();
+    return await operation();
   } finally {
     rmSync(lock, { recursive: true, force: true });
   }
 }
 
-function readReservation(root: string, jdHash: string): number | null {
+function readReservation(root: string, jdHash: string): { num: number; createdAt: string } | null {
   try {
     const parsed = JSON.parse(readFileSync(reservationPath(root, jdHash), 'utf-8')) as {
       num?: unknown;
+      createdAt?: unknown;
     };
-    return Number.isInteger(parsed.num) && Number(parsed.num) > 0 ? Number(parsed.num) : null;
+    return Number.isInteger(parsed.num) &&
+      Number(parsed.num) > 0 &&
+      typeof parsed.createdAt === 'string'
+      ? { num: Number(parsed.num), createdAt: parsed.createdAt }
+      : null;
   } catch {
     return null;
   }
 }
 
-export function reserveTextOfferNumber(root: string, jdHash: string, minimumNext: number): number {
+export async function reserveTextOfferNumber(
+  root: string,
+  jdHash: string,
+  minimumNext: number,
+): Promise<number> {
   return withLock(root, 'allocation', () => {
     const existing = readReservation(root, jdHash);
-    if (existing !== null) return existing;
+    if (existing !== null && Date.now() - Date.parse(existing.createdAt) <= RESERVATION_TTL_MS) {
+      return existing.num;
+    }
+    if (existing !== null) rmSync(reservationPath(root, jdHash), { force: true });
 
     const reserved = new Set<number>();
     for (const name of readdirSync(reservationsDir(root))) {
@@ -59,8 +79,13 @@ export function reserveTextOfferNumber(root: string, jdHash: string, minimumNext
       try {
         const value = JSON.parse(readFileSync(join(reservationsDir(root), name), 'utf-8')) as {
           num?: unknown;
+          createdAt?: unknown;
         };
-        if (Number.isInteger(value.num) && Number(value.num) > 0) {
+        const createdAt =
+          typeof value.createdAt === 'string' ? Date.parse(value.createdAt) : Number.NaN;
+        if (!Number.isFinite(createdAt) || Date.now() - createdAt > RESERVATION_TTL_MS) {
+          rmSync(join(reservationsDir(root), name), { force: true });
+        } else if (Number.isInteger(value.num) && Number(value.num) > 0) {
           reserved.add(Number(value.num));
         }
       } catch {
@@ -79,14 +104,21 @@ export function reserveTextOfferNumber(root: string, jdHash: string, minimumNext
   });
 }
 
-export function releaseTextOfferNumber(root: string, jdHash: string, num: number): void {
-  withLock(root, 'allocation', () => {
-    if (readReservation(root, jdHash) === num) {
+export async function releaseTextOfferNumber(
+  root: string,
+  jdHash: string,
+  num: number,
+): Promise<void> {
+  await withLock(root, 'allocation', () => {
+    if (readReservation(root, jdHash)?.num === num) {
       rmSync(reservationPath(root, jdHash), { force: true });
     }
   });
 }
 
-export function withTextOfferCreationLock<T>(root: string, operation: () => T): T {
+export function withTextOfferCreationLock<T>(
+  root: string,
+  operation: () => T | Promise<T>,
+): Promise<T> {
   return withLock(root, 'creation', operation);
 }

--- a/src/lib/server/text-offers.ts
+++ b/src/lib/server/text-offers.ts
@@ -8,6 +8,11 @@ import type { ApplicationRow } from '../schemas/applications';
 import { findByNum, loadApplications } from './applications';
 import { companySlug } from './format';
 import { saveReport } from './reports';
+import {
+  releaseTextOfferNumber,
+  reserveTextOfferNumber,
+  withTextOfferCreationLock,
+} from './text-offer-reservations';
 
 const MAX_TEXT_LENGTH = 32_000;
 
@@ -15,6 +20,7 @@ export interface CreateTextOfferInput {
   text: string;
   company?: string;
   role?: string;
+  reservedNum?: number;
 }
 
 export interface TextOfferResult {
@@ -94,6 +100,15 @@ export function previewTextOffer(rootPath: string, text: string): TextOfferPrevi
   };
 }
 
+export function reserveTextOfferPreview(rootPath: string, text: string): TextOfferPreview {
+  const preview = previewTextOffer(rootPath, text);
+  if (preview.reused) return preview;
+  return {
+    ...preview,
+    anticipatedNum: reserveTextOfferNumber(rootPath, preview.jdHash, preview.anticipatedNum),
+  };
+}
+
 function mergeTracker(rootPath: string): void {
   const additionsDir = join(rootPath, 'batch/tracker-additions');
   const appsFile = join(rootPath, 'data/applications.md');
@@ -113,80 +128,89 @@ export function createOrReuseTextOffer(
   input: CreateTextOfferInput,
 ): TextOfferResult {
   const text = normalizeJobDescription(input.text);
-  const preview = previewTextOffer(rootPath, text);
-  const { jdHash } = preview;
-  const existing = preview.offer;
-  if (existing) {
-    return {
-      reused: true,
-      offer: existing,
-      jdHash,
-      jdPath: `inputs/jds/${jdHash}.md`,
-    };
-  }
+  return withTextOfferCreationLock(rootPath, () => {
+    const preview = previewTextOffer(rootPath, text);
+    const { jdHash } = preview;
+    const existing = preview.offer;
+    if (existing) {
+      if (input.reservedNum) releaseTextOfferNumber(rootPath, jdHash, input.reservedNum);
+      return {
+        reused: true,
+        offer: existing,
+        jdHash,
+        jdPath: `inputs/jds/${jdHash}.md`,
+      };
+    }
 
-  const company = input.company?.trim() || 'Unknown';
-  const role = input.role?.trim() || 'Unknown role';
-  const num = nextOfferNum(rootPath);
-  const today = new Date().toISOString().slice(0, 10);
-  const slug = companySlug(company) || 'unknown';
-  const jdPath = `inputs/jds/${jdHash}.md`;
-  const reportPath = `artifacts/reports/${String(num).padStart(3, '0')}-${slug}-${today}.md`;
+    const reservedNum = reserveTextOfferNumber(rootPath, jdHash, preview.anticipatedNum);
+    if (input.reservedNum && input.reservedNum !== reservedNum) {
+      throw new Error(`reserved offer number changed from ${input.reservedNum} to ${reservedNum}`);
+    }
+    const company = input.company?.trim() || 'Unknown';
+    const role = input.role?.trim() || 'Unknown role';
+    const num = reservedNum;
+    const today = new Date().toISOString().slice(0, 10);
+    const slug = companySlug(company) || 'unknown';
+    const jdPath = `inputs/jds/${jdHash}.md`;
+    const reportPath = `artifacts/reports/${String(num).padStart(3, '0')}-${slug}-${today}.md`;
 
-  mkdirSync(join(rootPath, 'inputs/jds'), { recursive: true });
-  mkdirSync(join(rootPath, 'artifacts/reports'), { recursive: true });
-  mkdirSync(join(rootPath, 'batch/tracker-additions'), { recursive: true });
-  writeFileSync(join(rootPath, jdPath), `${text}\n`, 'utf-8');
-  saveReport({
-    filePath: join(rootPath, reportPath),
-    frontmatter: {
+    mkdirSync(join(rootPath, 'inputs/jds'), { recursive: true });
+    mkdirSync(join(rootPath, 'artifacts/reports'), { recursive: true });
+    mkdirSync(join(rootPath, 'batch/tracker-additions'), { recursive: true });
+    writeFileSync(join(rootPath, jdPath), `${text}\n`, 'utf-8');
+    saveReport({
+      filePath: join(rootPath, reportPath),
+      frontmatter: {
+        num,
+        company,
+        role,
+        date: today,
+        status: 'Screened',
+        state: 'screened',
+        score: 'N/A',
+        source_kind: 'text',
+        jd_path: jdPath,
+        jd_hash: jdHash,
+        tldr: 'Created from a pasted job description. Run screening or another offer mode when ready.',
+      },
+      body: [
+        '<div data-callout data-variant="info" data-emoji="💡">',
+        '',
+        '**Next Steps** Run screening, a full evaluation, or generate a tailored application document.',
+        '',
+        '</div>',
+        '',
+        '## TL;DR',
+        '',
+        'Created from a pasted job description. No screening score has been assigned yet.',
+        '',
+      ].join('\n'),
+    });
+
+    const clean = (value: string) => value.replace(/[|\t\r\n]+/g, ' ').trim();
+    const tsv = [
       num,
-      company,
-      role,
-      date: today,
-      status: 'Screened',
-      state: 'screened',
-      score: 'N/A',
-      source_kind: 'text',
-      jd_path: jdPath,
-      jd_hash: jdHash,
-      tldr: 'Created from a pasted job description. Run screening or another offer mode when ready.',
-    },
-    body: [
-      '<div data-callout data-variant="info" data-emoji="💡">',
+      today,
+      clean(company),
+      clean(role),
+      'N/A',
+      'Screened',
+      '❌',
+      `[${num}](${reportPath})`,
+      'Created from pasted job description',
       '',
-      '**Next Steps** Run screening, a full evaluation, or generate a tailored application document.',
-      '',
-      '</div>',
-      '',
-      '## TL;DR',
-      '',
-      'Created from a pasted job description. No screening score has been assigned yet.',
-      '',
-    ].join('\n'),
+    ].join('\t');
+    writeFileSync(
+      join(rootPath, `batch/tracker-additions/${String(num).padStart(3, '0')}-${slug}.tsv`),
+      `${tsv}\n`,
+      'utf-8',
+    );
+
+    mergeTracker(rootPath);
+    const offer = findByNum(rootPath, num);
+    if (!offer)
+      throw new Error(`text offer #${num} was created but did not merge into the tracker`);
+    releaseTextOfferNumber(rootPath, jdHash, num);
+    return { reused: false, offer, jdHash, jdPath };
   });
-
-  const clean = (value: string) => value.replace(/[|\t\r\n]+/g, ' ').trim();
-  const tsv = [
-    num,
-    today,
-    clean(company),
-    clean(role),
-    'N/A',
-    'Screened',
-    '❌',
-    `[${num}](${reportPath})`,
-    'Created from pasted job description',
-    '',
-  ].join('\t');
-  writeFileSync(
-    join(rootPath, `batch/tracker-additions/${String(num).padStart(3, '0')}-${slug}.tsv`),
-    `${tsv}\n`,
-    'utf-8',
-  );
-
-  mergeTracker(rootPath);
-  const offer = findByNum(rootPath, num);
-  if (!offer) throw new Error(`text offer #${num} was created but did not merge into the tracker`);
-  return { reused: false, offer, jdHash, jdPath };
 }

--- a/src/lib/server/text-offers.ts
+++ b/src/lib/server/text-offers.ts
@@ -27,6 +27,7 @@ export interface TextOfferResult {
 export interface TextOfferPreview {
   reused: boolean;
   offer: ApplicationRow | null;
+  anticipatedNum: number;
   jdHash: string;
   jdPath: string;
 }
@@ -87,6 +88,7 @@ export function previewTextOffer(rootPath: string, text: string): TextOfferPrevi
   return {
     reused: offer !== null,
     offer,
+    anticipatedNum: offer?.num ?? nextOfferNum(rootPath),
     jdHash,
     jdPath: `inputs/jds/${jdHash}.md`,
   };

--- a/src/lib/server/text-offers.ts
+++ b/src/lib/server/text-offers.ts
@@ -100,12 +100,15 @@ export function previewTextOffer(rootPath: string, text: string): TextOfferPrevi
   };
 }
 
-export function reserveTextOfferPreview(rootPath: string, text: string): TextOfferPreview {
+export async function reserveTextOfferPreview(
+  rootPath: string,
+  text: string,
+): Promise<TextOfferPreview> {
   const preview = previewTextOffer(rootPath, text);
   if (preview.reused) return preview;
   return {
     ...preview,
-    anticipatedNum: reserveTextOfferNumber(rootPath, preview.jdHash, preview.anticipatedNum),
+    anticipatedNum: await reserveTextOfferNumber(rootPath, preview.jdHash, preview.anticipatedNum),
   };
 }
 
@@ -123,17 +126,19 @@ function mergeTracker(rootPath: string): void {
   });
 }
 
-export function createOrReuseTextOffer(
+export async function createOrReuseTextOffer(
   rootPath: string,
   input: CreateTextOfferInput,
-): TextOfferResult {
+): Promise<TextOfferResult> {
   const text = normalizeJobDescription(input.text);
-  return withTextOfferCreationLock(rootPath, () => {
+  return withTextOfferCreationLock(rootPath, async () => {
     const preview = previewTextOffer(rootPath, text);
     const { jdHash } = preview;
     const existing = preview.offer;
     if (existing) {
-      if (input.reservedNum) releaseTextOfferNumber(rootPath, jdHash, input.reservedNum);
+      if (input.reservedNum) {
+        await releaseTextOfferNumber(rootPath, jdHash, input.reservedNum);
+      }
       return {
         reused: true,
         offer: existing,
@@ -142,75 +147,78 @@ export function createOrReuseTextOffer(
       };
     }
 
-    const reservedNum = reserveTextOfferNumber(rootPath, jdHash, preview.anticipatedNum);
+    const reservedNum = await reserveTextOfferNumber(rootPath, jdHash, preview.anticipatedNum);
     if (input.reservedNum && input.reservedNum !== reservedNum) {
       throw new Error(`reserved offer number changed from ${input.reservedNum} to ${reservedNum}`);
     }
-    const company = input.company?.trim() || 'Unknown';
-    const role = input.role?.trim() || 'Unknown role';
-    const num = reservedNum;
-    const today = new Date().toISOString().slice(0, 10);
-    const slug = companySlug(company) || 'unknown';
-    const jdPath = `inputs/jds/${jdHash}.md`;
-    const reportPath = `artifacts/reports/${String(num).padStart(3, '0')}-${slug}-${today}.md`;
+    try {
+      const company = input.company?.trim() || 'Unknown';
+      const role = input.role?.trim() || 'Unknown role';
+      const num = reservedNum;
+      const today = new Date().toISOString().slice(0, 10);
+      const slug = companySlug(company) || 'unknown';
+      const jdPath = `inputs/jds/${jdHash}.md`;
+      const reportPath = `artifacts/reports/${String(num).padStart(3, '0')}-${slug}-${today}.md`;
 
-    mkdirSync(join(rootPath, 'inputs/jds'), { recursive: true });
-    mkdirSync(join(rootPath, 'artifacts/reports'), { recursive: true });
-    mkdirSync(join(rootPath, 'batch/tracker-additions'), { recursive: true });
-    writeFileSync(join(rootPath, jdPath), `${text}\n`, 'utf-8');
-    saveReport({
-      filePath: join(rootPath, reportPath),
-      frontmatter: {
+      mkdirSync(join(rootPath, 'inputs/jds'), { recursive: true });
+      mkdirSync(join(rootPath, 'artifacts/reports'), { recursive: true });
+      mkdirSync(join(rootPath, 'batch/tracker-additions'), { recursive: true });
+      writeFileSync(join(rootPath, jdPath), `${text}\n`, 'utf-8');
+      saveReport({
+        filePath: join(rootPath, reportPath),
+        frontmatter: {
+          num,
+          company,
+          role,
+          date: today,
+          status: 'Screened',
+          state: 'screened',
+          score: 'N/A',
+          source_kind: 'text',
+          jd_path: jdPath,
+          jd_hash: jdHash,
+          tldr: 'Created from a pasted job description. Run screening or another offer mode when ready.',
+        },
+        body: [
+          '<div data-callout data-variant="info" data-emoji="💡">',
+          '',
+          '**Next Steps** Run screening, a full evaluation, or generate a tailored application document.',
+          '',
+          '</div>',
+          '',
+          '## TL;DR',
+          '',
+          'Created from a pasted job description. No screening score has been assigned yet.',
+          '',
+        ].join('\n'),
+      });
+
+      const clean = (value: string) => value.replace(/[|\t\r\n]+/g, ' ').trim();
+      const tsv = [
         num,
-        company,
-        role,
-        date: today,
-        status: 'Screened',
-        state: 'screened',
-        score: 'N/A',
-        source_kind: 'text',
-        jd_path: jdPath,
-        jd_hash: jdHash,
-        tldr: 'Created from a pasted job description. Run screening or another offer mode when ready.',
-      },
-      body: [
-        '<div data-callout data-variant="info" data-emoji="💡">',
+        today,
+        clean(company),
+        clean(role),
+        'N/A',
+        'Screened',
+        '❌',
+        `[${num}](${reportPath})`,
+        'Created from pasted job description',
         '',
-        '**Next Steps** Run screening, a full evaluation, or generate a tailored application document.',
-        '',
-        '</div>',
-        '',
-        '## TL;DR',
-        '',
-        'Created from a pasted job description. No screening score has been assigned yet.',
-        '',
-      ].join('\n'),
-    });
+      ].join('\t');
+      writeFileSync(
+        join(rootPath, `batch/tracker-additions/${String(num).padStart(3, '0')}-${slug}.tsv`),
+        `${tsv}\n`,
+        'utf-8',
+      );
 
-    const clean = (value: string) => value.replace(/[|\t\r\n]+/g, ' ').trim();
-    const tsv = [
-      num,
-      today,
-      clean(company),
-      clean(role),
-      'N/A',
-      'Screened',
-      '❌',
-      `[${num}](${reportPath})`,
-      'Created from pasted job description',
-      '',
-    ].join('\t');
-    writeFileSync(
-      join(rootPath, `batch/tracker-additions/${String(num).padStart(3, '0')}-${slug}.tsv`),
-      `${tsv}\n`,
-      'utf-8',
-    );
-
-    mergeTracker(rootPath);
-    const offer = findByNum(rootPath, num);
-    if (!offer)
-      throw new Error(`text offer #${num} was created but did not merge into the tracker`);
-    releaseTextOfferNumber(rootPath, jdHash, num);
-    return { reused: false, offer, jdHash, jdPath };
+      mergeTracker(rootPath);
+      const offer = findByNum(rootPath, num);
+      if (!offer)
+        throw new Error(`text offer #${num} was created but did not merge into the tracker`);
+      return { reused: false, offer, jdHash, jdPath };
+    } finally {
+      await releaseTextOfferNumber(rootPath, jdHash, reservedNum);
+    }
   });
 }

--- a/src/lib/server/workflows.ts
+++ b/src/lib/server/workflows.ts
@@ -1,0 +1,2 @@
+export * from './workflows/api';
+export * from './workflows/planner';

--- a/src/lib/server/workflows/__tests__/api.test.ts
+++ b/src/lib/server/workflows/__tests__/api.test.ts
@@ -9,7 +9,9 @@ import {
   cancelWorkflow,
   createWorkflow,
   getWorkflow,
+  planWorkflowForTargets,
   type WorkflowRuntimeDeps,
+  workflowChildJobs,
 } from '../api';
 import { planWorkflow } from '../planner';
 
@@ -133,6 +135,24 @@ describe('workflow persistence and execution', () => {
     expect(h.starts.map(job => job.type)).toEqual(['screen', 'evaluate']);
     expect(h.starts[1]?.params).toMatchObject({ num: 44 });
     expect(advanced.targets[0]).toMatchObject({ url: 'https://example.com/jobs/1', num: 44 });
+    expect(getWorkflow(repo, workflow.id)?.targets[0]).toMatchObject({
+      url: 'https://example.com/jobs/1',
+      num: 44,
+    });
+  });
+
+  it('uses one canonical evaluation rule for confirmation and execution plans', () => {
+    const repo = root();
+    const h = harness();
+    h.deps.isEvaluated = num => num === 12;
+
+    const plan = planWorkflowForTargets(
+      repo,
+      { targets: [{ num: 12 }], modes: ['cover-letter'] },
+      h.deps,
+    );
+
+    expect(plan.steps.map(step => step.mode)).toEqual(['cover-letter']);
   });
 
   it('limits selected-offer bulk work to four active children', () => {
@@ -405,8 +425,9 @@ describe('workflow persistence and execution', () => {
 
     const cancelled = cancelWorkflow(repo, workflow.id, h.deps);
 
-    expect(cancelled.status).toBe('cancelled');
-    expect(cancelled.steps.every(step => step.status === 'cancelled')).toBe(true);
+    expect(cancelled.cancelled).toBe(true);
+    expect(cancelled.workflow.status).toBe('cancelled');
+    expect(cancelled.workflow.steps.every(step => step.status === 'cancelled')).toBe(true);
     expect(h.cancellations).toEqual([h.starts[0]?.id]);
     expect(getWorkflow(repo, workflow.id)?.status).toBe('cancelled');
   });
@@ -426,7 +447,23 @@ describe('workflow persistence and execution', () => {
     const unchanged = cancelWorkflow(repo, workflow.id, h.deps);
 
     expect(finished.status).toBe('done');
-    expect(unchanged.status).toBe('done');
+    expect(unchanged).toMatchObject({ cancelled: false, workflow: { status: 'done' } });
     expect(h.cancellations).toEqual([]);
+  });
+
+  it('rejects invalid workflow ids before filesystem access', () => {
+    const repo = root();
+    expect(getWorkflow(repo, '../../../../etc/passwd')).toBeNull();
+    expect(() => cancelWorkflow(repo, '../../../../etc/passwd')).toThrow(
+      'workflow not found: ../../../../etc/passwd',
+    );
+  });
+
+  it('materializes only persisted child jobs for a workflow response', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
+
+    expect(workflowChildJobs(repo, workflow, h.deps)).toEqual([h.starts[0]]);
   });
 });

--- a/src/lib/server/workflows/__tests__/api.test.ts
+++ b/src/lib/server/workflows/__tests__/api.test.ts
@@ -1,0 +1,432 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { JobRecord } from '../../../schemas/jobs';
+import {
+  advanceWorkflow,
+  assertWorkflowStartable,
+  cancelWorkflow,
+  createWorkflow,
+  getWorkflow,
+  type WorkflowRuntimeDeps,
+} from '../api';
+import { planWorkflow } from '../planner';
+
+const roots: string[] = [];
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), 'sur9e-workflow-'));
+  roots.push(value);
+  return value;
+}
+
+afterEach(() => {
+  for (const value of roots.splice(0)) rmSync(value, { recursive: true, force: true });
+});
+
+function harness() {
+  const jobs = new Map<string, JobRecord>();
+  let nextId = 0;
+  const starts: JobRecord[] = [];
+  const cancellations: string[] = [];
+  const deps: WorkflowRuntimeDeps = {
+    offerExists: () => true,
+    isEvaluated: () => false,
+    startJob: (kind, params) => {
+      const job = {
+        id: String(++nextId).padStart(16, '0'),
+        type: kind,
+        status: 'queued',
+        params,
+        startedAt: new Date().toISOString(),
+        finishedAt: null,
+        output: '',
+        error: null,
+        exitCode: null,
+      } as JobRecord;
+      jobs.set(job.id, job);
+      starts.push(job);
+      return job;
+    },
+    getJob: id => jobs.get(id) ?? null,
+    cancelJob: id => {
+      cancellations.push(id);
+      const job = jobs.get(id);
+      if (job) jobs.set(id, { ...job, status: 'cancelled', finishedAt: new Date().toISOString() });
+    },
+  };
+  return { jobs, starts, cancellations, deps };
+}
+
+describe('workflow persistence and execution', () => {
+  it('rejects an incompatible singleton before confirmation but permits exact reuse', () => {
+    const repo = root();
+    const plan = planWorkflow({
+      targets: [{ url: 'https://example.com/jobs/1' }],
+      modes: ['screen'],
+      evaluatedOfferNums: new Set(),
+    });
+    const active = {
+      id: 'existing-job-001',
+      type: 'screen',
+      status: 'running',
+      params: { url: 'https://example.com/jobs/1' },
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    } as JobRecord;
+    const inspect = () => ({
+      conflict: true as const,
+      message: 'a screen is already running',
+      job: active,
+    });
+
+    expect(() => assertWorkflowStartable(repo, plan, inspect)).not.toThrow();
+    expect(() =>
+      assertWorkflowStartable(repo, plan, () => ({
+        ...inspect(),
+        job: {
+          ...active,
+          params: { url: 'https://example.com/jobs/other' },
+        },
+      })),
+    ).toThrow('a screen is already running');
+  });
+
+  it('persists and starts only the first step of a sequential workflow', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      { targets: [{ num: 12 }], modes: ['screen-evaluate'] },
+      h.deps,
+    );
+
+    expect(h.starts.map(job => job.type)).toEqual(['screen']);
+    expect(workflow.steps.map(step => step.status)).toEqual(['running', 'blocked']);
+    expect(
+      JSON.parse(readFileSync(join(repo, 'data/workflows', `${workflow.id}.json`), 'utf-8')),
+    ).toMatchObject({ id: workflow.id, status: 'running' });
+  });
+
+  it('starts the dependent evaluation after screening resolves', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      { targets: [{ url: 'https://example.com/jobs/1' }], modes: ['screen-evaluate'] },
+      h.deps,
+    );
+    const screen = h.starts[0] as JobRecord;
+    h.jobs.set(screen.id, {
+      ...screen,
+      status: 'done',
+      params: { ...screen.params, num: 44 },
+      finishedAt: new Date().toISOString(),
+    });
+
+    const advanced = advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(h.starts.map(job => job.type)).toEqual(['screen', 'evaluate']);
+    expect(h.starts[1]?.params).toMatchObject({ num: 44 });
+    expect(advanced.targets[0]).toMatchObject({ url: 'https://example.com/jobs/1', num: 44 });
+  });
+
+  it('limits selected-offer bulk work to four active children', () => {
+    const repo = root();
+    const h = harness();
+    createWorkflow(
+      repo,
+      {
+        targets: [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4 }, { num: 5 }],
+        modes: ['evaluate'],
+      },
+      h.deps,
+    );
+
+    expect(h.starts).toHaveLength(4);
+  });
+
+  it('serializes singleton screening across URL targets without coupling their failure branches', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      {
+        targets: [{ url: 'https://example.com/jobs/1' }, { url: 'https://example.com/jobs/2' }],
+        modes: ['screen-evaluate'],
+      },
+      h.deps,
+    );
+
+    expect(h.starts.map(job => job.type)).toEqual(['screen']);
+    const first = h.starts[0] as JobRecord;
+    h.jobs.set(first.id, {
+      ...first,
+      status: 'error',
+      error: 'unreachable',
+      finishedAt: new Date().toISOString(),
+    });
+
+    const advanced = advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(h.starts.map(job => job.type)).toEqual(['screen', 'screen']);
+    expect(
+      advanced.steps.find(step => step.targetIndex === 0 && step.mode === 'evaluate')?.status,
+    ).toBe('skipped');
+    expect(
+      advanced.steps.find(step => step.targetIndex === 1 && step.mode === 'screen')?.status,
+    ).toBe('running');
+  });
+
+  it('starts the next independent child when a concurrency slot becomes available', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      {
+        targets: [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4 }, { num: 5 }],
+        modes: ['evaluate'],
+      },
+      h.deps,
+    );
+    const first = h.starts[0] as JobRecord;
+    h.jobs.set(first.id, {
+      ...first,
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+
+    advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(h.starts).toHaveLength(5);
+  });
+
+  it('reattaches an identical active job instead of starting a duplicate', () => {
+    const repo = root();
+    const h = harness();
+    const active = {
+      id: 'existing-job-001',
+      type: 'evaluate',
+      status: 'running',
+      params: { num: 12 },
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    } as JobRecord;
+    h.jobs.set(active.id, active);
+    h.deps.startJob = () => ({
+      conflict: true,
+      message: 'already running',
+      job: active,
+    });
+
+    const workflow = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
+
+    expect(workflow.status).toBe('running');
+    expect(workflow.steps[0]).toMatchObject({ status: 'running', jobId: active.id });
+    expect(
+      JSON.parse(readFileSync(join(repo, 'data/jobs', `${active.id}.json`), 'utf-8')),
+    ).toMatchObject({
+      workflowId: workflow.id,
+      workflowStepId: workflow.steps[0]?.id,
+      params: {
+        workflow_id: workflow.id,
+        workflow_step_id: workflow.steps[0]?.id,
+      },
+    });
+  });
+
+  it('marks an incompatible active-job conflict as an error', () => {
+    const repo = root();
+    const h = harness();
+    const active = {
+      id: 'existing-job-001',
+      type: 'screen',
+      status: 'running',
+      params: { url: 'https://example.com/other' },
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      output: '',
+      error: null,
+      exitCode: null,
+    } as JobRecord;
+    h.deps.startJob = () => ({
+      conflict: true,
+      message: 'a screen is already running',
+      job: active,
+    });
+
+    const workflow = createWorkflow(
+      repo,
+      { targets: [{ url: 'https://example.com/jobs/1' }], modes: ['screen'] },
+      h.deps,
+    );
+
+    expect(workflow.status).toBe('error');
+    expect(workflow.steps[0]).toMatchObject({
+      status: 'error',
+      error: 'a screen is already running',
+    });
+  });
+
+  it('isolates a failed branch and continues another offer', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      {
+        targets: [{ num: 1 }, { num: 2 }],
+        modes: ['evaluate', 'cover-letter'],
+      },
+      h.deps,
+    );
+    const [first, second] = h.starts;
+    h.jobs.set(first?.id as string, {
+      ...(first as JobRecord),
+      status: 'error',
+      error: 'failed',
+      finishedAt: new Date().toISOString(),
+    });
+    h.jobs.set(second?.id as string, {
+      ...(second as JobRecord),
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+
+    const advanced = advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(
+      advanced.steps.find(step => step.targetIndex === 0 && step.mode === 'cover-letter')?.status,
+    ).toBe('skipped');
+    expect(
+      advanced.steps.find(step => step.targetIndex === 1 && step.mode === 'cover-letter')?.status,
+    ).toBe('running');
+  });
+
+  it('finishes partial after one offer branch fails and another completes', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      {
+        targets: [{ num: 1 }, { num: 2 }],
+        modes: ['evaluate', 'cover-letter'],
+      },
+      h.deps,
+    );
+    const [first, second] = h.starts as [JobRecord, JobRecord];
+    h.jobs.set(first.id, {
+      ...first,
+      status: 'error',
+      error: 'failed',
+      finishedAt: new Date().toISOString(),
+    });
+    h.jobs.set(second.id, {
+      ...second,
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+    const withArtifact = advanceWorkflow(repo, workflow.id, h.deps);
+    const artifact = h.starts.find(job => job.type === 'cover-letter') as JobRecord;
+    h.jobs.set(artifact.id, {
+      ...artifact,
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+
+    const finished = advanceWorkflow(repo, withArtifact.id, h.deps);
+
+    expect(finished.status).toBe('partial');
+    expect(finished.finishedAt).not.toBeNull();
+  });
+
+  it('cancelling one child skips only its dependent branch', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      {
+        targets: [{ num: 1 }, { num: 2 }],
+        modes: ['evaluate', 'cover-letter'],
+      },
+      h.deps,
+    );
+    const [first, second] = h.starts as [JobRecord, JobRecord];
+    h.jobs.set(first.id, {
+      ...first,
+      status: 'cancelled',
+      finishedAt: new Date().toISOString(),
+    });
+    h.jobs.set(second.id, {
+      ...second,
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+
+    const advanced = advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(
+      advanced.steps.find(step => step.targetIndex === 0 && step.mode === 'cover-letter')?.status,
+    ).toBe('skipped');
+    expect(
+      advanced.steps.find(step => step.targetIndex === 1 && step.mode === 'cover-letter')?.status,
+    ).toBe('running');
+  });
+
+  it('marks a workflow child as error when restart reconciliation cannot find its job record', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
+    h.jobs.clear();
+
+    const reconciled = advanceWorkflow(repo, workflow.id, h.deps);
+
+    expect(reconciled.status).toBe('error');
+    expect(reconciled.steps[0]).toMatchObject({
+      status: 'error',
+      error: 'child job record is missing',
+    });
+  });
+
+  it('cancels active children and every unstarted step', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(
+      repo,
+      { targets: [{ num: 12 }], modes: ['evaluate', 'cover-letter'] },
+      h.deps,
+    );
+
+    const cancelled = cancelWorkflow(repo, workflow.id, h.deps);
+
+    expect(cancelled.status).toBe('cancelled');
+    expect(cancelled.steps.every(step => step.status === 'cancelled')).toBe(true);
+    expect(h.cancellations).toEqual([h.starts[0]?.id]);
+    expect(getWorkflow(repo, workflow.id)?.status).toBe('cancelled');
+  });
+
+  it('does not rewrite an already-finished workflow as cancelled', () => {
+    const repo = root();
+    const h = harness();
+    const workflow = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
+    const job = h.starts[0] as JobRecord;
+    h.jobs.set(job.id, {
+      ...job,
+      status: 'done',
+      finishedAt: new Date().toISOString(),
+    });
+    const finished = advanceWorkflow(repo, workflow.id, h.deps);
+
+    const unchanged = cancelWorkflow(repo, workflow.id, h.deps);
+
+    expect(finished.status).toBe('done');
+    expect(unchanged.status).toBe('done');
+    expect(h.cancellations).toEqual([]);
+  });
+});

--- a/src/lib/server/workflows/__tests__/api.test.ts
+++ b/src/lib/server/workflows/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { JobRecord } from '../../../schemas/jobs';
 import {
   advanceWorkflow,
@@ -10,6 +10,7 @@ import {
   createWorkflow,
   getWorkflow,
   planWorkflowForTargets,
+  reconcileWorkflows,
   type WorkflowRuntimeDeps,
   workflowChildJobs,
 } from '../api';
@@ -465,5 +466,30 @@ describe('workflow persistence and execution', () => {
     const workflow = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
 
     expect(workflowChildJobs(repo, workflow, h.deps)).toEqual([h.starts[0]]);
+  });
+
+  it('continues boot reconciliation after one workflow fails', () => {
+    const repo = root();
+    const h = harness();
+    const first = createWorkflow(repo, { targets: [{ num: 12 }], modes: ['evaluate'] }, h.deps);
+    const second = createWorkflow(repo, { targets: [{ num: 13 }], modes: ['evaluate'] }, h.deps);
+    const firstJobId = first.steps[0]?.jobId;
+    const getJob = h.deps.getJob;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const reconciled = reconcileWorkflows(repo, {
+      ...h.deps,
+      getJob: id => {
+        if (id === firstJobId) throw new Error('damaged workflow');
+        return getJob(id);
+      },
+    });
+
+    expect(reconciled.map(workflow => workflow.id)).toContain(second.id);
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Failed to reconcile workflow ${first.id}:`,
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/src/lib/server/workflows/__tests__/planner.test.ts
+++ b/src/lib/server/workflows/__tests__/planner.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { planWorkflow } from '../planner';
+
+describe('workflow planner', () => {
+  it('expands screen-evaluate into two dependent jobs', () => {
+    const plan = planWorkflow({
+      targets: [{ num: 12 }],
+      modes: ['screen-evaluate'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps.map(step => step.mode)).toEqual(['screen', 'evaluate']);
+    expect(plan.steps[1]?.dependsOn).toEqual([plan.steps[0]?.id]);
+  });
+
+  it('inserts evaluation and serializes report writers before parallel artifacts', () => {
+    const plan = planWorkflow({
+      targets: [{ num: 12 }],
+      modes: ['cover-letter', 'research', 'tailor-cv', 'reach-out'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps.map(step => step.mode)).toEqual([
+      'evaluate',
+      'research',
+      'reach-out',
+      'cover-letter',
+      'tailor-cv',
+    ]);
+    const [evaluate, research, outreach, coverLetter, tailorCv] = plan.steps;
+    expect(research?.dependsOn).toEqual([evaluate?.id]);
+    expect(outreach?.dependsOn).toEqual([research?.id]);
+    expect(coverLetter?.dependsOn).toEqual([outreach?.id]);
+    expect(tailorCv?.dependsOn).toEqual([outreach?.id]);
+  });
+
+  it('does not regenerate evaluation when a valid one already exists', () => {
+    const plan = planWorkflow({
+      targets: [{ num: 12 }],
+      modes: ['cover-letter', 'tailor-cv'],
+      evaluatedOfferNums: new Set([12]),
+    });
+
+    expect(plan.steps.map(step => step.mode)).toEqual(['cover-letter', 'tailor-cv']);
+    expect(plan.steps.every(step => step.dependsOn.length === 0)).toBe(true);
+  });
+
+  it('plans independent offer branches for selected bulk actions', () => {
+    const plan = planWorkflow({
+      targets: [{ num: 12 }, { num: 13 }],
+      modes: ['evaluate', 'cover-letter'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps.map(step => [step.targetIndex, step.mode])).toEqual([
+      [0, 'evaluate'],
+      [0, 'cover-letter'],
+      [1, 'evaluate'],
+      [1, 'cover-letter'],
+    ]);
+    expect(plan.maxParallel).toBe(4);
+  });
+
+  it('inserts screening before offer modes for URL targets', () => {
+    const plan = planWorkflow({
+      targets: [{ url: 'https://example.com/jobs/1' }],
+      modes: ['tailor-cv'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps.map(step => step.mode)).toEqual(['screen', 'evaluate', 'tailor-cv']);
+    expect(plan.steps[1]?.dependsOn).toEqual([plan.steps[0]?.id]);
+  });
+
+  it('maps process-queue to a queue screen system step', () => {
+    const plan = planWorkflow({
+      targets: [],
+      modes: ['process-queue'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps).toMatchObject([{ mode: 'screen', params: { queue: true } }]);
+  });
+
+  it('canonicalizes aliases and removes duplicate requested modes', () => {
+    const plan = planWorkflow({
+      targets: [{ num: 12 }],
+      modes: ['pdf', 'tailor-cv', 'contact', 'outreach'],
+      evaluatedOfferNums: new Set([12]),
+    });
+
+    expect(plan.requestedModes).toEqual(['tailor-cv', 'reach-out']);
+    expect(plan.steps.map(step => step.mode)).toEqual(['reach-out', 'tailor-cv']);
+  });
+
+  it.each(['scan', 'batch-evaluate'] as const)('plans %s as a singleton system workflow', mode => {
+    const plan = planWorkflow({
+      targets: [],
+      modes: [mode],
+      evaluatedOfferNums: new Set(),
+    });
+
+    expect(plan.steps).toEqual([
+      expect.objectContaining({ targetIndex: null, mode, dependsOn: [] }),
+    ]);
+  });
+
+  it('rejects mixed system and offer modes', () => {
+    expect(() =>
+      planWorkflow({
+        targets: [{ num: 12 }],
+        modes: ['scan', 'evaluate'],
+        evaluatedOfferNums: new Set(),
+      }),
+    ).toThrow('system modes cannot be mixed');
+  });
+
+  it('rejects inline and handoff modes as background workflows', () => {
+    expect(() =>
+      planWorkflow({
+        targets: [{ num: 12 }],
+        modes: ['tracker'],
+        evaluatedOfferNums: new Set(),
+      }),
+    ).toThrow('tracker runs inline');
+    expect(() =>
+      planWorkflow({
+        targets: [{ num: 12 }],
+        modes: ['apply'],
+        evaluatedOfferNums: new Set(),
+      }),
+    ).toThrow('apply requires a handoff');
+  });
+});

--- a/src/lib/server/workflows/api.ts
+++ b/src/lib/server/workflows/api.ts
@@ -1,0 +1,375 @@
+import 'server-only';
+import { randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { JobRecord, JobType } from '../../schemas/jobs';
+import {
+  WorkflowRecord,
+  type WorkflowRecord as WorkflowRecordType,
+  type WorkflowStep,
+} from '../../schemas/workflows';
+import { findByNum, normalizeStatus } from '../applications';
+import { atomicWrite } from '../atomic-write';
+import { getJob as getPersistedJob } from '../jobs/api';
+import { cancelJob as cancelPersistedJob, persistJobRecord } from '../jobs/lifecycle';
+import {
+  findJobConflict,
+  type JobConflictPayload,
+  startJob as startPersistedJob,
+} from '../jobs/start';
+import { planWorkflow, type WorkflowPlan, type WorkflowTarget } from './planner';
+
+type StartedJob =
+  | JobRecord
+  | { conflict: true; message: string; job?: JobRecord; setupRequired?: boolean };
+
+const WORKFLOW_SINGLETON_MODES = new Set(['screen', 'scan', 'batch-evaluate']);
+
+export interface WorkflowRuntimeDeps {
+  offerExists: (num: number) => boolean;
+  isEvaluated: (num: number) => boolean;
+  startJob: (kind: string, params: Record<string, unknown>) => StartedJob;
+  getJob: (id: string) => JobRecord | null;
+  cancelJob: (id: string) => void;
+}
+
+export interface CreateWorkflowInput {
+  targets: WorkflowTarget[];
+  modes: string[];
+  guidance?: string;
+}
+
+function workflowsDir(root: string): string {
+  return join(root, 'data', 'workflows');
+}
+
+function workflowPath(root: string, id: string): string {
+  return join(workflowsDir(root), `${id}.json`);
+}
+
+function persist(root: string, workflow: WorkflowRecordType): void {
+  mkdirSync(workflowsDir(root), { recursive: true });
+  atomicWrite(workflowPath(root, workflow.id), JSON.stringify(workflow, null, 2));
+}
+
+function defaultDeps(root: string): WorkflowRuntimeDeps {
+  return {
+    offerExists: num => Boolean(findByNum(root, num)),
+    isEvaluated: num => {
+      const row = findByNum(root, num);
+      if (!row?.reportPath) return false;
+      return !['screened', 'discarded'].includes(normalizeStatus(row.status));
+    },
+    startJob: (kind, params) =>
+      startPersistedJob(root, { kind: kind as JobType, params }) as StartedJob,
+    getJob: id => getPersistedJob(root, id),
+    cancelJob: id => {
+      cancelPersistedJob(root, id);
+    },
+  };
+}
+
+export function getWorkflow(root: string, id: string): WorkflowRecordType | null {
+  const path = workflowPath(root, id);
+  if (!existsSync(path)) return null;
+  try {
+    return WorkflowRecord.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  } catch {
+    return null;
+  }
+}
+
+export function listWorkflows(root: string): WorkflowRecordType[] {
+  const dir = workflowsDir(root);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(name => name.endsWith('.json'))
+    .flatMap(name => {
+      try {
+        return [
+          WorkflowRecord.parse(JSON.parse(readFileSync(join(dir, name), 'utf-8'))),
+        ] as WorkflowRecordType[];
+      } catch {
+        return [];
+      }
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+function resolveStepParams(
+  workflow: WorkflowRecordType,
+  step: WorkflowStep,
+): Record<string, unknown> {
+  const target = step.targetIndex === null ? null : workflow.targets[step.targetIndex];
+  const params = { ...step.params };
+  if (target && 'num' in target && Number.isInteger(target.num) && step.mode !== 'screen') {
+    params.num = target.num;
+    delete params.url;
+  } else if (target && 'num' in target && Number.isInteger(target.num) && !('url' in target)) {
+    params.num = target.num;
+  }
+  if (workflow.guidance) params.guidance = workflow.guidance;
+  params.workflow_id = workflow.id;
+  params.workflow_step_id = step.id;
+  return params;
+}
+
+function hasBadDependency(step: WorkflowStep, byId: Map<string, WorkflowStep>): boolean {
+  return step.dependsOn.some(id => {
+    const dependency = byId.get(id);
+    return (
+      !dependency ||
+      dependency.status === 'error' ||
+      dependency.status === 'cancelled' ||
+      dependency.status === 'skipped'
+    );
+  });
+}
+
+function allDependenciesDone(step: WorkflowStep, byId: Map<string, WorkflowStep>): boolean {
+  return step.dependsOn.every(id => byId.get(id)?.status === 'done');
+}
+
+function deriveStatus(workflow: WorkflowRecordType): WorkflowRecordType['status'] {
+  if (workflow.status === 'cancelled') return 'cancelled';
+  const statuses = workflow.steps.map(step => step.status);
+  if (statuses.some(status => status === 'running')) return 'running';
+  if (statuses.some(status => status === 'queued' || status === 'blocked')) return 'queued';
+  const bad = statuses.some(status => ['error', 'cancelled', 'skipped'].includes(status));
+  const done = statuses.some(status => status === 'done');
+  if (bad && done) return 'partial';
+  if (bad) return 'error';
+  return 'done';
+}
+
+function sameActiveJob(step: Pick<WorkflowStep, 'mode' | 'params'>, job: JobRecord): boolean {
+  if (job.type !== step.mode) return false;
+  const expectedNum = step.params.num;
+  const expectedUrl = step.params.url;
+  const expectedQueue = step.params.queue;
+  return (
+    (expectedNum === undefined || job.params.num === expectedNum) &&
+    (expectedUrl === undefined || job.params.url === expectedUrl) &&
+    (expectedQueue === undefined || job.params.queue === expectedQueue)
+  );
+}
+
+/** Reject an incompatible already-running singleton before confirmation.
+ * Identical active jobs are intentionally allowed: approval attaches the
+ * workflow step to that existing record instead of spending twice. */
+export function assertWorkflowStartable(
+  root: string,
+  plan: WorkflowPlan,
+  inspect: (
+    rootPath: string,
+    kind: JobType,
+    params: Record<string, unknown>,
+  ) => JobConflictPayload | null = findJobConflict,
+): void {
+  const inspectedSingletons = new Set<string>();
+  for (const step of plan.steps) {
+    if (step.dependsOn.length > 0) continue;
+    if (WORKFLOW_SINGLETON_MODES.has(step.mode)) {
+      if (inspectedSingletons.has(step.mode)) continue;
+      inspectedSingletons.add(step.mode);
+    }
+    const conflict = inspect(root, step.mode as JobType, step.params);
+    if (conflict && !sameActiveJob(step, conflict.job)) {
+      throw new Error(conflict.message);
+    }
+  }
+}
+
+export function advanceWorkflow(
+  root: string,
+  id: string,
+  providedDeps?: WorkflowRuntimeDeps,
+): WorkflowRecordType {
+  const deps = providedDeps ?? defaultDeps(root);
+  const stored = getWorkflow(root, id);
+  if (!stored) throw new Error(`workflow not found: ${id}`);
+  if (['done', 'partial', 'error', 'cancelled'].includes(stored.status)) return stored;
+
+  const workflow: WorkflowRecordType = {
+    ...stored,
+    targets: stored.targets.map(target => ({ ...target })),
+    steps: stored.steps.map(step => ({
+      ...step,
+      dependsOn: [...step.dependsOn],
+      params: { ...step.params },
+    })),
+  };
+
+  for (const step of workflow.steps) {
+    if (step.status !== 'running' || !step.jobId) continue;
+    const job = deps.getJob(step.jobId);
+    if (!job) {
+      step.status = 'error';
+      step.error = 'child job record is missing';
+      continue;
+    }
+    if (job.status === 'queued' || job.status === 'running') continue;
+    step.status = job.status === 'done' ? 'done' : job.status;
+    step.error = job.error;
+    if (
+      step.mode === 'screen' &&
+      step.status === 'done' &&
+      step.targetIndex !== null &&
+      Number.isInteger(job.params.num)
+    ) {
+      const target = workflow.targets[step.targetIndex];
+      if (target && 'url' in target) {
+        workflow.targets[step.targetIndex] = { ...target, num: job.params.num as number };
+      }
+    }
+  }
+
+  const byId = new Map(workflow.steps.map(step => [step.id, step]));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const step of workflow.steps) {
+      if (step.status !== 'blocked' && step.status !== 'queued') continue;
+      if (hasBadDependency(step, byId)) {
+        step.status = 'skipped';
+        step.error = 'prerequisite did not complete';
+        changed = true;
+      } else if (step.status === 'blocked' && allDependenciesDone(step, byId)) {
+        step.status = 'queued';
+        changed = true;
+      }
+    }
+  }
+
+  let active = workflow.steps.filter(step => step.status === 'running').length;
+  const activeSingletons = new Set(
+    workflow.steps
+      .filter(step => step.status === 'running' && WORKFLOW_SINGLETON_MODES.has(step.mode))
+      .map(step => step.mode),
+  );
+  for (const step of workflow.steps) {
+    if (active >= workflow.maxParallel || step.status !== 'queued') continue;
+    if (WORKFLOW_SINGLETON_MODES.has(step.mode) && activeSingletons.has(step.mode)) continue;
+    const params = resolveStepParams(workflow, step);
+    const result = deps.startJob(step.mode, params);
+    if ('conflict' in result) {
+      if (result.job && sameActiveJob({ ...step, params }, result.job)) {
+        if (!result.job.workflowId) {
+          persistJobRecord(root, {
+            ...result.job,
+            workflowId: workflow.id,
+            workflowStepId: step.id,
+            params: {
+              ...result.job.params,
+              workflow_id: workflow.id,
+              workflow_step_id: step.id,
+            },
+          });
+        }
+        step.jobId = result.job.id;
+        step.status = 'running';
+        active += 1;
+        if (WORKFLOW_SINGLETON_MODES.has(step.mode)) activeSingletons.add(step.mode);
+      } else {
+        step.status = 'error';
+        step.error = result.message;
+      }
+      continue;
+    }
+    step.jobId = result.id;
+    step.status = 'running';
+    active += 1;
+    if (WORKFLOW_SINGLETON_MODES.has(step.mode)) activeSingletons.add(step.mode);
+  }
+
+  workflow.status = deriveStatus(workflow);
+  workflow.updatedAt = new Date().toISOString();
+  workflow.finishedAt = ['done', 'partial', 'error', 'cancelled'].includes(workflow.status)
+    ? workflow.updatedAt
+    : null;
+  persist(root, workflow);
+  return workflow;
+}
+
+export function createWorkflow(
+  root: string,
+  input: CreateWorkflowInput,
+  providedDeps?: WorkflowRuntimeDeps,
+): WorkflowRecordType {
+  const deps = providedDeps ?? defaultDeps(root);
+  for (const target of input.targets) {
+    if ('num' in target && !('url' in target) && !deps.offerExists(target.num)) {
+      throw new Error(`num not found: ${target.num}`);
+    }
+  }
+  const evaluatedOfferNums = new Set(
+    input.targets.flatMap(target =>
+      'num' in target && Number.isInteger(target.num) && deps.isEvaluated(target.num)
+        ? [target.num]
+        : [],
+    ),
+  );
+  const plan = planWorkflow({
+    targets: input.targets,
+    modes: input.modes,
+    evaluatedOfferNums,
+  });
+  const now = new Date().toISOString();
+  const workflow = WorkflowRecord.parse({
+    id: randomBytes(8).toString('hex'),
+    status: 'queued',
+    targets: plan.targets,
+    requestedModes: plan.requestedModes,
+    guidance: input.guidance,
+    maxParallel: plan.maxParallel,
+    steps: plan.steps.map(step => ({
+      ...step,
+      status: step.dependsOn.length > 0 ? 'blocked' : 'queued',
+      error: null,
+    })),
+    createdAt: now,
+    updatedAt: now,
+    finishedAt: null,
+  });
+  persist(root, workflow);
+  return advanceWorkflow(root, workflow.id, deps);
+}
+
+export function cancelWorkflow(
+  root: string,
+  id: string,
+  providedDeps?: WorkflowRuntimeDeps,
+): WorkflowRecordType {
+  const deps = providedDeps ?? defaultDeps(root);
+  const workflow = getWorkflow(root, id);
+  if (!workflow) throw new Error(`workflow not found: ${id}`);
+  if (['done', 'partial', 'error', 'cancelled'].includes(workflow.status)) return workflow;
+  for (const step of workflow.steps) {
+    if (step.status === 'running' && step.jobId) deps.cancelJob(step.jobId);
+    if (['running', 'queued', 'blocked'].includes(step.status)) {
+      step.status = 'cancelled';
+      step.error = null;
+    }
+  }
+  workflow.status = 'cancelled';
+  workflow.updatedAt = new Date().toISOString();
+  workflow.finishedAt = workflow.updatedAt;
+  persist(root, workflow);
+  return workflow;
+}
+
+export function advanceWorkflowsForJob(
+  root: string,
+  jobId: string,
+  deps?: WorkflowRuntimeDeps,
+): WorkflowRecordType[] {
+  return listWorkflows(root)
+    .filter(workflow => workflow.steps.some(step => step.jobId === jobId))
+    .map(workflow => advanceWorkflow(root, workflow.id, deps));
+}
+
+export function reconcileWorkflows(root: string, deps?: WorkflowRuntimeDeps): WorkflowRecordType[] {
+  return listWorkflows(root)
+    .filter(workflow => workflow.status === 'queued' || workflow.status === 'running')
+    .map(workflow => advanceWorkflow(root, workflow.id, deps));
+}

--- a/src/lib/server/workflows/api.ts
+++ b/src/lib/server/workflows/api.ts
@@ -39,11 +39,28 @@ export interface CreateWorkflowInput {
   guidance?: string;
 }
 
+export interface CancelWorkflowResult {
+  cancelled: boolean;
+  workflow: WorkflowRecordType;
+}
+
+const TERMINAL_WORKFLOW_STATUSES = new Set<WorkflowRecordType['status']>([
+  'done',
+  'partial',
+  'error',
+  'cancelled',
+]);
+
+export function isWorkflowTerminal(status: WorkflowRecordType['status']): boolean {
+  return TERMINAL_WORKFLOW_STATUSES.has(status);
+}
+
 function workflowsDir(root: string): string {
   return join(root, 'data', 'workflows');
 }
 
 function workflowPath(root: string, id: string): string {
+  if (!/^[a-f0-9]{16}$/.test(id)) throw new Error('invalid workflow id');
   return join(workflowsDir(root), `${id}.json`);
 }
 
@@ -70,6 +87,7 @@ function defaultDeps(root: string): WorkflowRuntimeDeps {
 }
 
 export function getWorkflow(root: string, id: string): WorkflowRecordType | null {
+  if (!/^[a-f0-9]{16}$/.test(id)) return null;
   const path = workflowPath(root, id);
   if (!existsSync(path)) return null;
   try {
@@ -77,6 +95,54 @@ export function getWorkflow(root: string, id: string): WorkflowRecordType | null
   } catch {
     return null;
   }
+}
+
+export function planWorkflowForTargets(
+  root: string,
+  input: CreateWorkflowInput,
+  providedDeps?: WorkflowRuntimeDeps,
+  options: { allowMissingOfferNums?: ReadonlySet<number> } = {},
+): WorkflowPlan {
+  const deps = providedDeps ?? defaultDeps(root);
+  for (const target of input.targets) {
+    if (
+      'num' in target &&
+      typeof target.num === 'number' &&
+      !('url' in target) &&
+      !options.allowMissingOfferNums?.has(target.num) &&
+      !deps.offerExists(target.num)
+    ) {
+      throw new Error(`num not found: ${target.num}`);
+    }
+  }
+  const evaluatedOfferNums = new Set(
+    input.targets.flatMap(target =>
+      'num' in target &&
+      typeof target.num === 'number' &&
+      Number.isInteger(target.num) &&
+      deps.isEvaluated(target.num)
+        ? [target.num]
+        : [],
+    ),
+  );
+  return planWorkflow({
+    targets: input.targets,
+    modes: input.modes,
+    evaluatedOfferNums,
+  });
+}
+
+export function workflowChildJobs(
+  root: string,
+  workflow: WorkflowRecordType,
+  providedDeps?: Pick<WorkflowRuntimeDeps, 'getJob'>,
+): JobRecord[] {
+  const getJob = providedDeps?.getJob ?? ((id: string) => getPersistedJob(root, id));
+  return workflow.steps.flatMap(step => {
+    if (!step.jobId) return [];
+    const job = getJob(step.jobId);
+    return job ? [job] : [];
+  });
 }
 
 export function listWorkflows(root: string): WorkflowRecordType[] {
@@ -188,7 +254,7 @@ export function advanceWorkflow(
   const deps = providedDeps ?? defaultDeps(root);
   const stored = getWorkflow(root, id);
   if (!stored) throw new Error(`workflow not found: ${id}`);
-  if (['done', 'partial', 'error', 'cancelled'].includes(stored.status)) return stored;
+  if (isWorkflowTerminal(stored.status)) return stored;
 
   const workflow: WorkflowRecordType = {
     ...stored,
@@ -284,9 +350,7 @@ export function advanceWorkflow(
 
   workflow.status = deriveStatus(workflow);
   workflow.updatedAt = new Date().toISOString();
-  workflow.finishedAt = ['done', 'partial', 'error', 'cancelled'].includes(workflow.status)
-    ? workflow.updatedAt
-    : null;
+  workflow.finishedAt = isWorkflowTerminal(workflow.status) ? workflow.updatedAt : null;
   persist(root, workflow);
   return workflow;
 }
@@ -297,23 +361,7 @@ export function createWorkflow(
   providedDeps?: WorkflowRuntimeDeps,
 ): WorkflowRecordType {
   const deps = providedDeps ?? defaultDeps(root);
-  for (const target of input.targets) {
-    if ('num' in target && !('url' in target) && !deps.offerExists(target.num)) {
-      throw new Error(`num not found: ${target.num}`);
-    }
-  }
-  const evaluatedOfferNums = new Set(
-    input.targets.flatMap(target =>
-      'num' in target && Number.isInteger(target.num) && deps.isEvaluated(target.num)
-        ? [target.num]
-        : [],
-    ),
-  );
-  const plan = planWorkflow({
-    targets: input.targets,
-    modes: input.modes,
-    evaluatedOfferNums,
-  });
+  const plan = planWorkflowForTargets(root, input, deps);
   const now = new Date().toISOString();
   const workflow = WorkflowRecord.parse({
     id: randomBytes(8).toString('hex'),
@@ -339,11 +387,11 @@ export function cancelWorkflow(
   root: string,
   id: string,
   providedDeps?: WorkflowRuntimeDeps,
-): WorkflowRecordType {
+): CancelWorkflowResult {
   const deps = providedDeps ?? defaultDeps(root);
   const workflow = getWorkflow(root, id);
   if (!workflow) throw new Error(`workflow not found: ${id}`);
-  if (['done', 'partial', 'error', 'cancelled'].includes(workflow.status)) return workflow;
+  if (isWorkflowTerminal(workflow.status)) return { cancelled: false, workflow };
   for (const step of workflow.steps) {
     if (step.status === 'running' && step.jobId) deps.cancelJob(step.jobId);
     if (['running', 'queued', 'blocked'].includes(step.status)) {
@@ -355,7 +403,7 @@ export function cancelWorkflow(
   workflow.updatedAt = new Date().toISOString();
   workflow.finishedAt = workflow.updatedAt;
   persist(root, workflow);
-  return workflow;
+  return { cancelled: true, workflow };
 }
 
 export function advanceWorkflowsForJob(

--- a/src/lib/server/workflows/api.ts
+++ b/src/lib/server/workflows/api.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { JobRecord, JobType } from '../../schemas/jobs';
+import type { WorkflowTarget } from '../../schemas/workflows';
 import {
   WorkflowRecord,
   type WorkflowRecord as WorkflowRecordType,
@@ -17,7 +18,7 @@ import {
   type JobConflictPayload,
   startJob as startPersistedJob,
 } from '../jobs/start';
-import { planWorkflow, type WorkflowPlan, type WorkflowTarget } from './planner';
+import { planWorkflow, type WorkflowPlan } from './planner';
 
 type StartedJob =
   | JobRecord
@@ -417,7 +418,14 @@ export function advanceWorkflowsForJob(
 }
 
 export function reconcileWorkflows(root: string, deps?: WorkflowRuntimeDeps): WorkflowRecordType[] {
-  return listWorkflows(root)
-    .filter(workflow => workflow.status === 'queued' || workflow.status === 'running')
-    .map(workflow => advanceWorkflow(root, workflow.id, deps));
+  const reconciled: WorkflowRecordType[] = [];
+  for (const workflow of listWorkflows(root)) {
+    if (workflow.status !== 'queued' && workflow.status !== 'running') continue;
+    try {
+      reconciled.push(advanceWorkflow(root, workflow.id, deps));
+    } catch (error) {
+      console.error(`Failed to reconcile workflow ${workflow.id}:`, error);
+    }
+  }
+  return reconciled;
 }

--- a/src/lib/server/workflows/planner.ts
+++ b/src/lib/server/workflows/planner.ts
@@ -1,6 +1,5 @@
 import { MODE_CATALOG, type ModeDefinition, type ModeId, resolveModeId } from '../../modes/catalog';
-
-export type WorkflowTarget = { num: number } | { url: string; num?: number };
+import type { WorkflowTarget } from '../../schemas/workflows';
 
 export interface PlannedWorkflowStep {
   id: string;

--- a/src/lib/server/workflows/planner.ts
+++ b/src/lib/server/workflows/planner.ts
@@ -1,6 +1,6 @@
 import { MODE_CATALOG, type ModeDefinition, type ModeId, resolveModeId } from '../../modes/catalog';
 
-export type WorkflowTarget = { num: number } | { url: string };
+export type WorkflowTarget = { num: number } | { url: string; num?: number };
 
 export interface PlannedWorkflowStep {
   id: string;
@@ -111,7 +111,8 @@ function planTarget(
   const needsEvaluation =
     expanded.includes('evaluate') ||
     expanded.some(mode => definitionFor(mode).requiresEvaluation === true);
-  const alreadyEvaluated = 'num' in target && evaluatedOfferNums.has(target.num);
+  const alreadyEvaluated =
+    'num' in target && typeof target.num === 'number' && evaluatedOfferNums.has(target.num);
   if (needsEvaluation && !alreadyEvaluated && !expanded.includes('evaluate')) {
     const screenIndex = expanded.indexOf('screen');
     expanded.splice(screenIndex >= 0 ? screenIndex + 1 : 0, 0, 'evaluate');

--- a/src/lib/server/workflows/planner.ts
+++ b/src/lib/server/workflows/planner.ts
@@ -1,0 +1,176 @@
+import { MODE_CATALOG, type ModeDefinition, type ModeId, resolveModeId } from '../../modes/catalog';
+
+export type WorkflowTarget = { num: number } | { url: string };
+
+export interface PlannedWorkflowStep {
+  id: string;
+  targetIndex: number | null;
+  mode: string;
+  dependsOn: string[];
+  params: Record<string, unknown>;
+}
+
+export interface WorkflowPlan {
+  targets: WorkflowTarget[];
+  requestedModes: ModeId[];
+  steps: PlannedWorkflowStep[];
+  maxParallel: 4;
+}
+
+export interface PlanWorkflowInput {
+  targets: WorkflowTarget[];
+  modes: string[];
+  evaluatedOfferNums: ReadonlySet<number>;
+}
+
+const SYSTEM_MODES = new Set<ModeId>(['scan', 'batch-evaluate', 'process-queue']);
+
+function definitionFor(mode: ModeId): ModeDefinition {
+  return MODE_CATALOG[mode] as ModeDefinition;
+}
+
+function canonicalModes(values: string[]): ModeId[] {
+  const seen = new Set<ModeId>();
+  const modes: ModeId[] = [];
+  for (const value of values) {
+    const mode = resolveModeId(value);
+    if (!mode) throw new Error(`unknown mode: ${value}`);
+    if (!seen.has(mode)) {
+      seen.add(mode);
+      modes.push(mode);
+    }
+  }
+  if (modes.length === 0) throw new Error('at least one mode is required');
+  return modes;
+}
+
+function expandModes(modes: ModeId[]): ModeId[] {
+  const expanded: ModeId[] = [];
+  const seen = new Set<ModeId>();
+  for (const mode of modes) {
+    const definition = definitionFor(mode);
+    const values = definition.expandsTo ?? [mode];
+    for (const value of values) {
+      const canonical = resolveModeId(value);
+      if (!canonical) throw new Error(`unknown expanded mode: ${value}`);
+      if (!seen.has(canonical)) {
+        seen.add(canonical);
+        expanded.push(canonical);
+      }
+    }
+  }
+  return expanded;
+}
+
+function stepId(targetIndex: number | null, index: number, mode: string): string {
+  return `${targetIndex === null ? 'system' : `target-${targetIndex}`}-${index}-${mode}`;
+}
+
+function systemPlan(requestedModes: ModeId[], targets: WorkflowTarget[]): WorkflowPlan | null {
+  const systemModes = requestedModes.filter(mode => SYSTEM_MODES.has(mode));
+  if (systemModes.length === 0) return null;
+  if (targets.length > 0 || requestedModes.length !== 1) {
+    throw new Error('system modes cannot be mixed with offer targets or other modes');
+  }
+  const requested = systemModes[0] as ModeId;
+  const mode = requested === 'process-queue' ? 'screen' : requested;
+  return {
+    targets: [],
+    requestedModes,
+    maxParallel: 4,
+    steps: [
+      {
+        id: stepId(null, 0, mode),
+        targetIndex: null,
+        mode,
+        dependsOn: [],
+        params: requested === 'process-queue' ? { queue: true } : {},
+      },
+    ],
+  };
+}
+
+function validateExecutableModes(modes: ModeId[]): void {
+  for (const mode of modes) {
+    const definition = definitionFor(mode);
+    if (definition.execution === 'inline') throw new Error(`${mode} runs inline in chat`);
+    if (definition.execution === 'handoff') throw new Error(`${mode} requires a handoff`);
+  }
+}
+
+function planTarget(
+  target: WorkflowTarget,
+  targetIndex: number,
+  requestedModes: ModeId[],
+  evaluatedOfferNums: ReadonlySet<number>,
+): PlannedWorkflowStep[] {
+  const expanded = expandModes(requestedModes);
+  const isUrl = 'url' in target;
+  if (isUrl && !expanded.includes('screen')) expanded.unshift('screen');
+
+  const needsEvaluation =
+    expanded.includes('evaluate') ||
+    expanded.some(mode => definitionFor(mode).requiresEvaluation === true);
+  const alreadyEvaluated = 'num' in target && evaluatedOfferNums.has(target.num);
+  if (needsEvaluation && !alreadyEvaluated && !expanded.includes('evaluate')) {
+    const screenIndex = expanded.indexOf('screen');
+    expanded.splice(screenIndex >= 0 ? screenIndex + 1 : 0, 0, 'evaluate');
+  }
+
+  const ordered: ModeId[] = [];
+  if (expanded.includes('screen')) ordered.push('screen');
+  if (expanded.includes('evaluate')) ordered.push('evaluate');
+  ordered.push(
+    ...expanded.filter(
+      mode =>
+        mode !== 'screen' && mode !== 'evaluate' && definitionFor(mode).mutatesReport === true,
+    ),
+  );
+  ordered.push(
+    ...expanded.filter(
+      mode =>
+        mode !== 'screen' && mode !== 'evaluate' && definitionFor(mode).mutatesReport !== true,
+    ),
+  );
+
+  const steps: PlannedWorkflowStep[] = [];
+  let lastReportStepId: string | null = null;
+  let screenStepId: string | null = null;
+
+  for (const mode of ordered) {
+    const id = stepId(targetIndex, steps.length, mode);
+    let dependsOn: string[] = [];
+    if (mode === 'evaluate' && screenStepId) dependsOn = [screenStepId];
+    else if (definitionFor(mode).mutatesReport && lastReportStepId) {
+      dependsOn = [lastReportStepId];
+    } else if (definitionFor(mode).requiresEvaluation && lastReportStepId) {
+      dependsOn = [lastReportStepId];
+    }
+
+    const params: Record<string, unknown> =
+      mode === 'screen' && isUrl ? { url: target.url } : 'num' in target ? { num: target.num } : {};
+    steps.push({ id, targetIndex, mode, dependsOn, params });
+
+    if (mode === 'screen') screenStepId = id;
+    if (mode === 'evaluate' || definitionFor(mode).mutatesReport) lastReportStepId = id;
+  }
+
+  return steps;
+}
+
+export function planWorkflow(input: PlanWorkflowInput): WorkflowPlan {
+  const requestedModes = canonicalModes(input.modes);
+  validateExecutableModes(requestedModes);
+  const system = systemPlan(requestedModes, input.targets);
+  if (system) return system;
+  if (input.targets.length === 0) throw new Error('offer workflows require at least one target');
+
+  return {
+    targets: input.targets,
+    requestedModes,
+    maxParallel: 4,
+    steps: input.targets.flatMap((target, index) =>
+      planTarget(target, index, requestedModes, input.evaluatedOfferNums),
+    ),
+  };
+}

--- a/test/components/chat-composer.test.tsx
+++ b/test/components/chat-composer.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatComposer } from '@/features/chat/chat-composer';
 import { filterSlashItems, SLASH_ITEMS } from '@/features/chat/slash-popover';
+import { CHAT_DISCOVERABLE_MODES } from '@/lib/modes/catalog';
 import { DRAFT_OVERRIDE_KEY, useChatStore } from '@/stores/chat-store';
 
 // The composer mounts useApplications (a TanStack Query hook) for the
@@ -188,6 +189,12 @@ describe('ChatComposer', () => {
     expect(listbox.querySelectorAll('[role="option"]').length).toBe(SLASH_ITEMS.length);
   });
 
+  it('keeps slash discovery in parity with the canonical mode catalog', () => {
+    expect(SLASH_ITEMS.map(item => item.command)).toEqual(
+      CHAT_DISCOVERABLE_MODES.map(mode => mode.id),
+    );
+  });
+
   it('arrow keys move the active option and Enter inserts the command', () => {
     const onSend = vi.fn();
     render(
@@ -202,8 +209,7 @@ describe('ChatComposer', () => {
     fireEvent.change(textarea(), { target: { value: '/' } });
     fireEvent.keyDown(textarea(), { key: 'ArrowDown' });
     fireEvent.keyDown(textarea(), { key: 'Enter' });
-    // Second item in SLASH_ITEMS is /offers.
-    expect(textarea().value).toBe('/offers ');
+    expect(textarea().value).toBe(`/${SLASH_ITEMS[1]?.command} `);
     expect(onSend).not.toHaveBeenCalled();
   });
 

--- a/test/components/chat-confirm-card.test.tsx
+++ b/test/components/chat-confirm-card.test.tsx
@@ -186,7 +186,8 @@ describe('ConfirmCard', () => {
               result: {
                 ok: true,
                 textOffer: { offer: { num: 42 } },
-                message: 'Offer #42 created. Screening and evaluation started.',
+                message:
+                  'Offer #42 created. Screening started; evaluation will start after screening succeeds.',
                 links: [{ label: 'Offer #42', href: '/report/42' }],
               },
             }),
@@ -205,8 +206,67 @@ describe('ConfirmCard', () => {
 
     fireEvent.click(getByRole('button', { name: 'Create, screen, and evaluate offer' }));
 
-    await findByText('Offer #42 created. Screening and evaluation started.');
+    await findByText(
+      'Offer #42 created. Screening started; evaluation will start after screening succeeds.',
+    );
     expect(await findByRole('link', { name: 'Offer #42' })).toHaveAttribute('href', '/report/42');
+  });
+
+  it('registers every initially running child returned by a workflow approval', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+              outcome: 'approved',
+              execution: 'succeeded',
+              result: {
+                ok: true,
+                workflow: { id: 'fedcba9876543210', status: 'running' },
+                jobs: [
+                  {
+                    id: '0123456789abcdef',
+                    type: 'evaluate',
+                    status: 'queued',
+                    params: { num: 42 },
+                  },
+                  {
+                    id: '1111111111111111',
+                    type: 'evaluate',
+                    status: 'running',
+                    params: { num: 43 },
+                  },
+                ],
+              },
+            }),
+          }) as Response,
+      ),
+    );
+    const { getByRole } = render(
+      <ConfirmCard
+        token="tok-workflow"
+        summary="Run evaluation for 2 targets"
+        meta=""
+        outcome="pending"
+        action="start-workflow"
+      />,
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Run evaluation for 2 targets' }));
+
+    await waitFor(() => {
+      expect(useChatJobsStore.getState().jobs['0123456789abcdef']).toMatchObject({
+        kind: 'evaluate',
+        num: 42,
+      });
+      expect(useChatJobsStore.getState().jobs['1111111111111111']).toMatchObject({
+        kind: 'evaluate',
+        num: 43,
+      });
+    });
   });
 
   it('surfaces the server reason when an approved action fails to execute', async () => {

--- a/test/e2e/chat.spec.ts
+++ b/test/e2e/chat.spec.ts
@@ -230,10 +230,16 @@ for (const viewport of VIEWPORTS) {
       await openChatBubble(page, viewport.width);
       const input = page.getByRole('textbox', { name: 'Message' });
       await input.fill('/');
-      await expect(page.getByRole('listbox', { name: 'Chat modes' })).toBeVisible();
+      const listbox = page.getByRole('listbox', { name: 'Chat modes' });
+      await expect(listbox).toBeVisible();
       await page.keyboard.press('ArrowDown');
+      const activeOption = listbox.locator('[role="option"][aria-selected="true"]');
+      await expect(activeOption).toHaveCount(1);
+      const command = (await activeOption.locator('.chat-slash__cmd').innerText())
+        .trim()
+        .split(/\s+/)[0];
       await page.keyboard.press('Enter');
-      await expect(input).toHaveValue('/offers ');
+      await expect(input).toHaveValue(`${command} `);
     });
   });
 }

--- a/test/latex-sandbox.test.mjs
+++ b/test/latex-sandbox.test.mjs
@@ -25,6 +25,45 @@ describe('LaTeX compiler sandbox', () => {
     ).toThrow(/install bubblewrap/);
   });
 
+  it.each(['linux', 'darwin'])('fails closed when pdflatex is unavailable on %s', platform => {
+    const root = mkdtempSync(join(tmpdir(), 'latex-sandbox-'));
+    const bin = join(root, 'bin');
+    const work = join(root, 'work');
+    mkdirSync(bin);
+    mkdirSync(work);
+
+    expect(() =>
+      buildLatexSandboxInvocation({
+        sandboxDir: work,
+        platform,
+        envPath: bin,
+        sandboxExecPath: join(bin, 'sandbox-exec'),
+      }),
+    ).toThrow(/pdflatex is required/);
+  });
+
+  it('builds a network-isolated Linux bubblewrap invocation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'latex-sandbox-'));
+    const bin = join(root, 'bin');
+    const work = join(root, 'work');
+    mkdirSync(bin);
+    mkdirSync(work);
+    writeFileSync(join(bin, 'pdflatex'), '');
+    writeFileSync(join(bin, 'bwrap'), '');
+
+    const invocation = buildLatexSandboxInvocation({
+      sandboxDir: work,
+      platform: 'linux',
+      envPath: bin,
+    });
+
+    expect(invocation.args).toContain('--unshare-all');
+    expect(invocation.args).toContain('--clearenv');
+    expect(invocation.args).toEqual(
+      expect.arrayContaining(['--bind', expect.any(String), '/work', '--chdir', '/work']),
+    );
+  });
+
   it('uses macOS sandbox-exec with network denied and a scrubbed environment', () => {
     const root = mkdtempSync(join(tmpdir(), 'latex-sandbox-'));
     const bin = join(root, 'bin');

--- a/test/latex-sandbox.test.mjs
+++ b/test/latex-sandbox.test.mjs
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { buildLatexSandboxInvocation } from '../cli/lib/latex-sandbox.mjs';
+
+function fakePath(root, names) {
+  for (const name of names) mkdirSync(join(root, name), { recursive: true });
+  return names.map(name => join(root, name)).join(':');
+}
+
+describe('LaTeX compiler sandbox', () => {
+  it('fails closed when Linux bubblewrap is unavailable', () => {
+    const root = mkdtempSync(join(tmpdir(), 'latex-sandbox-'));
+    const path = fakePath(root, ['bin']);
+    mkdirSync(join(root, 'work'));
+    writeFileSync(join(root, 'bin', 'pdflatex'), '');
+
+    expect(() =>
+      buildLatexSandboxInvocation({
+        sandboxDir: join(root, 'work'),
+        platform: 'linux',
+        envPath: path,
+      }),
+    ).toThrow(/install bubblewrap/);
+  });
+
+  it('uses macOS sandbox-exec with network denied and a scrubbed environment', () => {
+    const root = mkdtempSync(join(tmpdir(), 'latex-sandbox-'));
+    const bin = join(root, 'bin');
+    const work = join(root, 'work');
+    mkdirSync(bin);
+    mkdirSync(work);
+    const pdflatex = join(bin, 'pdflatex');
+    const sandboxExec = join(bin, 'sandbox-exec');
+    writeFileSync(pdflatex, '');
+    writeFileSync(sandboxExec, '');
+
+    const invocation = buildLatexSandboxInvocation({
+      sandboxDir: work,
+      platform: 'darwin',
+      envPath: bin,
+      sandboxExecPath: sandboxExec,
+    });
+
+    expect(invocation.command).toBe(sandboxExec);
+    expect(invocation.args).toContain('-no-shell-escape');
+    expect(invocation.args.join(' ')).toContain('deny network');
+    expect(invocation.options.env).toEqual({
+      HOME: expect.any(String),
+      LANG: 'C.UTF-8',
+      PATH: expect.any(String),
+      TEXMFOUTPUT: expect.any(String),
+      TMPDIR: expect.any(String),
+      openout_any: 'p',
+    });
+    expect(invocation.options.env).not.toHaveProperty('OPENAI_API_KEY');
+  });
+});

--- a/test/mode-runner-catalog-parity.test.mjs
+++ b/test/mode-runner-catalog-parity.test.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { MODE_RUNNER_MODE_IDS } from '../batch/mode-runner.mjs';
+
+const catalog = JSON.parse(
+  readFileSync(join(process.cwd(), 'src/lib/modes/catalog.json'), 'utf-8'),
+);
+
+describe('mode-runner catalog parity', () => {
+  it('has one executable spec for every offer-scoped LLM background job', () => {
+    const expected = Object.entries(catalog.modes)
+      .filter(
+        ([id, mode]) =>
+          mode.execution === 'background' && mode.scope === 'offer' && id !== 'screen',
+      )
+      .map(([id]) => id)
+      .sort();
+
+    expect([...MODE_RUNNER_MODE_IDS].sort()).toEqual(expected);
+  });
+});

--- a/test/mode-runner-spec-latex.test.mjs
+++ b/test/mode-runner-spec-latex.test.mjs
@@ -1,0 +1,49 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { latexSpec } from '../batch/specs/latex.mjs';
+
+let root;
+let ctx;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'latex-spec-'));
+  mkdirSync(join(root, 'artifacts/output'), { recursive: true });
+  ctx = { rootPath: root, num: 7 };
+});
+
+const TEX = String.raw`\documentclass{article}
+\begin{document}
+Hello
+\end{document}`;
+
+describe('latex mode spec', () => {
+  it('parses a sentinel-wrapped tex document', () => {
+    expect(latexSpec.parse(`<<<SUR9E_OUTPUT>>>\n${TEX}\n<<<SUR9E_END>>>`)).toContain(
+      '\\begin{document}',
+    );
+  });
+
+  it('rejects non-LaTeX output', () => {
+    expect(() => latexSpec.parse('<<<SUR9E_OUTPUT>>>\nplain text\n<<<SUR9E_END>>>')).toThrow(
+      /latex/i,
+    );
+  });
+
+  it('writes a distinct cv-latex artifact and invokes the compiler', async () => {
+    const compile = vi.fn((texPath, pdfPath) => {
+      expect(readFileSync(texPath, 'utf-8')).toContain('\\documentclass');
+      writeFileSync(pdfPath, 'PDF', 'utf-8');
+    });
+    const inputs = {
+      offer: { company: 'Otter.ai' },
+      profile: { candidate: { full_name: 'John Doe' } },
+    };
+
+    const result = await latexSpec.write(ctx, inputs, TEX, { compile });
+
+    expect(compile).toHaveBeenCalledOnce();
+    expect(result.summary).toContain('artifacts/output/cv-latex-john-doe-otter-ai-7-');
+  });
+});

--- a/test/unit/chat/chat-action-routes.test.ts
+++ b/test/unit/chat/chat-action-routes.test.ts
@@ -52,6 +52,8 @@ type StartJobRoute = typeof import('@/app/api/chat/actions/start-job/route');
 type SetStatusRoute = typeof import('@/app/api/chat/actions/set-status/route');
 type CancelJobRoute = typeof import('@/app/api/chat/actions/cancel-job/route');
 type CreateTextOfferRoute = typeof import('@/app/api/chat/actions/create-offer-from-text/route');
+type StartWorkflowRoute = typeof import('@/app/api/chat/actions/start-workflow/route');
+type CancelWorkflowRoute = typeof import('@/app/api/chat/actions/cancel-workflow/route');
 
 describe('chat action routes', () => {
   let root: string;
@@ -59,6 +61,8 @@ describe('chat action routes', () => {
   let setStatusRoute: SetStatusRoute;
   let cancelJobRoute: CancelJobRoute;
   let createTextOfferRoute: CreateTextOfferRoute;
+  let startWorkflowRoute: StartWorkflowRoute;
+  let cancelWorkflowRoute: CancelWorkflowRoute;
 
   beforeEach(async () => {
     root = seedRoot();
@@ -68,6 +72,8 @@ describe('chat action routes', () => {
     setStatusRoute = await import('@/app/api/chat/actions/set-status/route');
     cancelJobRoute = await import('@/app/api/chat/actions/cancel-job/route');
     createTextOfferRoute = await import('@/app/api/chat/actions/create-offer-from-text/route');
+    startWorkflowRoute = await import('@/app/api/chat/actions/start-workflow/route');
+    cancelWorkflowRoute = await import('@/app/api/chat/actions/cancel-workflow/route');
     emitTurnEventMock.mockReset();
     spawnJobMock.mockReset();
     revalidatePathMock.mockReset();
@@ -147,6 +153,46 @@ describe('chat action routes', () => {
       expect(spawnJobMock).toHaveBeenCalledTimes(1);
     });
 
+    it('expands an explicit URL screen-and-evaluate request into sequential jobs', async () => {
+      const url = 'https://jobs.example.com/roles/123';
+      const res = await startJobRoute.POST(
+        postJson('http://localhost/api/chat/actions/start-job', {
+          kind: 'screen-evaluate',
+          params: { url },
+          terminalApproved: true,
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.started).toBe(true);
+      expect(body.job).toMatchObject({
+        type: 'screen',
+        params: { url, then: 'evaluate' },
+      });
+      expect(body.message).toBe(
+        'Screening started; evaluation will start after screening succeeds.',
+      );
+      await flushImmediate();
+      expect(spawnJobMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('cannot smuggle evaluation into a screen-only request through params', async () => {
+      const url = 'https://jobs.example.com/roles/456';
+      const res = await startJobRoute.POST(
+        postJson('http://localhost/api/chat/actions/start-job', {
+          kind: 'screen',
+          params: { url, then: 'evaluate', next_job_id: 'attacker-controlled' },
+          terminalApproved: true,
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.started).toBe(true);
+      expect(body.job).toMatchObject({ type: 'screen', params: { url } });
+      expect(body.job.params).not.toHaveProperty('then');
+      expect(body.job.params).not.toHaveProperty('next_job_id');
+    });
+
     it('rejects an unknown kind with 400', async () => {
       const res = await startJobRoute.POST(
         postJson('http://localhost/api/chat/actions/start-job', { kind: 'nonsense' }),
@@ -224,7 +270,7 @@ describe('chat action routes', () => {
       expect(spawnJobMock).toHaveBeenCalledTimes(1);
     });
 
-    it('starts the recommended screen + evaluate workflow for pasted text', async () => {
+    it('starts screening first and queues evaluation as a separate successor job', async () => {
       const res = await createTextOfferRoute.POST(
         postJson('http://localhost/api/chat/actions/create-offer-from-text', {
           text: 'Own platform reliability.',
@@ -237,13 +283,166 @@ describe('chat action routes', () => {
       const body = await res.json();
       expect(res.status).toBe(200);
       expect(body.job).toMatchObject({
-        type: 'screen-evaluate',
-        params: { num: body.offer.num },
+        type: 'screen',
+        params: { num: body.offer.num, then: 'evaluate' },
       });
-      expect(body.message).toMatch(/screening and evaluation started/i);
+      expect(body.message).toMatch(/evaluation will start after screening succeeds/i);
       expect(body.links).toEqual([
         { label: `Offer #${body.offer.num}`, href: `/report/${body.offer.num}` },
       ]);
+    });
+
+    it('rejects combining legacy startKind with workflow modes', async () => {
+      const res = await createTextOfferRoute.POST(
+        postJson('http://localhost/api/chat/actions/create-offer-from-text', {
+          text: 'Own platform reliability.',
+          company: 'Acme',
+          role: 'Staff Engineer',
+          startKind: 'screen',
+          modes: ['screen', 'evaluate'],
+          terminalApproved: true,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an invalid workflow mode before creating or confirming the offer', async () => {
+      const res = await createTextOfferRoute.POST(
+        postJson(
+          'http://localhost/api/chat/actions/create-offer-from-text',
+          {
+            text: 'Own platform reliability.',
+            company: 'Acme',
+            role: 'Staff Engineer',
+            modes: ['tracker'],
+          },
+          { 'x-sur9e-turn': 'turn-1' },
+        ),
+      );
+
+      expect(res.status).toBe(400);
+      expect(emitTurnEventMock).not.toHaveBeenCalled();
+      expect(readFileSync(join(root, 'data/applications.md'), 'utf-8')).not.toContain(
+        'Staff Engineer',
+      );
+    });
+  });
+
+  describe('workflow action routes', () => {
+    it('parks the complete workflow behind one chat confirmation', async () => {
+      const res = await startWorkflowRoute.POST(
+        postJson(
+          'http://localhost/api/chat/actions/start-workflow',
+          {
+            targets: [{ num: 1001 }],
+            modes: ['evaluate', 'cover-letter'],
+          },
+          { 'x-sur9e-turn': 'turn-1' },
+        ),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.needsConfirm).toBe(true);
+      expect(body.summary).toContain('2 modes');
+      expect(body.meta).toContain('evaluation');
+      expect(emitTurnEventMock).toHaveBeenCalledWith(
+        'turn-1',
+        expect.objectContaining({ kind: 'start-workflow' }),
+      );
+      expect(readdirSync(join(root, 'data/jobs'))).toHaveLength(0);
+    });
+
+    it('starts and persists a terminal-approved workflow', async () => {
+      const res = await startWorkflowRoute.POST(
+        postJson('http://localhost/api/chat/actions/start-workflow', {
+          targets: [{ num: 1001 }],
+          modes: ['screen', 'evaluate'],
+          terminalApproved: true,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.started).toBe(true);
+      expect(body.workflow.status).toBe('running');
+      expect(body.jobs).toEqual([expect.objectContaining({ type: 'screen' })]);
+      expect(
+        readdirSync(join(root, 'data/workflows')).filter(name => name.endsWith('.json')),
+      ).toHaveLength(1);
+    });
+
+    it('rejects inline modes before creating a confirmation', async () => {
+      const res = await startWorkflowRoute.POST(
+        postJson(
+          'http://localhost/api/chat/actions/start-workflow',
+          {
+            targets: [{ num: 1001 }],
+            modes: ['tracker'],
+          },
+          { 'x-sur9e-turn': 'turn-1' },
+        ),
+      );
+
+      expect(res.status).toBe(400);
+      expect(emitTurnEventMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an incompatible running singleton before confirmation', async () => {
+      writeFileSync(
+        join(root, 'data/jobs', '0123456789abcdef.json'),
+        JSON.stringify({
+          id: '0123456789abcdef',
+          type: 'screen',
+          status: 'queued',
+          params: { url: 'https://example.com/jobs/already-running' },
+          startedAt: new Date().toISOString(),
+          finishedAt: null,
+          output: '',
+          error: null,
+          exitCode: null,
+        }),
+      );
+
+      const res = await startWorkflowRoute.POST(
+        postJson(
+          'http://localhost/api/chat/actions/start-workflow',
+          {
+            targets: [{ url: 'https://example.com/jobs/new' }],
+            modes: ['screen'],
+          },
+          { 'x-sur9e-turn': 'turn-1' },
+        ),
+      );
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toContain('screen is already running');
+      expect(emitTurnEventMock).not.toHaveBeenCalled();
+    });
+
+    it('confirmation-gates workflow cancellation', async () => {
+      const started = await startWorkflowRoute.POST(
+        postJson('http://localhost/api/chat/actions/start-workflow', {
+          targets: [{ num: 1001 }],
+          modes: ['evaluate'],
+          terminalApproved: true,
+        }),
+      );
+      const workflowId = (await started.json()).workflow.id;
+      const res = await cancelWorkflowRoute.POST(
+        postJson(
+          'http://localhost/api/chat/actions/cancel-workflow',
+          { workflowId },
+          { 'x-sur9e-turn': 'turn-1' },
+        ),
+      );
+
+      expect((await res.json()).needsConfirm).toBe(true);
+      expect(emitTurnEventMock).toHaveBeenCalledWith(
+        'turn-1',
+        expect.objectContaining({ kind: 'cancel-workflow' }),
+      );
     });
   });
 

--- a/test/unit/chat/chat-action-routes.test.ts
+++ b/test/unit/chat/chat-action-routes.test.ts
@@ -444,6 +444,42 @@ describe('chat action routes', () => {
         expect.objectContaining({ kind: 'cancel-workflow' }),
       );
     });
+
+    it('terminal approval cancels an active workflow', async () => {
+      const started = await startWorkflowRoute.POST(
+        postJson('http://localhost/api/chat/actions/start-workflow', {
+          targets: [{ num: 1001 }],
+          modes: ['evaluate'],
+          terminalApproved: true,
+        }),
+      );
+      const workflowId = (await started.json()).workflow.id;
+
+      const res = await cancelWorkflowRoute.POST(
+        postJson('http://localhost/api/chat/actions/cancel-workflow', {
+          workflowId,
+          terminalApproved: true,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        cancelled: true,
+        workflow: { id: workflowId, status: 'cancelled' },
+      });
+    });
+
+    it('returns 404 when cancelling an unknown workflow', async () => {
+      const res = await cancelWorkflowRoute.POST(
+        postJson('http://localhost/api/chat/actions/cancel-workflow', {
+          workflowId: '0000000000000000',
+          terminalApproved: true,
+        }),
+      );
+
+      expect(res.status).toBe(404);
+      expect((await res.json()).error).toContain('workflow not found');
+    });
   });
 
   describe('POST /api/chat/actions/set-status', () => {

--- a/test/unit/chat/confirm-persistence.test.tsx
+++ b/test/unit/chat/confirm-persistence.test.tsx
@@ -136,10 +136,10 @@ describe('confirm resolution persists to the owning message', () => {
     return { conversationId: conversation.id, token };
   }
 
-  it('approve: the started outcome lands in events_json and re-renders as job-started, no buttons', () => {
+  it('approve: the started outcome lands in events_json and re-renders as job-started, no buttons', async () => {
     const { conversationId, token } = seedTurn();
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('approved');
 
     // Reload from disk — the persisted events now carry the confirm-resolved.
@@ -176,10 +176,10 @@ describe('confirm resolution persists to the owning message', () => {
     expect(queryByRole('button')).toBeNull();
   });
 
-  it('cancel: the cancelled outcome persists and re-renders as cancelled, no buttons', () => {
+  it('cancel: the cancelled outcome persists and re-renders as cancelled, no buttons', async () => {
     const { conversationId, token } = seedTurn();
 
-    const res = confirms.resolveConfirm(root, token, false);
+    const res = await confirms.resolveConfirm(root, token, false);
     expect(res.outcome).toBe('cancelled');
 
     const [msg] = store.listMessages(root, conversationId);
@@ -204,13 +204,13 @@ describe('confirm resolution persists to the owning message', () => {
     expect(queryByRole('button')).toBeNull();
   });
 
-  it('is idempotent: a stale second resolve never overwrites the recorded outcome', () => {
+  it('is idempotent: a stale second resolve never overwrites the recorded outcome', async () => {
     const { conversationId, token } = seedTurn();
 
-    confirms.resolveConfirm(root, token, true); // approved persisted
+    await confirms.resolveConfirm(root, token, true); // approved persisted
     // A late/stale click: the token is already consumed, so it resolves to
     // expired — which must NOT clobber the approved state on the message.
-    const second = confirms.resolveConfirm(root, token, false);
+    const second = await confirms.resolveConfirm(root, token, false);
     expect(second.outcome).toBe('expired');
 
     const [msg] = store.listMessages(root, conversationId);
@@ -219,7 +219,7 @@ describe('confirm resolution persists to the owning message', () => {
     expect(resolutions[0].outcome).toBe('approved');
   });
 
-  it('a resolve whose owning message is not (yet) persisted is a harmless no-op', () => {
+  it('a resolve whose owning message is not (yet) persisted is a harmless no-op', async () => {
     // The live turn is still streaming: no assistant message on disk yet. The
     // live SSE event carries the resolution; persistence simply finds no owner
     // and does nothing (the turn will persist the full events at 'done').
@@ -232,7 +232,7 @@ describe('confirm resolution persists to the owning message', () => {
       meta: 'tracker write · no AI spend',
     });
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('approved');
     // No assistant message existed, so listMessages is empty and nothing threw.
     expect(store.listMessages(root, conversation.id)).toHaveLength(0);

--- a/test/unit/chat/confirms.test.ts
+++ b/test/unit/chat/confirms.test.ts
@@ -238,7 +238,7 @@ describe('chat confirms store', () => {
     expect(spawnJobMock).toHaveBeenCalledTimes(1);
   });
 
-  it('runs pasted-text screening then evaluation behind one approval', async () => {
+  it('starts pasted-text screening with evaluation queued as a separate successor job', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'create-offer-from-text',
@@ -256,8 +256,11 @@ describe('chat confirms store', () => {
       outcome: 'approved',
       result: {
         ok: true,
-        job: { type: 'screen-evaluate' },
-        message: expect.stringMatching(/screening and evaluation started/i),
+        job: {
+          type: 'screen',
+          params: expect.objectContaining({ then: 'evaluate' }),
+        },
+        message: expect.stringMatching(/evaluation will start after screening succeeds/i),
       },
     });
     expect(emitTurnEventMock).toHaveBeenLastCalledWith(
@@ -265,10 +268,87 @@ describe('chat confirms store', () => {
       expect.objectContaining({
         type: 'confirm-resolved',
         token,
-        message: expect.stringMatching(/screening and evaluation started/i),
+        message: expect.stringMatching(/evaluation will start after screening succeeds/i),
         links: [expect.objectContaining({ href: expect.stringMatching(/^\/report\//) })],
       }),
     );
+  });
+
+  it('approves one workflow confirmation and starts only its first sequential child', async () => {
+    const { token } = confirms.createConfirm(root, {
+      turnId: 'turn-1',
+      kind: 'start-workflow',
+      payload: {
+        targets: [{ num: 1001 }],
+        modes: ['screen-evaluate'],
+      },
+      summary: 'Run screening then evaluation',
+      meta: 'screening → evaluation',
+    });
+
+    const res = confirms.resolveConfirm(root, token, true);
+
+    expect(res).toMatchObject({
+      outcome: 'approved',
+      execution: 'succeeded',
+      result: {
+        ok: true,
+        workflow: {
+          status: 'running',
+          requestedModes: ['screen-evaluate'],
+          steps: [
+            { mode: 'screen', status: 'running' },
+            { mode: 'evaluate', status: 'blocked' },
+          ],
+        },
+        jobs: [{ type: 'screen' }],
+        message: expect.stringMatching(/Workflow started/i),
+        links: [{ label: 'Offer #1001', href: '/report/1001' }],
+      },
+    });
+    await flushImmediate();
+    expect(spawnJobMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a pasted-text offer and a dependency-aware workflow in one approval', async () => {
+    const { token } = confirms.createConfirm(root, {
+      turnId: 'turn-1',
+      kind: 'create-offer-from-text',
+      payload: {
+        text: 'Build durable infrastructure.',
+        company: 'Acme',
+        role: 'Infrastructure Engineer',
+        modes: ['screen-evaluate', 'cover-letter'],
+      },
+      summary: 'Create offer and run workflow',
+      meta: 'local tracker write · screening → evaluation → cover letter',
+    });
+
+    const res = confirms.resolveConfirm(root, token, true);
+
+    expect(res).toMatchObject({
+      outcome: 'approved',
+      execution: 'succeeded',
+      result: {
+        ok: true,
+        textOffer: {
+          reused: false,
+          offer: { company: 'Acme', role: 'Infrastructure Engineer' },
+        },
+        workflow: {
+          requestedModes: ['screen-evaluate', 'cover-letter'],
+          steps: [
+            { mode: 'screen', status: 'running' },
+            { mode: 'evaluate', status: 'blocked' },
+            { mode: 'cover-letter', status: 'blocked' },
+          ],
+        },
+        jobs: [{ type: 'screen' }],
+        links: [{ href: expect.stringMatching(/^\/report\/\d+$/) }],
+      },
+    });
+    await flushImmediate();
+    expect(spawnJobMock).toHaveBeenCalledTimes(1);
   });
 
   it('cancel executes nothing and emits confirm-resolved cancelled', () => {
@@ -356,6 +436,27 @@ describe('chat confirms store', () => {
     const d = confirms.describeStartJob(root, 'scan');
     expect(d.summary).toBe('Start portal scan');
     expect(d.meta).toContain(' min');
+  });
+
+  it('describeStartWorkflow shows sequential and parallel phases from the actual plan', async () => {
+    const { planWorkflow } = await import('@/lib/server/workflows');
+    const plan = planWorkflow({
+      targets: [{ num: 1001 }],
+      modes: ['screen-evaluate', 'cover-letter', 'tailor-cv'],
+      evaluatedOfferNums: new Set(),
+    });
+
+    const d = confirms.describeStartWorkflow(
+      {
+        targets: [{ num: 1001 }],
+        modes: ['screen-evaluate', 'cover-letter', 'tailor-cv'],
+      },
+      plan,
+    );
+
+    expect(d.meta).toContain('screening → evaluation');
+    expect(d.meta).toContain('cover letter + CV tailoring');
+    expect(d.meta).toContain('max 4 parallel');
   });
 
   it('describeSetStatus marks the write as spend-free', () => {

--- a/test/unit/chat/confirms.test.ts
+++ b/test/unit/chat/confirms.test.ts
@@ -351,6 +351,34 @@ describe('chat confirms store', () => {
     expect(spawnJobMock).toHaveBeenCalledTimes(1);
   });
 
+  it('defensively rejects a persisted text-offer payload that combines legacy and workflow modes', () => {
+    const { token } = confirms.createConfirm(root, {
+      turnId: 'turn-1',
+      kind: 'create-offer-from-text',
+      payload: {
+        text: 'Build durable infrastructure.',
+        company: 'Acme',
+        role: 'Infrastructure Engineer',
+        startKind: 'screen',
+        modes: ['evaluate'],
+      },
+      summary: 'Create offer and run modes',
+      meta: 'invalid persisted payload',
+    });
+
+    const res = confirms.resolveConfirm(root, token, true);
+
+    expect(res).toMatchObject({
+      outcome: 'approved',
+      execution: 'failed',
+      result: { ok: false, error: 'startKind and modes cannot be combined' },
+    });
+    expect(readdirSync(join(root, 'data/jobs'))).toHaveLength(0);
+    expect(readFileSync(join(root, 'data/applications.md'), 'utf-8')).not.toContain(
+      'Infrastructure Engineer',
+    );
+  });
+
   it('cancel executes nothing and emits confirm-resolved cancelled', () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',

--- a/test/unit/chat/confirms.test.ts
+++ b/test/unit/chat/confirms.test.ts
@@ -91,7 +91,7 @@ describe('chat confirms store', () => {
     });
   });
 
-  it('approve executes a set-status payload and emits confirm-resolved', () => {
+  it('approve executes a set-status payload and emits confirm-resolved', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'set-status',
@@ -99,7 +99,7 @@ describe('chat confirms store', () => {
       summary: 's',
       meta: 'm',
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('approved');
     expect(res.result).toMatchObject({ ok: true });
     const md = readFileSync(join(root, 'data/applications.md'), 'utf-8');
@@ -120,7 +120,7 @@ describe('chat confirms store', () => {
       summary: 's',
       meta: 'm',
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('approved');
     expect(res.result).toMatchObject({ ok: true });
     const files = readdirSync(join(root, 'data/jobs')).filter(f => f.endsWith('.json'));
@@ -132,7 +132,7 @@ describe('chat confirms store', () => {
     expect(spawnJobMock).toHaveBeenCalledTimes(1);
   });
 
-  it('approve executes an exact cancel-job payload through the shared lifecycle', () => {
+  it('approve executes an exact cancel-job payload through the shared lifecycle', async () => {
     const jobId = '0123456789abcdef';
     writeFileSync(
       join(root, 'data/jobs', `${jobId}.json`),
@@ -155,7 +155,7 @@ describe('chat confirms store', () => {
       summary: 'Cancel evaluation for offer #1001',
       meta: `job ${jobId}`,
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res).toMatchObject({
       outcome: 'approved',
       execution: 'succeeded',
@@ -163,7 +163,7 @@ describe('chat confirms store', () => {
     });
   });
 
-  it('records an unchanged execution when a cancel approval arrives after completion', () => {
+  it('records an unchanged execution when a cancel approval arrives after completion', async () => {
     const jobId = '0123456789abcdee';
     writeFileSync(
       join(root, 'data/jobs', `${jobId}.json`),
@@ -187,7 +187,7 @@ describe('chat confirms store', () => {
       meta: `job ${jobId}`,
     });
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
 
     expect(res).toMatchObject({
       outcome: 'approved',
@@ -215,7 +215,7 @@ describe('chat confirms store', () => {
       summary: 'Create offer from pasted text',
       meta: 'local tracker write · then start cover letter',
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res).toMatchObject({
       outcome: 'approved',
       result: {
@@ -251,7 +251,7 @@ describe('chat confirms store', () => {
       summary: 'Create, screen, and evaluate offer',
       meta: 'local tracker write · then start screen + evaluate',
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res).toMatchObject({
       outcome: 'approved',
       result: {
@@ -286,7 +286,7 @@ describe('chat confirms store', () => {
       meta: 'screening → evaluation',
     });
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
 
     expect(res).toMatchObject({
       outcome: 'approved',
@@ -324,7 +324,7 @@ describe('chat confirms store', () => {
       meta: 'local tracker write · screening → evaluation → cover letter',
     });
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
 
     expect(res).toMatchObject({
       outcome: 'approved',
@@ -351,7 +351,7 @@ describe('chat confirms store', () => {
     expect(spawnJobMock).toHaveBeenCalledTimes(1);
   });
 
-  it('defensively rejects a persisted text-offer payload that combines legacy and workflow modes', () => {
+  it('defensively rejects a persisted text-offer payload that combines legacy and workflow modes', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'create-offer-from-text',
@@ -366,7 +366,7 @@ describe('chat confirms store', () => {
       meta: 'invalid persisted payload',
     });
 
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
 
     expect(res).toMatchObject({
       outcome: 'approved',
@@ -379,7 +379,7 @@ describe('chat confirms store', () => {
     );
   });
 
-  it('cancel executes nothing and emits confirm-resolved cancelled', () => {
+  it('cancel executes nothing and emits confirm-resolved cancelled', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'start-job',
@@ -387,7 +387,7 @@ describe('chat confirms store', () => {
       summary: 's',
       meta: 'm',
     });
-    const res = confirms.resolveConfirm(root, token, false);
+    const res = await confirms.resolveConfirm(root, token, false);
     expect(res.outcome).toBe('cancelled');
     expect(res.result).toBeUndefined();
     expect(readdirSync(join(root, 'data/jobs'))).toHaveLength(0);
@@ -398,7 +398,7 @@ describe('chat confirms store', () => {
     });
   });
 
-  it('double-resolve: the second resolve returns expired and executes nothing', () => {
+  it('double-resolve: the second resolve returns expired and executes nothing', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'set-status',
@@ -406,8 +406,8 @@ describe('chat confirms store', () => {
       summary: 's',
       meta: 'm',
     });
-    confirms.resolveConfirm(root, token, false);
-    const second = confirms.resolveConfirm(root, token, true);
+    await confirms.resolveConfirm(root, token, false);
+    const second = await confirms.resolveConfirm(root, token, true);
     expect(second.outcome).toBe('expired');
     // 1 confirm + 1 confirm-resolved — the expired path emits nothing.
     expect(emitTurnEventMock).toHaveBeenCalledTimes(2);
@@ -417,7 +417,7 @@ describe('chat confirms store', () => {
     expect(readFileSync(join(root, 'data/applications.md'), 'utf-8')).toContain('| Screened  |');
   });
 
-  it('a confirm expires after 15 minutes and never executes', () => {
+  it('a confirm expires after 15 minutes and never executes', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-18T12:00:00Z'));
     const { token } = confirms.createConfirm(root, {
@@ -428,14 +428,14 @@ describe('chat confirms store', () => {
       meta: 'm',
     });
     vi.setSystemTime(new Date('2026-07-18T12:16:00Z'));
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('expired');
     expect(res.result).toBeUndefined();
     expect(readFileSync(join(root, 'data/applications.md'), 'utf-8')).toContain('| Screened  |');
     expect(emitTurnEventMock).toHaveBeenCalledTimes(1); // only the original confirm event
   });
 
-  it('an execution failure surfaces as ok:false without breaking resolution', () => {
+  it('an execution failure surfaces as ok:false without breaking resolution', async () => {
     const { token } = confirms.createConfirm(root, {
       turnId: 'turn-1',
       kind: 'start-job',
@@ -443,7 +443,7 @@ describe('chat confirms store', () => {
       summary: 's',
       meta: 'm',
     });
-    const res = confirms.resolveConfirm(root, token, true);
+    const res = await confirms.resolveConfirm(root, token, true);
     expect(res.outcome).toBe('approved');
     expect(res.result).toMatchObject({ ok: false });
     if (res.result && res.result.ok === false) {

--- a/test/unit/chat/mcp-action-tools.test.ts
+++ b/test/unit/chat/mcp-action-tools.test.ts
@@ -7,6 +7,7 @@
 // the human, then re-call with terminalApproved: true.
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { JOB_MODE_IDS } from '@/lib/modes/catalog';
 import { McpTestClient, type MockApp, startMockApp } from './mcp-test-utils';
 
 const CONFIRM_RESPONSE = {
@@ -35,8 +36,173 @@ describe('mcp-app-server — action tools', () => {
     const res = await client.request(2, 'tools/list');
     const names = res.result.tools.map((t: { name: string }) => t.name);
     expect(names).toEqual(
-      expect.arrayContaining(['start_job', 'cancel_job', 'set_status', 'edit_report', 'navigate']),
+      expect.arrayContaining([
+        'list_modes',
+        'get_mode_instructions',
+        'start_workflow',
+        'list_workflows',
+        'cancel_workflow',
+        'start_job',
+        'cancel_job',
+        'set_status',
+        'edit_report',
+        'navigate',
+      ]),
     );
+    const startJob = res.result.tools.find((tool: { name: string }) => tool.name === 'start_job');
+    expect([...startJob.inputSchema.properties.kind.enum].sort()).toEqual([...JOB_MODE_IDS].sort());
+  });
+
+  it('lists canonical modes and loads inline instructions', async () => {
+    app = await startMockApp({
+      'GET /api/chat/modes': {
+        status: 200,
+        body: { modes: [{ id: 'tracker', execution: 'inline' }] },
+      },
+      'GET /api/chat/modes/tracker': {
+        status: 200,
+        body: { id: 'tracker', execution: 'inline', instructions: '# Tracker' },
+      },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url });
+    await client.initialize();
+
+    const listed = await client.request(2, 'tools/call', {
+      name: 'list_modes',
+      arguments: {},
+    });
+    const loaded = await client.request(3, 'tools/call', {
+      name: 'get_mode_instructions',
+      arguments: { mode: 'tracker' },
+    });
+
+    expect(JSON.parse(listed.result.content[0].text).modes[0].id).toBe('tracker');
+    expect(JSON.parse(loaded.result.content[0].text).instructions).toContain('# Tracker');
+  });
+
+  it('starts a selected-offer multi-mode workflow behind one confirmation', async () => {
+    app = await startMockApp({
+      'POST /api/chat/actions/start-workflow': {
+        status: 200,
+        body: {
+          needsConfirm: true,
+          token: 'tok-workflow',
+          summary: 'Run 3 modes for offer #7',
+          meta: 'screen → evaluate → cover letter',
+        },
+      },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url, SUR9E_CHAT_TURN_ID: 'turn-42' });
+    await client.initialize();
+
+    const res = await client.request(2, 'tools/call', {
+      name: 'start_workflow',
+      arguments: {
+        targets: [{ num: 7 }],
+        modes: ['screen', 'evaluate', 'cover-letter'],
+        guidance: 'Focus on platform work.',
+      },
+    });
+
+    expect(JSON.parse(res.result.content[0].text).token).toBe('tok-workflow');
+    expect(app.requests[0].body).toEqual({
+      targets: [{ num: 7 }],
+      modes: ['screen', 'evaluate', 'cover-letter'],
+      guidance: 'Focus on platform work.',
+    });
+  });
+
+  it('requires terminal approval once, then relays a started workflow', async () => {
+    app = await startMockApp({
+      'POST /api/chat/actions/start-workflow': req =>
+        (req.body as Record<string, unknown>).terminalApproved === true
+          ? {
+              status: 200,
+              body: {
+                started: true,
+                workflow: { id: '0123456789abcdef', status: 'running' },
+                jobs: [{ id: 'fedcba9876543210', type: 'evaluate', status: 'queued' }],
+              },
+            }
+          : {
+              status: 200,
+              body: { needsConfirm: true, summary: 'Run evaluation', meta: 'evaluation' },
+            },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url });
+    await client.initialize();
+
+    const pending = await client.request(2, 'tools/call', {
+      name: 'start_workflow',
+      arguments: { targets: [{ num: 7 }], modes: ['evaluate'] },
+    });
+    const approved = await client.request(3, 'tools/call', {
+      name: 'start_workflow',
+      arguments: {
+        targets: [{ num: 7 }],
+        modes: ['evaluate'],
+        terminalApproved: true,
+      },
+    });
+
+    expect(JSON.parse(pending.result.content[0].text).instructions).toContain('terminalApproved');
+    expect(JSON.parse(approved.result.content[0].text)).toMatchObject({
+      started: true,
+      workflow: { id: '0123456789abcdef' },
+      jobs: [{ type: 'evaluate' }],
+    });
+  });
+
+  it('lists and confirmation-gates workflow cancellation', async () => {
+    app = await startMockApp({
+      'GET /api/workflows': {
+        status: 200,
+        body: { workflows: [{ id: '0123456789abcdef', status: 'running' }] },
+      },
+      'POST /api/chat/actions/cancel-workflow': {
+        status: 200,
+        body: { needsConfirm: true, token: 'tok-cancel-workflow' },
+      },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url, SUR9E_CHAT_TURN_ID: 'turn-42' });
+    await client.initialize();
+
+    const listed = await client.request(2, 'tools/call', {
+      name: 'list_workflows',
+      arguments: {},
+    });
+    const cancelled = await client.request(3, 'tools/call', {
+      name: 'cancel_workflow',
+      arguments: { workflow_id: '0123456789abcdef' },
+    });
+
+    expect(JSON.parse(listed.result.content[0].text).workflows[0].status).toBe('running');
+    expect(JSON.parse(cancelled.result.content[0].text).token).toBe('tok-cancel-workflow');
+    expect(app.requests[1].body).toEqual({ workflowId: '0123456789abcdef' });
+  });
+
+  it('rejects malformed mode-instruction and workflow calls without claiming success', async () => {
+    app = await startMockApp({
+      'POST /api/chat/actions/start-workflow': {
+        status: 400,
+        body: { error: 'at least one mode is required' },
+      },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url });
+    await client.initialize();
+
+    const missingMode = await client.request(2, 'tools/call', {
+      name: 'get_mode_instructions',
+      arguments: {},
+    });
+    const malformedWorkflow = await client.request(3, 'tools/call', {
+      name: 'start_workflow',
+      arguments: { targets: [{ num: 7 }] },
+    });
+
+    expect(missingMode.result.isError).toBe(true);
+    expect(malformedWorkflow.result.isError).toBe(true);
+    expect(malformedWorkflow.result.content[0].text).toContain('at least one mode');
   });
 
   it('advertises tracked pasted-text screening by offer number', async () => {
@@ -44,6 +210,9 @@ describe('mcp-app-server — action tools', () => {
     await client.initialize();
     const res = await client.request(2, 'tools/list');
     const startJob = res.result.tools.find((tool: { name: string }) => tool.name === 'start_job');
+    expect(startJob.description).toContain(
+      'use screen-evaluate only when the user explicitly asks for both',
+    );
     expect(startJob.inputSchema.properties.params.description).toContain(
       'screen or screen-evaluate with { "num": <tracker number> }',
     );
@@ -84,7 +253,35 @@ describe('mcp-app-server — action tools', () => {
     });
   });
 
-  it('advertises and forwards the recommended create + screen + evaluate workflow', async () => {
+  it('create_offer_from_text forwards a multi-mode workflow and not legacy start_kind', async () => {
+    app = await startMockApp({
+      'POST /api/chat/actions/create-offer-from-text': {
+        status: 200,
+        body: { needsConfirm: true, token: 'tok-text-workflow' },
+      },
+    });
+    client = new McpTestClient({ SUR9E_APP_URL: app.url, SUR9E_CHAT_TURN_ID: 'turn-42' });
+    await client.initialize();
+
+    await client.request(2, 'tools/call', {
+      name: 'create_offer_from_text',
+      arguments: {
+        text: 'Build the platform.',
+        company: 'Acme',
+        role: 'Engineer',
+        modes: ['screen', 'evaluate'],
+      },
+    });
+
+    expect(app.requests[0].body).toEqual({
+      text: 'Build the platform.',
+      company: 'Acme',
+      role: 'Engineer',
+      modes: ['screen', 'evaluate'],
+    });
+  });
+
+  it('allows an explicitly requested combined workflow without recommending it', async () => {
     app = await startMockApp({
       'POST /api/chat/actions/create-offer-from-text': {
         status: 200,
@@ -103,8 +300,14 @@ describe('mcp-app-server — action tools', () => {
       (candidate: { name: string }) => candidate.name === 'create_offer_from_text',
     );
     expect(tool.inputSchema.properties.start_kind.enum).toContain('screen-evaluate');
-    expect(tool.description).toContain('Create + screen + evaluate');
-    expect(tool.description).toContain('recommended');
+    expect(tool.description).toMatch(/screening and evaluation are separate modes/i);
+    expect(tool.description).toContain(
+      'screen-evaluate only when the user explicitly asks for both',
+    );
+    expect(tool.description).not.toContain('recommended');
+    expect(tool.inputSchema.properties.start_kind.description).toContain(
+      'only when the user explicitly asks for both',
+    );
 
     await client.request(3, 'tools/call', {
       name: 'create_offer_from_text',

--- a/test/unit/chat/mcp-e2e.test.ts
+++ b/test/unit/chat/mcp-e2e.test.ts
@@ -1,7 +1,8 @@
 // test/unit/chat/mcp-e2e.test.ts
 //
 // One MCP session end-to-end against a single server process:
-// initialize → initialized → tools/list → get_tracker → start_job
+// initialize → initialized → tools/list → list_modes → get_tracker →
+// start_workflow → start_job
 // (needs_confirm). Complements the per-tool suites by proving the frame
 // ordering holds across a whole conversation on one stdio stream.
 
@@ -23,6 +24,22 @@ describe('mcp-app-server — full session', () => {
         status: 200,
         body: { entries: [{ num: 7, company: 'Acme', status: 'evaluated' }], count: 1 },
       },
+      'GET /api/chat/modes': {
+        status: 200,
+        body: {
+          modes: [{ id: 'screen', execution: 'background', scope: 'offer' }],
+          aliases: {},
+        },
+      },
+      'POST /api/chat/actions/start-workflow': {
+        status: 200,
+        body: {
+          needsConfirm: true,
+          token: 'tok-workflow',
+          summary: 'Run 2 modes for 1 target',
+          meta: 'screening → evaluation',
+        },
+      },
       'POST /api/chat/actions/start-job': {
         status: 200,
         body: {
@@ -39,34 +56,58 @@ describe('mcp-app-server — full session', () => {
     const init = await client.initialize();
     expect(init.result.serverInfo.name).toBe('sur9e-app');
 
-    // 2. Discovery: all nine tools
+    // 2. Discovery: every public MCP tool
     const list = await client.request(2, 'tools/list');
     const names = list.result.tools.map((t: { name: string }) => t.name).sort();
     expect(names).toEqual(
       [
         'edit_report',
         'cancel_job',
+        'cancel_workflow',
         'create_offer_from_text',
+        'get_mode_instructions',
         'get_pipeline',
         'get_profile_summary',
         'get_report',
         'get_tracker',
         'list_jobs',
+        'list_modes',
+        'list_workflows',
         'navigate',
         'set_status',
         'start_job',
+        'start_workflow',
       ].sort(),
     );
 
-    // 3. Read
-    const tracker = await client.request(3, 'tools/call', {
+    // 3. Canonical mode discovery
+    const modes = await client.request(3, 'tools/call', {
+      name: 'list_modes',
+      arguments: {},
+    });
+    expect(JSON.parse(modes.result.content[0].text).modes[0].id).toBe('screen');
+
+    // 4. Tracker read
+    const tracker = await client.request(4, 'tools/call', {
       name: 'get_tracker',
       arguments: {},
     });
     expect(JSON.parse(tracker.result.content[0].text).count).toBe(1);
 
-    // 4. Confirm-gated action: never {started:true} straight from the model turn
-    const start = await client.request(4, 'tools/call', {
+    // 5. A multi-mode request receives one workflow confirmation.
+    const workflow = await client.request(5, 'tools/call', {
+      name: 'start_workflow',
+      arguments: {
+        targets: [{ num: 7 }],
+        modes: ['screen', 'evaluate'],
+      },
+    });
+    const workflowData = JSON.parse(workflow.result.content[0].text);
+    expect(workflowData.needsConfirm).toBe(true);
+    expect(workflowData.token).toBe('tok-workflow');
+
+    // 6. Single-job confirmation remains backward compatible.
+    const start = await client.request(6, 'tools/call', {
       name: 'start_job',
       arguments: { kind: 'tailor-cv', params: { num: 7 } },
     });
@@ -77,6 +118,8 @@ describe('mcp-app-server — full session', () => {
     expect(app.requests.at(-1)?.headers['x-sur9e-turn']).toBe('turn-e2e');
 
     // Frame ids stayed matched throughout — no interleaving corruption.
-    expect([init.id, list.id, tracker.id, start.id]).toEqual([1, 2, 3, 4]);
+    expect([init.id, list.id, modes.id, tracker.id, workflow.id, start.id]).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
   });
 });

--- a/test/unit/chat/mode-catalog.test.ts
+++ b/test/unit/chat/mode-catalog.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_DISCOVERABLE_MODES,
+  JOB_MODE_IDS,
+  MODE_ALIASES,
+  MODE_CATALOG,
+  resolveModeId,
+} from '@/lib/modes/catalog';
+import { JOB_TYPES } from '@/lib/schemas/jobs';
+
+const ROOT = process.cwd();
+
+describe('mode catalog', () => {
+  it('classifies every public content mode exactly once', () => {
+    const files = readdirSync(join(ROOT, 'content', 'modes'))
+      .filter(name => name.endsWith('.md') && name !== '_shared.md')
+      .map(name => name.replace(/\.md$/, ''))
+      .sort();
+
+    expect(
+      Object.keys(MODE_CATALOG)
+        .filter(id => id !== 'screen-evaluate' && id !== 'scan')
+        .sort(),
+    ).toEqual(files);
+    for (const mode of Object.values(MODE_CATALOG)) {
+      expect(['background', 'inline', 'handoff', 'composite']).toContain(mode.execution);
+    }
+  });
+
+  it('resolves every legacy alias to a canonical mode', () => {
+    for (const [alias, canonical] of Object.entries(MODE_ALIASES)) {
+      expect(MODE_CATALOG[canonical]).toBeDefined();
+      expect(resolveModeId(alias)).toBe(canonical);
+    }
+    expect(resolveModeId('outreach')).toBe('reach-out');
+    expect(resolveModeId('not-a-mode')).toBeNull();
+  });
+
+  it('makes every canonical mode discoverable in chat', () => {
+    expect(CHAT_DISCOVERABLE_MODES.map(mode => mode.id).sort()).toEqual(
+      Object.keys(MODE_CATALOG).sort(),
+    );
+  });
+
+  it('marks composites and report dependencies explicitly', () => {
+    expect(MODE_CATALOG['screen-evaluate'].expandsTo).toEqual(['screen', 'evaluate']);
+    expect(MODE_CATALOG['evaluate-offer'].expandsTo).toEqual(['screen', 'evaluate']);
+    expect(MODE_CATALOG['process-queue'].expandsTo).toEqual(['screen']);
+    expect(MODE_CATALOG.research.requiresEvaluation).toBe(true);
+    expect(MODE_CATALOG['tailor-cv'].requiresEvaluation).toBe(true);
+  });
+
+  it('derives the persisted job schema from catalog single-job declarations', () => {
+    expect([...JOB_TYPES].sort()).toEqual([...JOB_MODE_IDS].sort());
+    expect(JOB_MODE_IDS).toContain('screen-evaluate');
+    expect(JOB_MODE_IDS).not.toContain('evaluate-offer');
+  });
+});

--- a/test/unit/chat/mode-routes.test.ts
+++ b/test/unit/chat/mode-routes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { GET as getMode } from '@/app/api/chat/modes/[mode]/route';
+import { GET as listModes } from '@/app/api/chat/modes/route';
+import { MODE_ALIASES, MODE_CATALOG } from '@/lib/modes/catalog';
+
+describe('chat mode routes', () => {
+  it('returns the complete canonical catalog and alias map', async () => {
+    const response = await listModes();
+    const body = await response.json();
+
+    expect(body.modes.map((mode: { id: string }) => mode.id).sort()).toEqual(
+      Object.keys(MODE_CATALOG).sort(),
+    );
+    expect(body.aliases).toEqual(MODE_ALIASES);
+  });
+
+  it('resolves aliases and returns canonical inline instructions', async () => {
+    const response = await getMode(new Request('http://localhost/api/chat/modes/followup'), {
+      params: Promise.resolve({ mode: 'followup' }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.canonicalMode).toBe('follow-up');
+    expect(body.execution).toBe('inline');
+    expect(body.instructions).toContain('# Mode: followup');
+  });
+
+  it('returns protected handoff guidance and rejects unknown modes', async () => {
+    const apply = await getMode(new Request('http://localhost/api/chat/modes/apply'), {
+      params: Promise.resolve({ mode: 'apply' }),
+    });
+    const missing = await getMode(new Request('http://localhost/api/chat/modes/nope'), {
+      params: Promise.resolve({ mode: 'nope' }),
+    });
+
+    expect(await apply.json()).toMatchObject({
+      canonicalMode: 'apply',
+      execution: 'handoff',
+      handoff: '/sur9e apply <offer-number>',
+    });
+    expect(missing.status).toBe(404);
+  });
+
+  it('loads canonical instructions for every inline and handoff mode', async () => {
+    for (const mode of Object.values(MODE_CATALOG).filter(candidate =>
+      ['inline', 'handoff'].includes(candidate.execution),
+    )) {
+      const response = await getMode(new Request(`http://localhost/api/chat/modes/${mode.id}`), {
+        params: Promise.resolve({ mode: mode.id }),
+      });
+      const body = await response.json();
+
+      expect(response.status, mode.id).toBe(200);
+      expect(body.instructions.length, mode.id).toBeGreaterThan(100);
+      if (mode.execution === 'handoff') {
+        expect(body.handoff, mode.id).toMatch(/^\/sur9e /);
+      }
+    }
+  });
+});

--- a/test/unit/chat/prompt.test.ts
+++ b/test/unit/chat/prompt.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { MODE_CATALOG } from '@/lib/modes/catalog';
 import { ChatMessage } from '@/lib/schemas/chat';
 import {
   buildChatSystemPrompt,
@@ -32,34 +33,19 @@ describe('buildChatSystemPrompt', () => {
     expect(prompt).toContain('confirmation');
   });
 
-  it('routes the 8 interactive modes and the job kinds', () => {
-    for (const mode of [
-      'enrich',
-      'offers',
-      'tracker',
-      'patterns',
-      'follow-up',
-      'process-queue',
-      'training',
-      'project',
-    ]) {
+  it('routes every canonical catalog mode', () => {
+    for (const mode of Object.keys(MODE_CATALOG)) {
       expect(prompt).toContain(`- ${mode} —`);
     }
-    for (const job of [
-      'evaluate',
-      'screen',
-      'screen-evaluate',
-      'research',
-      'tailor-cv',
-      'cover-letter',
-      'interview-prep',
-      'reach-out',
-      'negotiate',
-      'scan',
-      'batch-evaluate',
-    ]) {
-      expect(prompt).toContain(`- ${job} —`);
-    }
+  });
+
+  it('uses durable workflows for multi-mode and selected-bulk requests', () => {
+    expect(prompt).toContain('start_workflow');
+    expect(prompt).toContain('list_workflows');
+    expect(prompt).toContain('cancel_workflow');
+    expect(prompt).toContain('dependency-aware');
+    expect(prompt).toContain('one confirmation');
+    expect(prompt).toContain('get_mode_instructions');
   });
 
   it('treats a pasted-text Screened/N/A offer as unscreened and screenable by number', () => {
@@ -69,12 +55,15 @@ describe('buildChatSystemPrompt', () => {
     expect(prompt).toContain('does not require a URL');
   });
 
-  it('offers the approved pasted-text workflows and recommends screening plus evaluation', () => {
-    expect(prompt).toContain('Create + screen + evaluate');
-    expect(prompt).toContain('recommended');
+  it('keeps screening and evaluation separate unless the user explicitly asks for both', () => {
+    expect(prompt).toContain('Treat screening and evaluation as separate modes');
     expect(prompt).toContain('Create + screen');
+    expect(prompt).toContain('Create + evaluate');
     expect(prompt).toContain('Create only');
-    expect(prompt).toContain('start_kind: screen-evaluate');
+    expect(prompt).toContain(
+      'Use screen-evaluate only when the user explicitly asks for both screening and evaluation',
+    );
+    expect(prompt).not.toContain('Create + screen + evaluate (recommended)');
   });
 
   it('requires durable Markdown links when mentioning internal app pages', () => {

--- a/test/unit/chat/workflow-schemas.test.ts
+++ b/test/unit/chat/workflow-schemas.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowTargetInput } from '@/lib/schemas/chat-actions';
+import { WorkflowRecord, WorkflowTarget } from '@/lib/schemas/workflows';
+
+describe('workflow schemas', () => {
+  it('accepts only HTTP(S) workflow URLs', () => {
+    expect(WorkflowTargetInput.safeParse({ url: 'https://example.com/jobs/1' }).success).toBe(true);
+    expect(WorkflowTargetInput.safeParse({ url: 'http://example.com/jobs/1' }).success).toBe(true);
+    expect(WorkflowTargetInput.safeParse({ url: 'ftp://example.com/jobs/1' }).success).toBe(false);
+  });
+
+  it('retains the source URL when a screened target also has an offer number', () => {
+    expect(WorkflowTarget.parse({ url: 'https://example.com/jobs/1', num: 42 })).toEqual({
+      url: 'https://example.com/jobs/1',
+      num: 42,
+    });
+  });
+
+  it('requires persisted workflow ids to use the generated hex shape', () => {
+    expect(WorkflowRecord.shape.id.safeParse('0123456789abcdef').success).toBe(true);
+    expect(WorkflowRecord.shape.id.safeParse('../../outside1234').success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- add one canonical catalog for all public chat/MCP modes and legacy aliases
- add durable dependency-aware workflows for single offers, multi-mode sequences, safe parallel execution, selected-offer bulk actions, and singleton system modes
- keep screening and evaluation as separate sequential child jobs
- add MCP mode discovery, workflow start/list/cancel tools, text-offer workflow support, internal offer links, and completion messages
- add workflow confirmation UI integration, cancellation, partial failure handling, active-job reuse, concurrency limits, and restart reconciliation
- add distinct LaTeX CV output and comprehensive catalog, planner, JSON-RPC, confirmation, job, and mode-runner regression coverage

## Why

Chat previously treated screening and evaluation as a combined action and had no durable orchestration model for multiple modes or offers. MCP, prompt, slash-command, confirmation, and runtime mode definitions could also drift independently. This caused invalid combinations, missing links, incomplete follow-on actions, and fragile cancellation behavior.

## User impact

The chat agent can now invoke every supported mode as a single job, a safe dependency-ordered workflow, or a selected-offer bulk action. Created offers return usable internal links, workflows survive reload/restart, and each child job remains independently visible and cancellable.

Apply remains a handoff and never submits an application automatically.

## Validation

- `npm run test:quick` — 100 passed, 0 failed, 0 warnings
- `npm run build` — successful, all 42 app routes/pages generated
- real local MCP JSON-RPC smoke — 16 tools, 22 modes, confirmation enforced
- production browser verification at 1280x800, 768x1024, and 375x667, covering full-page chat and the mobile bubble

The build retains the existing non-fatal Turbopack NFT tracing warning.