### PR TITLE
feat(triage): add GitHub issue triage workflow

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,6 +38,47 @@ reviews:
     - path: "test/e2e/**"
       instructions: "Browser tests must not mutate a developer's real personalization, tracker, reports, or generated artifacts."
 
+issue_enrichment:
+  auto_enrich:
+    enabled: true
+  labeling:
+    auto_apply_labels: true
+    labeling_instructions:
+      - label: type:bug
+        instructions: "Apply exactly one type: a reproducible defect where observed behavior differs from expected behavior."
+      - label: type:feature
+        instructions: "Apply exactly one type: a proposal for a new capability or user-visible improvement."
+      - label: type:question
+        instructions: "Apply exactly one type: a request for usage, setup, or contributor guidance."
+      - label: type:task
+        instructions: "Apply exactly one type: a scoped maintenance or contributor task rather than a bug, feature, or question."
+      - label: area:web
+        instructions: "Apply exactly one primary area when the local web UI, accessibility, or browser behavior is primarily affected."
+      - label: area:agent
+        instructions: "Apply exactly one primary area when agent modes, prompts, hooks, or AI integrations are primarily affected."
+      - label: area:jobs
+        instructions: "Apply exactly one primary area when job discovery, screening, evaluation, or application workflow is primarily affected."
+      - label: area:data
+        instructions: "Apply exactly one primary area when local data contracts, persistence, reports, or privacy boundaries are primarily affected."
+      - label: area:tooling
+        instructions: "Apply exactly one primary area when build tooling, CI, scripts, dependencies, or developer setup is primarily affected."
+      - label: area:docs
+        instructions: "Apply exactly one primary area when documentation, contributor guidance, or examples are primarily affected."
+      - label: priority:p0
+        instructions: "Apply exactly one priority for data loss, a security risk, or a broadly blocked core workflow."
+      - label: priority:p1
+        instructions: "Apply exactly one priority when a major workflow is materially impaired without a reasonable workaround."
+      - label: priority:p2
+        instructions: "Apply exactly one priority for valuable normal work that can follow the usual planning cadence."
+      - label: priority:p3
+        instructions: "Apply exactly one priority for low-urgency polish, a niche improvement, or work deferred by higher priorities."
+      - label: status:needs-info
+        instructions: "Apply status:needs-info only when material missing details block triage. You must not apply status:accepted, must not apply status:declined, must not apply any resolution: label, must not make acceptance decisions, must not make closure decisions, and must not make comments that purport to accept, decline, resolve, or close an issue; those are maintainer-only decisions."
+  planning:
+    enabled: false
+    auto_planning:
+      enabled: false
+
 chat:
   auto_reply: false
   allow_non_org_members: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: Bug report
+description: Report a reproducible problem in sur9e.
+title: "bug: "
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping improve sur9e. Please keep personal job-search data out of this issue.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead? Include the exact error when safe to share.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Give the smallest steps another contributor can follow.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and version
+      description: Include sur9e version or commit, OS, Node version, and browser when relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Optional safe evidence
+      description: Add redacted logs or screenshots only. Never include tokens, CVs, or personal data.
+  - type: checkboxes
+    id: privacy_confirmation
+    attributes:
+      label: Privacy and duplicate check
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I have removed secrets, CV content, and personal data.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/arspesk/sur9e/blob/main/SECURITY.md
+    about: Do not disclose vulnerabilities publicly. Follow SECURITY.md or email hello@sur9e.com privately.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose an improvement that supports sur9e's quality-over-quantity mission.
+title: "feature: "
+labels: ["type:feature", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Describe the user problem, not just a preferred implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What is difficult, confusing, or missing today?
+    validations:
+      required: true
+  - type: textarea
+    id: affected_user
+    attributes:
+      label: Affected user
+      description: Who has this problem and in what situation?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What would success look like for that person?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds, tools, or approaches have you considered?
+    validations:
+      required: true
+  - type: textarea
+    id: mission_fit
+    attributes:
+      label: Mission fit
+      description: How does this improve job-search quality, clarity, or user control without auto-submitting applications?
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy_confirmation
+    attributes:
+      label: Privacy and duplicate check
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I have removed secrets, CV content, and personal data.
+          required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,47 @@
+name: Question
+description: Ask for help using or contributing to sur9e.
+title: "question: "
+labels: ["type:question", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Please do not include CVs, job-offer text, credentials, or other personal data.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What are you trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Exact question
+      description: Ask the specific question that would unblock you.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Include relevant commands, documentation, or safe error details.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include sur9e version, OS, and other non-personal context that matters.
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy_confirmation
+    attributes:
+      label: Privacy and duplicate check
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+        - label: I have removed secrets, CV content, and personal data.
+          required: true
+    validations:
+      required: true

--- a/.github/issue-labels.yml
+++ b/.github/issue-labels.yml
@@ -1,0 +1,64 @@
+labels:
+  - name: type:bug
+    color: a855f7
+    description: A reproducible defect in sur9e behavior.
+  - name: type:feature
+    color: a855f7
+    description: A proposed user-facing capability or improvement.
+  - name: type:question
+    color: a855f7
+    description: A request for help or clarification.
+  - name: type:task
+    color: a855f7
+    description: A scoped maintenance or contributor task.
+  - name: area:web
+    color: 2563eb
+    description: The local web UI, accessibility, or browser behavior.
+  - name: area:agent
+    color: 2563eb
+    description: Agent modes, prompts, hooks, or AI integrations.
+  - name: area:jobs
+    color: 2563eb
+    description: Job discovery, screening, evaluation, or application workflow.
+  - name: area:data
+    color: 2563eb
+    description: Local data contracts, persistence, reports, or privacy boundaries.
+  - name: area:tooling
+    color: 2563eb
+    description: Build tooling, CI, scripts, dependencies, or developer setup.
+  - name: area:docs
+    color: 2563eb
+    description: Documentation, contributor guidance, or examples.
+  - name: priority:p0
+    color: dc2626
+    description: "Critical: data loss, security risk, or a broadly blocked core workflow."
+  - name: priority:p1
+    color: ea580c
+    description: "High: a major workflow is impaired without a reasonable workaround."
+  - name: priority:p2
+    color: ca8a04
+    description: "Normal: valuable work that can be planned in the usual cadence."
+  - name: priority:p3
+    color: 16a34a
+    description: "Low: polish, niche improvement, or work deferred by higher priorities."
+  - name: status:needs-triage
+    color: 64748b
+    description: New report awaiting human review and categorization.
+  - name: status:needs-info
+    color: d97706
+    description: More information is needed before human triage can proceed.
+  - name: status:accepted
+    color: 0f766e
+    description: A maintainer accepted this issue for future work.
+  - name: status:declined
+    color: be123c
+    description: A maintainer declined this issue after review.
+  - name: resolution:duplicate
+    color: 6b7280
+    description: Closed as a duplicate of an existing tracked issue.
+  - name: resolution:invalid
+    color: 6b7280
+    description: Closed because the report is not actionable or valid.
+  - name: resolution:wontfix
+    color: 6b7280
+    description: Closed because it will not be addressed in this project.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,32 @@
+name: Issue triage labels
+
+on:
+  issues:
+    types: [labeled, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+  queue: max
+
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Normalize issue triage labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_ACTION: ${{ github.event.action }}
+          ISSUE_BODY_CHANGED: ${{ github.event.changes.body != null }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_LABEL: ${{ github.event.label.name }}
+        run: node scripts/triage-github-issue.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ are the most valuable thing you can send.
 - Check existing [GitHub Issues](https://github.com/arspesk/sur9e/issues)
   before opening a new one or starting a large change. For anything bigger
   than a bugfix, open an issue first so we can agree on the approach.
+- Follow the human-owned [issue triage policy](docs/triage.md) when reporting,
+  labeling, or reviewing an issue.
 
 ## Dev setup
 

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,0 +1,94 @@
+# Issue triage
+
+GitHub Issues are sur9e's only issue-tracking system. They are reviewed by
+humans; this project uses no Codex delegation, no Claude delegation, no Linear,
+no GitHub Projects, and no reminder bot for triage. There is no issue
+implementation planning in phase one.
+
+## Weekly zero-inbox
+
+Once each week, a maintainer works the oldest open triage queue first. The
+target is zero `status:needs-triage` issues older than 7 days. Use this saved
+query:
+
+```text
+is:issue is:open label:"status:needs-triage" sort:created-asc
+```
+
+The maintainer either requests the smallest missing detail with
+`status:needs-info`, accepts the work, declines it, or closes it with a
+resolution. Editing the issue body after a needs-info request returns it to
+`status:needs-triage` for fresh human review.
+
+## Taxonomy
+
+Every issue has exactly one primary label in each category once triaged:
+
+- `type:bug`, `type:feature`, `type:question`, or `type:task` says what kind
+  of work it represents.
+- `area:web`, `area:agent`, `area:jobs`, `area:data`, `area:tooling`, or
+  `area:docs` identifies the one primary affected area.
+- `priority:p0` is a security risk, data loss, or broadly blocked core
+  workflow; `priority:p1` materially impairs a major workflow; `priority:p2`
+  is normal planned work; `priority:p3` is deferred polish or niche value.
+- `status:needs-triage` means new; `status:needs-info` means information is
+  materially missing; `status:accepted` and `status:declined` are human
+  maintainer decisions.
+- `resolution:duplicate`, `resolution:invalid`, and `resolution:wontfix` are
+  human-applied closure reasons. At most one resolution label belongs on an
+  issue.
+
+Unprefixed labels are existing PR labels and are not part of this issue
+taxonomy.
+
+## Activation
+
+The forms reference the taxonomy labels, and GitHub skips form labels that do
+not yet exist. The implementation is inactive until this human-gated activation
+is completed; do not merge or enable the forms first.
+
+From this branch, a maintainer must:
+
+1. Review the plan with the default dry run:
+
+   ```bash
+   npm run github:labels -- --repo arspesk/sur9e
+   ```
+
+2. After explicit approval, create or update the labels with this exact command
+   (there is no second `--` before `--apply`):
+
+   ```bash
+   npm run github:labels -- --repo arspesk/sur9e --apply
+   ```
+
+   The command creates or updates manifest labels only; it never deletes
+   labels. Do not run it without that approval.
+
+3. Verify all 21 label names through GitHub CLI before merge:
+
+   ```bash
+   gh label list --repo arspesk/sur9e --limit 100 --json name --jq '.[].name'
+   ```
+
+   Confirm the output includes every name in `.github/issue-labels.yml`.
+
+4. Only then merge this branch. The workflow does not add a manual dispatch or
+   standing label-write permission beyond its scoped issue-event token.
+
+## Automation boundaries
+
+CodeRabbit is an advisory, free-for-OSS helper. On issue creation or edit it
+may enrich descriptions and assign exactly one type, primary area, and priority
+when evidence supports them. It may apply `status:needs-info` only when details
+are materially missing. It does not accept, decline, resolve, close, or make
+comments that imply those maintainer-only decisions.
+
+The issue-label workflow only resolves conflicting prefixed labels by keeping
+the newest label in its category, and it returns a needs-info report to the
+triage queue only when its body changes. It never comments, closes, accepts,
+declines, or resolves an issue. Human maintainers retain acceptance, decline,
+resolution, and closure authority.
+
+Use the forms' privacy confirmation seriously: do not file secrets, CV content,
+job-offer text, credentials, or other personal data in public issues.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "update:check": "node update-system.mjs check",
     "update:apply": "node update-system.mjs apply",
     "update:rollback": "node update-system.mjs rollback",
+    "github:labels": "node scripts/sync-github-labels.mjs",
     "jobs:liveness": "tsx cli/check-liveness.mjs",
     "scan": "node batch/scan-portals.mjs && node batch/scan-jobspy.mjs",
     "setup": "npm install && node scripts/setup.mjs",

--- a/scripts/lib/issue-triage-labels.mjs
+++ b/scripts/lib/issue-triage-labels.mjs
@@ -1,0 +1,54 @@
+export const ISSUE_LABEL_GROUPS = Object.freeze({
+  type: Object.freeze(['type:bug', 'type:feature', 'type:question', 'type:task']),
+  area: Object.freeze([
+    'area:web',
+    'area:agent',
+    'area:jobs',
+    'area:data',
+    'area:tooling',
+    'area:docs',
+  ]),
+  priority: Object.freeze(['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3']),
+  status: Object.freeze([
+    'status:needs-triage',
+    'status:needs-info',
+    'status:accepted',
+    'status:declined',
+  ]),
+  resolution: Object.freeze(['resolution:duplicate', 'resolution:invalid', 'resolution:wontfix']),
+});
+
+function groupFor(label) {
+  return Object.values(ISSUE_LABEL_GROUPS).find(group => group.includes(label));
+}
+
+export function exclusiveGroupForLabel(label) {
+  return groupFor(label);
+}
+
+/**
+ * Returns the smallest set of issue-label changes required for a GitHub issue
+ * event. Labels outside the triage taxonomy are deliberately left untouched.
+ */
+export function applyIssueTriageEvent({ action, bodyChanged = false, newestLabel, labels }) {
+  const currentLabels = Array.isArray(labels) ? labels : [];
+
+  if (action === 'labeled') {
+    const group = groupFor(newestLabel);
+    if (!group || !currentLabels.includes(newestLabel)) return { add: [], remove: [] };
+
+    return {
+      add: [],
+      remove: currentLabels.filter(label => label !== newestLabel && group.includes(label)),
+    };
+  }
+
+  if (action === 'edited' && bodyChanged && currentLabels.includes('status:needs-info')) {
+    return {
+      add: currentLabels.includes('status:needs-triage') ? [] : ['status:needs-triage'],
+      remove: ['status:needs-info'],
+    };
+  }
+
+  return { add: [], remove: [] };
+}

--- a/scripts/lib/issue-triage-runner.mjs
+++ b/scripts/lib/issue-triage-runner.mjs
@@ -1,0 +1,110 @@
+import { applyIssueTriageEvent, exclusiveGroupForLabel } from './issue-triage-labels.mjs';
+
+function labelNames(issue) {
+  if (
+    !Array.isArray(issue?.labels) ||
+    !issue.labels.every(label => typeof label?.name === 'string')
+  ) {
+    throw new Error('GitHub returned an invalid issue label payload.');
+  }
+  return issue.labels.map(label => label.name);
+}
+
+function timelineEvents(pages) {
+  if (!Array.isArray(pages) || !pages.every(Array.isArray)) {
+    throw new Error('GitHub returned an invalid issue event timeline.');
+  }
+
+  const events = pages.flat();
+  for (const event of events) {
+    if (
+      !event ||
+      typeof event !== 'object' ||
+      !Number.isSafeInteger(event.id) ||
+      typeof event.event !== 'string' ||
+      typeof event.created_at !== 'string' ||
+      Number.isNaN(Date.parse(event.created_at)) ||
+      (event.event === 'labeled' && typeof event.label?.name !== 'string')
+    ) {
+      throw new Error('GitHub returned an invalid issue event timeline.');
+    }
+  }
+  return events;
+}
+
+function latestLiveLabeledLabel({ events, labels, group }) {
+  const candidates = events.filter(
+    event =>
+      event.event === 'labeled' &&
+      group.includes(event.label.name) &&
+      labels.includes(event.label.name),
+  );
+  if (candidates.length === 0) return undefined;
+
+  return candidates.reduce((latest, candidate) => {
+    const latestTime = Date.parse(latest.created_at);
+    const candidateTime = Date.parse(candidate.created_at);
+    if (candidateTime > latestTime || (candidateTime === latestTime && candidate.id > latest.id)) {
+      return candidate;
+    }
+    return latest;
+  }).label.name;
+}
+
+/**
+ * Refetches the live issue immediately before resolving an event so delayed
+ * workflows cannot overwrite a newer human or automation label change.
+ */
+export async function runIssueTriage({
+  issueNumber,
+  repo,
+  action,
+  bodyChanged,
+  newestLabel,
+  execute,
+}) {
+  const { stdout } = await execute('gh', [
+    'issue',
+    'view',
+    issueNumber,
+    '--repo',
+    repo,
+    '--json',
+    'labels',
+  ]);
+  const labels = labelNames(JSON.parse(stdout));
+  let effectiveLabel = newestLabel;
+
+  if (action === 'labeled') {
+    const group = exclusiveGroupForLabel(newestLabel);
+    if (group && labels.includes(newestLabel)) {
+      const timeline = await execute('gh', [
+        'api',
+        '--paginate',
+        '--slurp',
+        `repos/${repo}/issues/${issueNumber}/events?per_page=100`,
+      ]);
+      effectiveLabel = latestLiveLabeledLabel({
+        events: timelineEvents(JSON.parse(timeline.stdout)),
+        labels,
+        group,
+      });
+      if (!effectiveLabel) return { add: [], remove: [] };
+    }
+  }
+
+  const changes = applyIssueTriageEvent({
+    action,
+    bodyChanged,
+    newestLabel: effectiveLabel,
+    labels,
+  });
+
+  if (changes.add.length === 0 && changes.remove.length === 0) return changes;
+
+  const args = ['issue', 'edit', issueNumber, '--repo', repo];
+  for (const label of changes.remove) args.push('--remove-label', label);
+  for (const label of changes.add) args.push('--add-label', label);
+  await execute('gh', args);
+  return changes;
+}

--- a/scripts/sync-github-labels.mjs
+++ b/scripts/sync-github-labels.mjs
@@ -1,0 +1,165 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import yaml from 'js-yaml';
+import { ISSUE_LABEL_GROUPS } from './lib/issue-triage-labels.mjs';
+
+const execFile = promisify(execFileCallback);
+const MANIFEST_URL = new URL('../.github/issue-labels.yml', import.meta.url);
+const ISSUE_LABEL_NAMES = Object.values(ISSUE_LABEL_GROUPS).flat();
+const MAX_DESCRIPTION_LENGTH = 100;
+
+export function parseArgs(args) {
+  let apply = false;
+  let repo;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (argument === '--repo') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error('--repo requires an OWNER/REPO value.');
+      }
+      repo = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}. Use --apply and/or --repo OWNER/REPO.`);
+  }
+
+  if (repo && !/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    throw new Error('--repo must use OWNER/REPO format.');
+  }
+
+  return { apply, repo };
+}
+
+export function repoFromOrigin(origin) {
+  const source = origin.trim();
+  const patterns = [
+    /^https:\/\/github\.com\/(?<owner>[^/\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?\/?$/i,
+    /^ssh:\/\/git@github\.com\/(?<owner>[^/\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?\/?$/i,
+    /^git@github\.com:(?<owner>[^/\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?$/i,
+  ];
+  const match = patterns.map(pattern => source.match(pattern)).find(Boolean);
+  return match ? `${match.groups.owner}/${match.groups.repo}` : undefined;
+}
+
+export function validateLabels(labels) {
+  if (!Array.isArray(labels)) throw new Error('Issue labels must be an array.');
+  if (labels.length !== ISSUE_LABEL_NAMES.length) {
+    throw new Error(`Issue labels must define exactly ${ISSUE_LABEL_NAMES.length} labels.`);
+  }
+
+  const names = [];
+  for (const label of labels) {
+    if (!label || typeof label !== 'object' || Array.isArray(label)) {
+      throw new Error('Every issue label must be an object.');
+    }
+    if (typeof label.name !== 'string' || !ISSUE_LABEL_NAMES.includes(label.name)) {
+      throw new Error('Issue labels must use the exact approved taxonomy names.');
+    }
+    if (typeof label.color !== 'string' || !/^[0-9a-f]{6}$/i.test(label.color)) {
+      throw new Error('Every issue label needs a 6-character hexadecimal color.');
+    }
+    if (
+      typeof label.description !== 'string' ||
+      label.description.trim().length === 0 ||
+      label.description.length > MAX_DESCRIPTION_LENGTH
+    ) {
+      throw new Error(
+        `Every issue label needs a non-empty description up to ${MAX_DESCRIPTION_LENGTH} characters.`,
+      );
+    }
+    names.push(label.name);
+  }
+
+  if (new Set(names).size !== names.length) throw new Error('Issue label names must be unique.');
+  if (ISSUE_LABEL_NAMES.some(name => !names.includes(name))) {
+    throw new Error('Issue labels must use the exact approved taxonomy names.');
+  }
+  return labels;
+}
+
+async function executeCommand(command, args) {
+  return execFile(command, args, { encoding: 'utf8' });
+}
+
+async function resolveRepo({ repo, execute }) {
+  if (repo) return repo;
+
+  try {
+    const { stdout } = await execute('git', ['remote', 'get-url', 'origin']);
+    const resolved = repoFromOrigin(stdout);
+    if (resolved) return resolved;
+  } catch {
+    // Use the clear error below so dry runs remain helpful outside a checkout.
+  }
+
+  throw new Error('Could not resolve a GitHub repository from origin. Pass --repo OWNER/REPO.');
+}
+
+export async function syncGithubLabels({
+  apply = false,
+  labels,
+  repo,
+  execute = executeCommand,
+  log = console.log,
+}) {
+  validateLabels(labels);
+  const targetRepo = await resolveRepo({ repo, execute });
+
+  if (!apply) {
+    log(`Dry run: would create or update ${labels.length} issue labels in ${targetRepo}.`);
+    for (const label of labels) log(`  ${label.name} (${label.color}) — ${label.description}`);
+    log('Re-run with --apply to make these create/update-only changes; no labels are deleted.');
+    return;
+  }
+
+  try {
+    await execute('gh', ['auth', 'status']);
+  } catch (error) {
+    throw new Error(
+      'GitHub CLI authentication is required for --apply. Install gh and run gh auth login.',
+      { cause: error },
+    );
+  }
+
+  for (const label of labels) {
+    await execute('gh', [
+      'label',
+      'create',
+      label.name,
+      '--repo',
+      targetRepo,
+      '--color',
+      label.color,
+      '--description',
+      label.description,
+      '--force',
+    ]);
+    log(`Created or updated ${label.name}.`);
+  }
+}
+
+async function loadManifest() {
+  const manifest = yaml.load(await readFile(MANIFEST_URL, 'utf8'));
+  return validateLabels(manifest?.labels);
+}
+
+async function main() {
+  const { apply, repo } = parseArgs(process.argv.slice(2));
+  await syncGithubLabels({ apply, labels: await loadManifest(), repo });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/triage-github-issue.mjs
+++ b/scripts/triage-github-issue.mjs
@@ -1,0 +1,31 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { runIssueTriage } from './lib/issue-triage-runner.mjs';
+
+const execFile = promisify(execFileCallback);
+
+function requiredEnvironment(name, pattern) {
+  const value = process.env[name];
+  if (!value || !pattern.test(value)) throw new Error(`Missing or invalid ${name}.`);
+  return value;
+}
+
+async function main() {
+  const issueNumber = requiredEnvironment('ISSUE_NUMBER', /^[1-9][0-9]*$/);
+  const repo = requiredEnvironment('GITHUB_REPOSITORY', /^[^/\s]+\/[^/\s]+$/);
+  const action = process.env.ISSUE_ACTION;
+  const bodyChanged = process.env.ISSUE_BODY_CHANGED === 'true';
+  await runIssueTriage({
+    issueNumber,
+    repo,
+    action,
+    bodyChanged,
+    newestLabel: process.env.ISSUE_LABEL || null,
+    execute: (command, args) => execFile(command, args, { encoding: 'utf8' }),
+  });
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/test/issue-triage-labels.test.mjs
+++ b/test/issue-triage-labels.test.mjs
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { applyIssueTriageEvent, ISSUE_LABEL_GROUPS } from '../scripts/lib/issue-triage-labels.mjs';
+
+describe('issue triage label resolution', () => {
+  it('keeps the newest prefixed label within its group and preserves unprefixed labels', () => {
+    const result = applyIssueTriageEvent({
+      action: 'labeled',
+      newestLabel: 'priority:p0',
+      labels: ['bug', 'type:bug', 'priority:p2', 'priority:p0', 'help wanted'],
+    });
+
+    expect(result).toEqual({
+      add: [],
+      remove: ['priority:p2'],
+    });
+  });
+
+  it('does not change labels when the newest label is not in the issue taxonomy', () => {
+    expect(
+      applyIssueTriageEvent({
+        action: 'labeled',
+        newestLabel: 'good first issue',
+        labels: ['type:bug', 'good first issue'],
+      }),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  it('returns needs-info issues to needs-triage only when the issue body changed', () => {
+    expect(
+      applyIssueTriageEvent({
+        action: 'edited',
+        bodyChanged: true,
+        newestLabel: null,
+        labels: ['type:bug', 'area:web', 'status:needs-info', 'good first issue'],
+      }),
+    ).toEqual({
+      add: ['status:needs-triage'],
+      remove: ['status:needs-info'],
+    });
+  });
+
+  it('leaves needs-info unchanged after a title-only edit', () => {
+    expect(
+      applyIssueTriageEvent({
+        action: 'edited',
+        bodyChanged: false,
+        newestLabel: null,
+        labels: ['type:bug', 'area:web', 'status:needs-info', 'good first issue'],
+      }),
+    ).toEqual({ add: [], remove: [] });
+  });
+
+  it('exposes every exclusive issue-label group including resolution', () => {
+    expect(ISSUE_LABEL_GROUPS).toEqual({
+      type: ['type:bug', 'type:feature', 'type:question', 'type:task'],
+      area: ['area:web', 'area:agent', 'area:jobs', 'area:data', 'area:tooling', 'area:docs'],
+      priority: ['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3'],
+      status: ['status:needs-triage', 'status:needs-info', 'status:accepted', 'status:declined'],
+      resolution: ['resolution:duplicate', 'resolution:invalid', 'resolution:wontfix'],
+    });
+  });
+});

--- a/test/issue-triage-policy.test.mjs
+++ b/test/issue-triage-policy.test.mjs
@@ -1,0 +1,196 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const issueTemplate = name => resolve(ROOT, '.github/ISSUE_TEMPLATE', name);
+const loadYaml = path => yaml.load(readFileSync(path, 'utf8'));
+const requiredConfirmations = [
+  'I have searched existing issues for duplicates.',
+  'I have removed secrets, CV content, and personal data.',
+];
+
+const taxonomy = {
+  type: ['type:bug', 'type:feature', 'type:question', 'type:task'],
+  area: ['area:web', 'area:agent', 'area:jobs', 'area:data', 'area:tooling', 'area:docs'],
+  priority: ['priority:p0', 'priority:p1', 'priority:p2', 'priority:p3'],
+  status: ['status:needs-triage', 'status:needs-info', 'status:accepted', 'status:declined'],
+  resolution: ['resolution:duplicate', 'resolution:invalid', 'resolution:wontfix'],
+};
+
+function fieldIds(form) {
+  return form.body.filter(field => field.type !== 'markdown').map(field => field.id);
+}
+
+describe('GitHub Issue Forms', () => {
+  it('disables blank issues and routes security reports to the security policy and email', () => {
+    const config = loadYaml(issueTemplate('config.yml'));
+    expect(config.blank_issues_enabled).toBe(false);
+    expect(config.contact_links).toHaveLength(1);
+    expect(config.contact_links[0]).toMatchObject({
+      name: expect.stringMatching(/security/i),
+      url: expect.stringMatching(/^https:\/\/.+SECURITY\.md$/),
+      about: expect.stringContaining('hello@sur9e.com'),
+    });
+    expect(config.contact_links.every(link => /^https:\/\//.test(link.url))).toBe(true);
+  });
+
+  it.each([
+    [
+      'bug.yml',
+      'Bug report',
+      'type:bug',
+      ['expected', 'actual', 'reproduction', 'environment', 'evidence'],
+    ],
+    [
+      'feature.yml',
+      'Feature request',
+      'type:feature',
+      ['problem', 'affected_user', 'outcome', 'alternatives', 'mission_fit'],
+    ],
+    ['question.yml', 'Question', 'type:question', ['goal', 'question', 'tried', 'context']],
+  ])('defines the required %s fields and privacy confirmation', (path, title, typeLabel, ids) => {
+    const form = loadYaml(issueTemplate(path));
+    expect(form.name).toBe(title);
+    expect(form.labels).toEqual([typeLabel, 'status:needs-triage']);
+    expect(fieldIds(form)).toEqual(expect.arrayContaining([...ids, 'privacy_confirmation']));
+
+    const confirmation = form.body.find(field => field.id === 'privacy_confirmation');
+    expect(confirmation).toMatchObject({
+      type: 'checkboxes',
+      validations: { required: true },
+      attributes: {
+        options: expect.arrayContaining(
+          requiredConfirmations.map(label => expect.objectContaining({ label, required: true })),
+        ),
+      },
+    });
+    expect(confirmation.attributes.options).toHaveLength(2);
+
+    for (const id of ids.filter(id => id !== 'evidence')) {
+      expect(form.body.find(field => field.id === id)?.validations?.required).toBe(true);
+    }
+    expect(form.body.find(field => field.id === 'evidence')?.validations?.required).not.toBe(true);
+  });
+});
+
+describe('issue label manifest', () => {
+  it('defines exactly the issue taxonomy with unique names and category colors', () => {
+    const labels = loadYaml(resolve(ROOT, '.github/issue-labels.yml')).labels;
+    const names = labels.map(label => label.name);
+    expect(names).toEqual(Object.values(taxonomy).flat());
+    expect(new Set(names).size).toBe(names.length);
+    expect(
+      labels.every(label => /^[0-9a-f]{6}$/i.test(label.color) && label.description.length > 12),
+    ).toBe(true);
+
+    const colors = Object.fromEntries(labels.map(label => [label.name, label.color]));
+    expect(new Set(taxonomy.type.map(name => colors[name])).size).toBe(1);
+    expect(new Set(taxonomy.area.map(name => colors[name])).size).toBe(1);
+    expect(new Set(taxonomy.resolution.map(name => colors[name])).size).toBe(1);
+  });
+});
+
+describe('issue triage automation policy', () => {
+  it('adds the labels script without changing the existing PR labeler', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
+    expect(packageJson.scripts['github:labels']).toBe('node scripts/sync-github-labels.mjs');
+
+    const labeler = loadYaml(resolve(ROOT, '.github/labeler.yml'));
+    expect(Object.keys(labeler)).toEqual([
+      'ui',
+      'server',
+      'agent-behavior',
+      'modes',
+      'scripts',
+      'tests',
+      'documentation',
+      'dependencies',
+      'ci',
+    ]);
+  });
+
+  it('keeps CodeRabbit advisory and constrains it to triage-only issue enrichment', () => {
+    const config = loadYaml(resolve(ROOT, '.coderabbit.yaml'));
+    expect(config.reviews.auto_review).toMatchObject({ enabled: true, drafts: false });
+    expect(config.chat).toEqual({ auto_reply: false, allow_non_org_members: false });
+    expect(config.issue_enrichment).toMatchObject({
+      auto_enrich: { enabled: true },
+      labeling: { auto_apply_labels: true },
+      planning: { enabled: false, auto_planning: { enabled: false } },
+    });
+
+    const instructions = config.issue_enrichment.labeling.labeling_instructions;
+    const allowedLabels = [
+      ...taxonomy.type,
+      ...taxonomy.area,
+      ...taxonomy.priority,
+      'status:needs-info',
+    ];
+    expect(instructions).toHaveLength(allowedLabels.length);
+    expect(instructions.map(entry => entry.label)).toEqual(allowedLabels);
+    expect(instructions.every(entry => typeof entry.instructions === 'string')).toBe(true);
+
+    const guidance = instructions.map(entry => entry.instructions).join(' ');
+    expect(guidance).toContain('exactly one type');
+    expect(guidance).toContain('exactly one primary area');
+    expect(guidance).toContain('exactly one priority');
+    expect(guidance).toContain('status:needs-info');
+    for (const forbidden of [
+      'must not apply status:accepted',
+      'must not apply status:declined',
+      'must not apply any resolution:',
+      'must not make acceptance',
+      'must not make closure',
+    ]) {
+      expect(guidance).toContain(forbidden);
+    }
+  });
+
+  it('uses a least-privilege issue-only workflow with no unsafe template interpolation', () => {
+    const path = resolve(ROOT, '.github/workflows/issue-triage.yml');
+    const source = readFileSync(path, 'utf8');
+    const workflow = loadYaml(path);
+    const triggers = workflow.on ?? workflow.true ?? workflow[true];
+
+    expect(triggers.issues.types).toEqual(['labeled', 'edited']);
+    expect(workflow.permissions).toEqual({ contents: 'read', issues: 'write' });
+    expect(workflow.concurrency).toEqual({
+      group: 'issue-triage-${{ github.event.issue.number }}',
+      'cancel-in-progress': false,
+      queue: 'max',
+    });
+    expect(source).toContain('actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1');
+    expect(source).toContain('node scripts/triage-github-issue.mjs');
+    expect(source).toContain('ISSUE_BODY_CHANGED: ${{ github.event.changes.body != null }}');
+    expect(source).not.toContain('ISSUE_LABELS_JSON');
+    expect(source).not.toMatch(/run:[\s\S]*\$\{\{/);
+    expect(source).not.toMatch(/issues: (?:read-all|write-all)/);
+  });
+});
+
+describe('triage documentation', () => {
+  it('links the contributor guide to the human-owned weekly zero-inbox policy', () => {
+    const contributing = readFileSync(resolve(ROOT, 'CONTRIBUTING.md'), 'utf8');
+    const docs = readFileSync(resolve(ROOT, 'docs/triage.md'), 'utf8');
+
+    expect(contributing).toContain('docs/triage.md');
+    expect(docs).toContain('is:issue is:open label:"status:needs-triage" sort:created-asc');
+    expect(docs).toContain('7 days');
+    expect(docs).toContain('CodeRabbit');
+    expect(docs).toContain('Editing the issue body');
+    expect(docs).toMatch(/no Codex delegation/i);
+    expect(docs).toMatch(/no Claude delegation/i);
+    expect(docs).toMatch(/no issue\s+implementation planning in phase one/i);
+    expect(docs).toMatch(/No Linear|no Linear/i);
+    expect(docs).toMatch(/No .*Projects|no .*Projects/i);
+    expect(docs).toMatch(/No reminder bot|no reminder bot/i);
+    expect(docs).toContain('Activation');
+    expect(docs).toContain('npm run github:labels -- --repo arspesk/sur9e');
+    expect(docs).toContain('npm run github:labels -- --repo arspesk/sur9e --apply');
+    expect(docs).toContain('gh label list --repo arspesk/sur9e');
+    expect(docs).toContain('all 21 label names');
+    expect(docs).toMatch(/inactive.*human-gated|human-gated.*inactive/i);
+  });
+});

--- a/test/issue-triage-runner.test.mjs
+++ b/test/issue-triage-runner.test.mjs
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import { runIssueTriage } from '../scripts/lib/issue-triage-runner.mjs';
+
+function fakeGitHub(initialLabels, timelinePages) {
+  const defaultTimeline = initialLabels.map((name, index) => ({
+    id: index + 1,
+    event: 'labeled',
+    created_at: `2026-01-01T00:00:${String(index).padStart(2, '0')}Z`,
+    label: { name },
+  }));
+  const state = {
+    labels: [...initialLabels],
+    calls: [],
+    timelinePages: timelinePages ?? [defaultTimeline],
+  };
+  const execute = async (command, args) => {
+    state.calls.push([command, args]);
+    if (args[1] === 'view') {
+      return { stdout: JSON.stringify({ labels: state.labels.map(name => ({ name })) }) };
+    }
+    if (args[1] === 'edit') {
+      for (let index = 0; index < args.length; index += 1) {
+        if (args[index] === '--remove-label')
+          state.labels = state.labels.filter(name => name !== args[index + 1]);
+        if (args[index] === '--add-label' && !state.labels.includes(args[index + 1])) {
+          state.labels.push(args[index + 1]);
+        }
+      }
+      return { stdout: '' };
+    }
+    if (args[0] === 'api') {
+      return { stdout: JSON.stringify(state.timelinePages) };
+    }
+    throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+  };
+  return { state, execute };
+}
+
+describe('live issue triage runner', () => {
+  it('does not let a stale labeled event overwrite the current live label state', async () => {
+    const { state, execute } = fakeGitHub(['type:bug', 'status:needs-triage', 'good first issue']);
+
+    const result = await runIssueTriage({
+      issueNumber: '42',
+      repo: 'arspesk/sur9e',
+      action: 'labeled',
+      newestLabel: 'status:needs-info',
+      bodyChanged: false,
+      execute,
+    });
+
+    expect(result).toEqual({ add: [], remove: [] });
+    expect(state.labels).toEqual(['type:bug', 'status:needs-triage', 'good first issue']);
+    expect(state.calls).toEqual([
+      ['gh', ['issue', 'view', '42', '--repo', 'arspesk/sur9e', '--json', 'labels']],
+    ]);
+  });
+
+  it.each(['labeled-first', 'body-edit-first'])(
+    'converges a needs-info label and reporter body edit to needs-triage when %s',
+    async order => {
+      const { state, execute } = fakeGitHub(['type:bug', 'good first issue', 'status:needs-info']);
+      const labeled = () =>
+        runIssueTriage({
+          issueNumber: '42',
+          repo: 'arspesk/sur9e',
+          action: 'labeled',
+          newestLabel: 'status:needs-info',
+          bodyChanged: false,
+          execute,
+        });
+      const bodyEdit = () =>
+        runIssueTriage({
+          issueNumber: '42',
+          repo: 'arspesk/sur9e',
+          action: 'edited',
+          newestLabel: null,
+          bodyChanged: true,
+          execute,
+        });
+
+      if (order === 'labeled-first') {
+        await labeled();
+        await bodyEdit();
+      } else {
+        await bodyEdit();
+        await labeled();
+      }
+
+      expect(state.labels).toEqual(['type:bug', 'good first issue', 'status:needs-triage']);
+    },
+  );
+
+  it.each(['older-event-first', 'newer-event-first'])(
+    'keeps area:docs when both live area events are processed %s',
+    async order => {
+      const timelinePages = [
+        [
+          {
+            id: 10,
+            event: 'labeled',
+            created_at: '2026-01-01T00:00:00Z',
+            label: { name: 'area:web' },
+          },
+        ],
+        [
+          {
+            id: 20,
+            event: 'labeled',
+            created_at: '2026-01-01T00:00:00Z',
+            label: { name: 'area:docs' },
+          },
+        ],
+      ];
+      const { state, execute } = fakeGitHub(['type:bug', 'area:web', 'area:docs'], timelinePages);
+      const labeled = newestLabel =>
+        runIssueTriage({
+          issueNumber: '42',
+          repo: 'arspesk/sur9e',
+          action: 'labeled',
+          newestLabel,
+          bodyChanged: false,
+          execute,
+        });
+
+      if (order === 'older-event-first') {
+        await labeled('area:web');
+        await labeled('area:docs');
+      } else {
+        await labeled('area:docs');
+        await labeled('area:web');
+      }
+
+      expect(state.labels).toEqual(['type:bug', 'area:docs']);
+    },
+  );
+
+  it('fails closed without mutation when the paginated label timeline is malformed', async () => {
+    const { state, execute } = fakeGitHub(
+      ['type:bug', 'area:web', 'area:docs'],
+      [
+        [
+          {
+            id: 'not-a-number',
+            event: 'labeled',
+            created_at: '2026-01-01T00:00:00Z',
+            label: { name: 'area:docs' },
+          },
+        ],
+      ],
+    );
+
+    await expect(
+      runIssueTriage({
+        issueNumber: '42',
+        repo: 'arspesk/sur9e',
+        action: 'labeled',
+        newestLabel: 'area:web',
+        bodyChanged: false,
+        execute,
+      }),
+    ).rejects.toThrow('GitHub returned an invalid issue event timeline.');
+    expect(state.labels).toEqual(['type:bug', 'area:web', 'area:docs']);
+    expect(state.calls.some(([, args]) => args[1] === 'edit')).toBe(false);
+  });
+});

--- a/test/sync-github-labels.test.mjs
+++ b/test/sync-github-labels.test.mjs
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { ISSUE_LABEL_GROUPS } from '../scripts/lib/issue-triage-labels.mjs';
+import {
+  parseArgs,
+  repoFromOrigin,
+  syncGithubLabels,
+  validateLabels,
+} from '../scripts/sync-github-labels.mjs';
+
+const labels = Object.values(ISSUE_LABEL_GROUPS)
+  .flat()
+  .map((name, index) => ({
+    name,
+    color: 'a855f7',
+    description: `Managed issue taxonomy label number ${index + 1}.`,
+  }));
+
+describe('GitHub issue-label synchronization', () => {
+  it('defaults to a dry run and accepts an explicit repository', () => {
+    expect(parseArgs(['--repo', 'arspesk/sur9e'])).toEqual({
+      apply: false,
+      repo: 'arspesk/sur9e',
+    });
+  });
+
+  it('rejects a missing --repo value clearly', () => {
+    expect(() => parseArgs(['--repo'])).toThrow('--repo requires an OWNER/REPO value.');
+  });
+
+  it.each([
+    ['https://github.com/arspesk/sur9e.git', 'arspesk/sur9e'],
+    ['git@github.com:arspesk/sur9e.git', 'arspesk/sur9e'],
+    ['ssh://git@github.com/arspesk/sur9e.git', 'arspesk/sur9e'],
+    ['https://notgithub.com/arspesk/sur9e.git', undefined],
+    ['https://github.com.evil.example/arspesk/sur9e.git', undefined],
+    ['git@github.com.evil.example:arspesk/sur9e.git', undefined],
+    ['ssh://git@github.com.evil.example/arspesk/sur9e.git', undefined],
+  ])('parses only exact GitHub origins: %s', (origin, expected) => {
+    expect(repoFromOrigin(origin)).toBe(expected);
+  });
+
+  it('validates the full exact issue taxonomy before doing any work', () => {
+    expect(validateLabels(labels)).toEqual(labels);
+  });
+
+  it('prints a dry-run plan without invoking GitHub', async () => {
+    const calls = [];
+    const lines = [];
+
+    await syncGithubLabels({
+      labels,
+      repo: 'arspesk/sur9e',
+      execute: async (...args) => calls.push(args),
+      log: line => lines.push(line),
+    });
+
+    expect(calls).toEqual([]);
+    expect(lines.join('\n')).toContain('Dry run');
+    expect(lines.join('\n')).toContain('type:bug');
+  });
+
+  it('checks gh authentication and only creates or updates manifest labels in apply mode', async () => {
+    const calls = [];
+
+    await syncGithubLabels({
+      apply: true,
+      labels,
+      repo: 'arspesk/sur9e',
+      execute: async (...args) => calls.push(args),
+      log: () => {},
+    });
+
+    expect(calls[0]).toEqual(['gh', ['auth', 'status']]);
+    expect(calls).toHaveLength(labels.length + 1);
+    expect(
+      calls.slice(1).every(([command, args]) => command === 'gh' && args[1] === 'create'),
+    ).toBe(true);
+    expect(calls.flat(2)).not.toContain('delete');
+  });
+
+  it('rejects an invalid later label before any command in dry-run or apply mode', async () => {
+    const invalidLabels = labels.map((label, index) =>
+      index === labels.length - 1 ? { ...label, color: 'nothex' } : label,
+    );
+
+    for (const apply of [false, true]) {
+      const calls = [];
+      await expect(
+        syncGithubLabels({
+          apply,
+          labels: invalidLabels,
+          repo: 'arspesk/sur9e',
+          execute: async (...args) => calls.push(args),
+          log: () => {},
+        }),
+      ).rejects.toThrow('6-character hexadecimal color');
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it('rejects a 101-character later description before any command in dry-run or apply mode', async () => {
+    const invalidLabels = labels.map((label, index) =>
+      index === labels.length - 1 ? { ...label, description: 'x'.repeat(101) } : label,
+    );
+
+    for (const apply of [false, true]) {
+      const calls = [];
+      await expect(
+        syncGithubLabels({
+          apply,
+          labels: invalidLabels,
+          repo: 'arspesk/sur9e',
+          execute: async (...args) => calls.push(args),
+          log: () => {},
+        }),
+      ).rejects.toThrow('up to 100 characters');
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it('rejects apply mode without an authenticated gh CLI', async () => {
+    await expect(
+      syncGithubLabels({
+        apply: true,
+        labels,
+        repo: 'arspesk/sur9e',
+        execute: async () => {
+          throw new Error('gh: command not found');
+        },
+        log: () => {},
+      }),
+    ).rejects.toThrow('GitHub CLI authentication is required for --apply');
+  });
+});


### PR DESCRIPTION
## Summary

- add mandatory bug, feature, and question Issue Forms with privacy and security routing
- add a versioned issue taxonomy, safe create/update-only label sync, and public maintainer triage policy
- enable CodeRabbit issue enrichment within human-only outcome boundaries
- normalize mutually exclusive labels safely using serialized, timeline-aware GitHub issue events

## Impact

GitHub Issues become sur9e's single structured intake and triage surface. CodeRabbit may classify and enrich issues, while maintainers retain acceptance, decline, resolution, and closure authority. Linear and coding-agent delegation remain out of scope.

## Validation

- 35 focused triage tests
- `npm run test:quick` — 99 passed, 0 failed
- `npm run build`
- independent specification and code-quality reviews approved
- all 21 taxonomy labels synchronized and verified; all existing labels preserved

## Smoke test

After merge, create or edit the maintainer smoke-test issue to exercise the default-branch forms, CodeRabbit enrichment, and label-normalization workflow.