### PR TITLE
fix(chat): restore full-page file drops

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -1740,7 +1740,8 @@
 }
 
 /* ── Attachments ── */
-.chat-card[data-dragover] {
+.chat-card[data-dragover],
+.chat-page__main[data-dragover] {
   outline: 2px dashed var(--accent);
   outline-offset: -4px;
 }

--- a/src/features/chat/chat-card.tsx
+++ b/src/features/chat/chat-card.tsx
@@ -4,17 +4,17 @@
 // conversation orchestration (send, streaming, reattach, per-thread
 // isolation) lives in useConversation, shared with the /chat page.
 
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
 import { useChatStore } from '@/stores/chat-store';
 import { ChatComposer } from './chat-composer';
 import { ChatConversationContent } from './chat-conversation-content';
 import { ChatHeader } from './chat-header';
+import { useChatFileDrop } from './use-chat-file-drop';
 import { useConversation } from './use-conversation';
 
 export function ChatCard() {
   const closeChat = useChatStore(s => s.closeChat);
-  const [dragOver, setDragOver] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   useFocusTrap(cardRef, true);
 
@@ -23,6 +23,7 @@ export function ChatCard() {
   // /chat, so the two surfaces are never mounted at once and only one can win
   // the read-and-clear.
   const convo = useConversation({ consumeAutoSend: true });
+  const fileDrop = useChatFileDrop(convo.setDraftFiles);
 
   function onKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'Escape') {
@@ -38,21 +39,10 @@ export function ChatCard() {
       role="dialog"
       aria-label="sur9e chat"
       onKeyDown={onKeyDown}
-      data-dragover={dragOver || undefined}
-      onDragOver={e => {
-        // Drops are accepted mid-reply too — the dropped files become draft
-        // chips and Enter queues them for the post-'done' flush.
-        if (e.dataTransfer.types.includes('Files')) {
-          e.preventDefault();
-          setDragOver(true);
-        }
-      }}
-      onDragLeave={() => setDragOver(false)}
-      onDrop={e => {
-        e.preventDefault();
-        setDragOver(false);
-        convo.setDraftFiles(prev => [...prev, ...Array.from(e.dataTransfer.files)].slice(0, 8));
-      }}
+      data-dragover={fileDrop.dragOver || undefined}
+      onDragOver={fileDrop.onDragOver}
+      onDragLeave={fileDrop.onDragLeave}
+      onDrop={fileDrop.onDrop}
     >
       <ChatHeader />
       {/* Stream-status announcements for SR users. Status transitions only —

--- a/src/features/chat/chat-page.tsx
+++ b/src/features/chat/chat-page.tsx
@@ -12,6 +12,7 @@ import { ChatComposer } from './chat-composer';
 import { ChatConversationContent } from './chat-conversation-content';
 import { ChatJobsSlot } from './chat-jobs-slot';
 import { ChatThreadsSidebar } from './chat-threads-sidebar';
+import { useChatFileDrop } from './use-chat-file-drop';
 import { useChatUrlSync } from './use-chat-url-sync';
 import { useConversation } from './use-conversation';
 import { useMobileChatRedirect } from './use-mobile-chat-redirect';
@@ -25,6 +26,7 @@ export function ChatPage({ conversationId }: { conversationId?: string }) {
   // when the bubble takes over on a phone.
   const redirectingToBubble = useMobileChatRedirect();
   const convo = useConversation({ consumeAutoSend: true });
+  const fileDrop = useChatFileDrop(convo.setDraftFiles);
   // Snapshot at mount so the value can't change under an in-flight animation.
   // The store copy is cleared on a timer (below) rather than here: a first
   // message rewrites /chat → /chat/[id], which remounts this page, and the
@@ -53,7 +55,14 @@ export function ChatPage({ conversationId }: { conversationId?: string }) {
   return (
     <div className="chat-page" data-enter={entryOrigin ?? undefined}>
       <ChatThreadsSidebar />
-      <section className="chat-page__main" aria-label="Conversation">
+      <section
+        className="chat-page__main"
+        aria-label="Conversation"
+        data-dragover={fileDrop.dragOver || undefined}
+        onDragOver={fileDrop.onDragOver}
+        onDragLeave={fileDrop.onDragLeave}
+        onDrop={fileDrop.onDrop}
+      >
         <header className="chat-page__header">
           <span className="chat-page__title" title={headerTitle}>
             {headerTitle}

--- a/src/features/chat/use-chat-file-drop.ts
+++ b/src/features/chat/use-chat-file-drop.ts
@@ -17,7 +17,10 @@ export function useChatFileDrop(setFiles: React.Dispatch<React.SetStateAction<Fi
     setDragOver(true);
   }
 
-  function onDragLeave() {
+  function onDragLeave(event: React.DragEvent<HTMLElement>) {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
+      return;
+    }
     setDragOver(false);
   }
 

--- a/src/features/chat/use-chat-file-drop.ts
+++ b/src/features/chat/use-chat-file-drop.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+
+const MAX_CHAT_FILES = 8;
+
+/**
+ * Shared file-drop behavior for the bubble card and full-page conversation.
+ * Both surfaces feed the same draft-file state owned by useConversation.
+ */
+export function useChatFileDrop(setFiles: React.Dispatch<React.SetStateAction<File[]>>) {
+  const [dragOver, setDragOver] = useState(false);
+
+  function onDragOver(event: React.DragEvent<HTMLElement>) {
+    if (!event.dataTransfer.types.includes('Files')) return;
+    event.preventDefault();
+    setDragOver(true);
+  }
+
+  function onDragLeave() {
+    setDragOver(false);
+  }
+
+  function onDrop(event: React.DragEvent<HTMLElement>) {
+    event.preventDefault();
+    setDragOver(false);
+    setFiles(previous =>
+      [...previous, ...Array.from(event.dataTransfer.files)].slice(0, MAX_CHAT_FILES),
+    );
+  }
+
+  return { dragOver, onDragLeave, onDragOver, onDrop };
+}

--- a/test/components/chat-page-file-drop.test.tsx
+++ b/test/components/chat-page-file-drop.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatPage } from '@/features/chat/chat-page';
+import { useChatStore } from '@/stores/chat-store';
+
+const setDraftFiles = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/use-chat-sessions', () => ({
+  useChatSessions: () => ({ data: [] }),
+}));
+
+vi.mock('@/features/chat/chat-composer', () => ({
+  ChatComposer: () => <div data-testid="composer" />,
+}));
+
+vi.mock('@/features/chat/chat-conversation-content', () => ({
+  ChatConversationContent: () => <div data-testid="conversation" />,
+}));
+
+vi.mock('@/features/chat/chat-jobs-slot', () => ({
+  ChatJobsSlot: () => null,
+}));
+
+vi.mock('@/features/chat/chat-threads-sidebar', () => ({
+  ChatThreadsSidebar: () => null,
+}));
+
+vi.mock('@/features/chat/use-chat-url-sync', () => ({
+  useChatUrlSync: () => undefined,
+}));
+
+vi.mock('@/features/chat/use-mobile-chat-redirect', () => ({
+  useMobileChatRedirect: () => false,
+}));
+
+vi.mock('@/features/chat/use-conversation', () => ({
+  useConversation: () => ({
+    conversationStatus: 'ready',
+    draftFiles: [],
+    retry: vi.fn(),
+    send: vi.fn(),
+    sendError: null,
+    setDraftFiles,
+    stop: vi.fn(),
+    streaming: false,
+    turnStatus: 'idle',
+  }),
+}));
+
+describe('ChatPage file drop', () => {
+  beforeEach(() => {
+    setDraftFiles.mockClear();
+    useChatStore.setState({
+      activeConversationId: null,
+      chatEntryOrigin: null,
+    });
+  });
+
+  it('adds files dropped on the full-page conversation to the draft', () => {
+    const { container } = render(<ChatPage />);
+    const conversation = container.querySelector('.chat-page__main');
+    if (!(conversation instanceof HTMLElement)) throw new Error('conversation surface missing');
+    const file = new File([new Uint8Array([1])], 'cv.pdf', { type: 'application/pdf' });
+
+    fireEvent.drop(conversation, {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+
+    expect(setDraftFiles).toHaveBeenCalledTimes(1);
+    const update = setDraftFiles.mock.calls[0][0] as (previous: File[]) => File[];
+    expect(update([])).toEqual([file]);
+  });
+
+  it('shows and clears the same drag-over state as the bubble chat', () => {
+    const { container } = render(<ChatPage />);
+    const conversation = container.querySelector('.chat-page__main');
+    if (!(conversation instanceof HTMLElement)) throw new Error('conversation surface missing');
+    const dataTransfer = { files: [], types: ['Files'] };
+
+    fireEvent.dragOver(conversation, { dataTransfer });
+    expect(conversation).toHaveAttribute('data-dragover');
+
+    fireEvent.dragLeave(conversation, { dataTransfer });
+    expect(conversation).not.toHaveAttribute('data-dragover');
+  });
+});

--- a/test/components/chat-page-file-drop.test.tsx
+++ b/test/components/chat-page-file-drop.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { createEvent, fireEvent, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatPage } from '@/features/chat/chat-page';
 import { useChatStore } from '@/stores/chat-store';
@@ -61,6 +61,9 @@ describe('ChatPage file drop', () => {
     const conversation = container.querySelector('.chat-page__main');
     if (!(conversation instanceof HTMLElement)) throw new Error('conversation surface missing');
     const file = new File([new Uint8Array([1])], 'cv.pdf', { type: 'application/pdf' });
+    const secondFile = new File([new Uint8Array([2])], 'cover-letter.pdf', {
+      type: 'application/pdf',
+    });
 
     fireEvent.drop(conversation, {
       dataTransfer: { files: [file], types: ['Files'] },
@@ -69,15 +72,35 @@ describe('ChatPage file drop', () => {
     expect(setDraftFiles).toHaveBeenCalledTimes(1);
     const update = setDraftFiles.mock.calls[0][0] as (previous: File[]) => File[];
     expect(update([])).toEqual([file]);
+
+    fireEvent.drop(conversation, {
+      dataTransfer: { files: [file, secondFile], types: ['Files'] },
+    });
+
+    const cappedUpdate = setDraftFiles.mock.calls[1][0] as (previous: File[]) => File[];
+    const existingFiles = Array.from(
+      { length: 7 },
+      (_, index) => new File([String(index)], `existing-${index}.txt`),
+    );
+    expect(cappedUpdate(existingFiles)).toEqual([...existingFiles, file]);
   });
 
-  it('shows and clears the same drag-over state as the bubble chat', () => {
+  it('keeps drag-over state between descendants and clears it on surface exit', () => {
     const { container } = render(<ChatPage />);
     const conversation = container.querySelector('.chat-page__main');
     if (!(conversation instanceof HTMLElement)) throw new Error('conversation surface missing');
+    const descendant = conversation.querySelector('[data-testid="conversation"]');
+    if (!(descendant instanceof HTMLElement)) throw new Error('conversation descendant missing');
+    const nextDescendant = conversation.querySelector('[data-testid="composer"]');
+    if (!(nextDescendant instanceof HTMLElement)) throw new Error('composer descendant missing');
     const dataTransfer = { files: [], types: ['Files'] };
 
     fireEvent.dragOver(conversation, { dataTransfer });
+    expect(conversation).toHaveAttribute('data-dragover');
+
+    const nestedLeave = createEvent.dragLeave(descendant, { dataTransfer });
+    Object.defineProperty(nestedLeave, 'relatedTarget', { value: nextDescendant });
+    fireEvent(descendant, nestedLeave);
     expect(conversation).toHaveAttribute('data-dragover');
 
     fireEvent.dragLeave(conversation, { dataTransfer });

--- a/test/e2e/chat.spec.ts
+++ b/test/e2e/chat.spec.ts
@@ -296,7 +296,6 @@ for (const viewport of VIEWPORTS) {
       types: ['Files'],
     });
     await expect(surface).toHaveAttribute('data-dragover');
-    await page.screenshot({ path: `test-results/chat-file-drop-${viewport.name}.png` });
 
     await surface.evaluate(element => {
       const dataTransfer = new DataTransfer();

--- a/test/e2e/chat.spec.ts
+++ b/test/e2e/chat.spec.ts
@@ -245,6 +245,80 @@ for (const viewport of VIEWPORTS) {
 }
 
 for (const viewport of VIEWPORTS) {
+  test(`file drop reaches the active chat surface @ ${viewport.name}`, async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', error => pageErrors.push(error.message));
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockChatApi(page);
+    await page.goto('/chat');
+    await suppressDevOverlay(page);
+
+    const surface =
+      viewport.width <= 640
+        ? page.getByRole('dialog', { name: 'sur9e chat' })
+        : page.locator('.chat-page__main');
+    await expect(surface).toBeVisible();
+    await expect(page.locator('html')).toHaveClass(/boot-ready/);
+    expect(pageErrors).toEqual([]);
+    const input = surface.getByRole('textbox', { name: 'Message' });
+    await input.fill('hydration probe');
+    await expect(surface.getByRole('button', { name: 'Send message' })).toBeEnabled();
+    await input.fill('');
+    if (viewport.width <= 640) {
+      // Let the mobile card's entrance animation settle before capturing its
+      // drag-over treatment; otherwise the underlying Home page composites
+      // through the still-transparent card.
+      await page.waitForTimeout(350);
+    }
+
+    const dragOverResult = await surface.evaluate(element => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(
+        new File(['resume'], 'cv.pdf', {
+          type: 'application/pdf',
+        }),
+      );
+      const event = new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      });
+      const dispatched = element.dispatchEvent(event);
+      return {
+        defaultPrevented: event.defaultPrevented,
+        dispatched,
+        types: Array.from(dataTransfer.types),
+      };
+    });
+    expect(dragOverResult).toEqual({
+      defaultPrevented: true,
+      dispatched: false,
+      types: ['Files'],
+    });
+    await expect(surface).toHaveAttribute('data-dragover');
+    await page.screenshot({ path: `test-results/chat-file-drop-${viewport.name}.png` });
+
+    await surface.evaluate(element => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(
+        new File(['resume'], 'cv.pdf', {
+          type: 'application/pdf',
+        }),
+      );
+      element.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        }),
+      );
+    });
+    await expect(surface.getByText('cv.pdf', { exact: true })).toBeVisible();
+    await expect(surface).not.toHaveAttribute('data-dragover');
+  });
+}
+
+for (const viewport of VIEWPORTS) {
   test(`new full-page thread never flashes the empty state @ ${viewport.name}`, async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- share the bubble chat file-drop behavior with the full-page conversation
- preserve the existing eight-file cap, draft chips, and branded drag-over treatment
- add component regression coverage and three-width browser verification

## Root cause

The bubble card owned drag/drop handlers directly, while the full-page chat rendered the same composer without installing any drop target. The handlers now live in one shared hook used by both surfaces.

## Verification

- `npm run test:quick` (100/100)
- `npm run build`
- targeted Playwright file-drop test at 1280x800, 768x1024, and 375x667