### PR TITLE
ci(coderabbit): skip release PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,8 @@ reviews:
     drafts: false
     base_branches:
       - main
+    ignore_title_keywords:
+      - "chore(main): release"
   path_instructions:
     - path: "CLAUDE.md"
       instructions: "This operating manual must remain byte-identical to AGENTS.md. Require both files to change together and flag conflicting instructions."

--- a/test/github-actions-policy.test.mjs
+++ b/test/github-actions-policy.test.mjs
@@ -485,6 +485,7 @@ describe('CodeRabbit policy', () => {
       enabled: true,
       drafts: false,
       base_branches: ['main'],
+      ignore_title_keywords: ['chore(main): release'],
     });
 
     const pathInstructions = config.reviews.path_instructions;


### PR DESCRIPTION
## Summary

- skip CodeRabbit auto-reviews when a PR title contains `chore(main): release`
- keep ordinary and Dependabot PR reviews unchanged
- lock the exclusion into the repository policy test

## Verification

- `npm exec -- vitest run test/github-actions-policy.test.mjs` (35 passed)
- `npm run test:quick` (99 passed, 0 failed, 1 expected missing-user-data warning)
- `npm run build` (passed; existing non-fatal Turbopack NFT tracing warning)