### PR TITLE
fix(chat): compact attachments and narrow file tracing

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -781,7 +781,9 @@
 }
 .chat-msg--user {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
 }
 .chat-user-bubble {
   background: var(--accent-soft);
@@ -1773,12 +1775,25 @@
 .chat-attach-chip__thumb--sent {
   width: 56px;
   height: 56px;
+  flex-shrink: 0;
+}
+.chat-attach-chip__body {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
 }
 .chat-attach-chip__name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.chat-attach-chip__meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.3;
 }
 .chat-attach-chip__size {
   font-family: var(--font-mono);
@@ -1816,9 +1831,8 @@
   opacity: 0.4;
   cursor: default;
 }
-/* Composer-scoped preview-chip spec (Option A): warm surface-2 tile at the 6px
-   radius, filename truncated ~180px, snug above the textarea inside the box.
-   Sent-message chips (.chat-msg__attachments) keep the base look above. */
+/* Composer-scoped preview-chip spec: warm surface-2 tile at the 6px radius,
+   filename truncated ~180px, snug above the textarea inside the box. */
 .chat-attach-chips {
   padding: 2px 0 6px;
 }
@@ -1828,6 +1842,30 @@
 }
 .chat-attach-chips .chat-attach-chip__name {
   max-width: 180px;
+}
+.chat-msg__attachments {
+  width: min(100%, 320px);
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 0;
+}
+.chat-msg__attachments .chat-attach-chip {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px;
+  border-radius: var(--radius);
+}
+.chat-msg__attachments .chat-attach-chip__icon {
+  display: inline-flex;
+  width: 56px;
+  height: 56px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: var(--radius-2xs);
+  background: var(--surface-2);
+  font-size: 18px;
 }
 /* File/selection chip leading glyph — the ▤ file fallback and the selection
    chip's quote mark both live here; keep it a snug, muted, non-shrinking box. */

--- a/src/features/chat/message-view.tsx
+++ b/src/features/chat/message-view.tsx
@@ -22,6 +22,12 @@ function parseTurnEvents(events: unknown[] | null | undefined): ChatTurnEvent[] 
   return parsed.length ? parsed : null;
 }
 
+function attachmentTypeLabel(mime: string): string {
+  const [kind, rawSubtype] = mime.split('/');
+  const subtype = rawSubtype?.split('+')[0]?.toUpperCase() || 'FILE';
+  return `${subtype} ${kind === 'image' ? 'image' : 'file'}`;
+}
+
 /** Shared copy control: message-level and (via delegation) code blocks.
  * `inline` renders the always-visible icon variant used under AI replies;
  * the default stays the hover-revealed corner button on user bubbles.
@@ -224,7 +230,12 @@ export function MessageView({
                     ▤
                   </span>
                 )}
-                <span className="chat-attach-chip__name">{a.name}</span>
+                <span className="chat-attach-chip__body">
+                  <span className="chat-attach-chip__name" title={a.name}>
+                    {a.name}
+                  </span>
+                  <span className="chat-attach-chip__meta">{attachmentTypeLabel(a.mime)}</span>
+                </span>
               </span>
             ))}
           </div>

--- a/src/lib/server/onboarding-status.ts
+++ b/src/lib/server/onboarding-status.ts
@@ -27,7 +27,10 @@ const REQUIRED_FILES: Record<OnboardingMissing, string> = {
 /** Which required personalization files are missing under `root`. */
 export function getOnboardingStatus(root: string): OnboardingStatus {
   const missing = (Object.keys(REQUIRED_FILES) as OnboardingMissing[]).filter(
-    key => !existsSync(join(root, REQUIRED_FILES[key])),
+    key =>
+      !existsSync(
+        /* turbopackIgnore: true */ join(/* turbopackIgnore: true */ root, REQUIRED_FILES[key]),
+      ),
   );
   return { ready: missing.length === 0, missing };
 }

--- a/test/components/message-view.test.tsx
+++ b/test/components/message-view.test.tsx
@@ -128,6 +128,31 @@ describe('MessageView', () => {
     expect(getByText('shot.png')).toBeTruthy();
     expect(getByText('cv.pdf')).toBeTruthy();
     expect(container.querySelector('.chat-attach-chip__icon')).toBeTruthy();
+    expect(getByText('PNG image')).toBeTruthy();
+    expect(getByText('PDF file')).toBeTruthy();
+    expect(container.querySelectorAll('.chat-attach-chip__meta')).toHaveLength(2);
+    const userMessage = container.querySelector('.chat-msg--user');
+    expect(userMessage?.children[0]).toHaveClass('chat-user-bubble');
+    expect(userMessage?.children[1]).toHaveClass('chat-msg__attachments');
+  });
+
+  it('preserves full sent filenames while exposing compact truncation hooks', () => {
+    const longName = 'CleanShot 2026-07-30 at 08.33.24@2x with recruiter location details.png';
+    const { container, getByText } = render(
+      <MessageView
+        message={userMsg('that is what recruiter has said', {
+          attachments: [
+            { path: 'c1/long.png', name: longName, mime: 'image/png', size: 10 },
+            { path: 'c1/notes.txt', name: 'notes.txt', mime: 'text/plain', size: 20 },
+          ],
+        })}
+      />,
+    );
+
+    const attachments = container.querySelector('.chat-msg__attachments');
+    expect(attachments?.querySelectorAll('.chat-attach-chip')).toHaveLength(2);
+    expect(attachments?.querySelectorAll('.chat-attach-chip__body')).toHaveLength(2);
+    expect(getByText(longName)).toHaveAttribute('title', longName);
   });
 
   it('renders no attachment row for a user message without attachments', () => {

--- a/test/e2e/chat.spec.ts
+++ b/test/e2e/chat.spec.ts
@@ -318,6 +318,76 @@ for (const viewport of VIEWPORTS) {
 }
 
 for (const viewport of VIEWPORTS) {
+  test(`sent attachment stays below its user bubble @ ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await mockChatApi(page);
+    await page.goto('/chat');
+    await suppressDevOverlay(page);
+
+    const surface =
+      viewport.width <= 640
+        ? page.getByRole('dialog', { name: 'sur9e chat' })
+        : page.locator('.chat-page__main');
+    await expect(surface).toBeVisible();
+    const body = surface.locator('.chat-page__body, .chat-card__body');
+    await expect(body).toBeVisible();
+    await body.evaluate(element => {
+      element.innerHTML = `
+        <div class="chat-transcript">
+          <div class="chat-msg chat-msg--user">
+            <div class="chat-user-bubble">that is what recruiter has said</div>
+            <div class="chat-msg__attachments">
+              <span class="chat-attach-chip">
+                <img
+                  class="chat-attach-chip__thumb chat-attach-chip__thumb--sent"
+                  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nLkAAAAASUVORK5CYII="
+                  alt="CleanShot 2026-07-30 at 08.33.24@2x with recruiter location details.png"
+                />
+                <span class="chat-attach-chip__body">
+                  <span
+                    class="chat-attach-chip__name"
+                    title="CleanShot 2026-07-30 at 08.33.24@2x with recruiter location details.png"
+                  >
+                    CleanShot 2026-07-30 at 08.33.24@2x with recruiter location details.png
+                  </span>
+                  <span class="chat-attach-chip__meta">PNG image</span>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      `;
+    });
+    const message = surface.locator('.chat-msg--user');
+    const bubble = message.locator('.chat-user-bubble');
+    const attachment = message.locator('.chat-msg__attachments');
+    await expect(bubble).toHaveText('that is what recruiter has said');
+    await expect(attachment.getByText('PNG image')).toBeVisible();
+
+    const bubbleBox = await bubble.boundingBox();
+    const attachmentBox = await attachment.boundingBox();
+    expect(bubbleBox).not.toBeNull();
+    expect(attachmentBox).not.toBeNull();
+    expect(attachmentBox?.y).toBeGreaterThanOrEqual((bubbleBox?.y ?? 0) + (bubbleBox?.height ?? 0));
+    expect(attachmentBox?.width).toBeLessThanOrEqual(320);
+    expect(
+      Math.abs(
+        (attachmentBox?.x ?? 0) +
+          (attachmentBox?.width ?? 0) -
+          ((bubbleBox?.x ?? 0) + (bubbleBox?.width ?? 0)),
+      ),
+    ).toBeLessThanOrEqual(1);
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.scrollWidth))
+      .toBeLessThanOrEqual(viewport.width + 1);
+    if (viewport.width <= 640) {
+      await page.waitForTimeout(350);
+    }
+    await page.screenshot({ path: `test-results/chat-sent-attachment-${viewport.name}.png` });
+  });
+}
+
+for (const viewport of VIEWPORTS) {
   test(`new full-page thread never flashes the empty state @ ${viewport.name}`, async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- narrow Turbopack tracing around onboarding file checks so the personalization paths no longer trace the whole project
- render sent files as compact, right-aligned cards below the user message with truncated names and file-type metadata
- cover sent attachments and file drop behavior across desktop, tablet, and mobile chat surfaces

## Verification
- npm run test:quick
- npm run build
- PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test test/e2e/chat.spec.ts --grep "sent attachment stays below|file drop reaches"
- visual inspection at 1280x800, 768x1024, and 375x667