### PR TITLE
fix(pipeline): refine card scores and action menus

### DIFF
--- a/src/app/styles/chrome.css
+++ b/src/app/styles/chrome.css
@@ -4211,10 +4211,16 @@ select.form-input {
   color: var(--st-danger);
 }
 
-/* Ellipsis (⋯) glyph inside icon buttons — e.g. row-actions, board-card kebab. */
-.icon-ellipsis {
-  font-size: 18px;
-  line-height: 1;
+/* Canonical Lucide menu glyphs. Kebab triggers use EllipsisVertical while
+   meatball triggers use Ellipsis; both stay optically consistent inside the
+   existing button hit areas. This rule intentionally follows .icon-btn svg
+   so the requested 2px stroke wins over the generic 1.7px icon treatment. */
+.menu-dots-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  display: block;
+  stroke-width: 2;
 }
 
 /* Card — generic surface container. Padding variants opt-in. */

--- a/src/app/styles/chrome.css
+++ b/src/app/styles/chrome.css
@@ -4213,9 +4213,9 @@ select.form-input {
 
 /* Canonical Lucide menu glyphs. Kebab triggers use EllipsisVertical while
    meatball triggers use Ellipsis; both stay optically consistent inside the
-   existing button hit areas. This rule intentionally follows .icon-btn svg
-   so the requested 2px stroke wins over the generic 1.7px icon treatment. */
-.menu-dots-icon {
+   existing button hit areas. Match .icon-btn svg's specificity so the
+   requested 2px stroke wins over the generic 1.7px icon treatment. */
+.icon-btn svg.menu-dots-icon {
   width: 16px;
   height: 16px;
   flex: 0 0 16px;

--- a/src/app/styles/pipeline-inline.css
+++ b/src/app/styles/pipeline-inline.css
@@ -430,19 +430,21 @@
   flex: 1;
   min-width: 0;
 }
-/* Company name + score share the top line; score baseline-aligned right. */
+/* Company name + score share the top line; score stays beside the company. */
 .card-id-line {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: baseline;
   gap: 8px;
   /* Reserve room for the absolute kebab (top:6/right:6, ~26px glyph) on every
-     width so the right-aligned score never renders under the ⋯ — on touch the
+     width so the company and score never render under the ⋯ — on touch the
      kebab is always visible, on desktop it appears on hover. Consistent across
      all views. */
   padding-right: 30px;
 }
 .card-company {
+  flex: 0 1 auto;
+  min-width: 0;
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 16px;
@@ -533,6 +535,7 @@
   border-top-left-radius: var(--radius);
 }
 .card .score-num {
+  flex: 0 0 auto;
   font-family: var(--font-display);
   font-weight: 600;
   font-variant-numeric: tabular-nums;

--- a/src/app/styles/pipeline-inline.css
+++ b/src/app/styles/pipeline-inline.css
@@ -401,8 +401,8 @@
   top: 6px;
   right: 6px;
   /* Always visible — every view, every state, hover or not. The card-id line
-     reserves room for it (padding-right above) so it never collides with the
-     score. Previously hover-gated, which hid it from touch users at rest. */
+     reserves its full responsive target width below so it never collides with
+     the score. Previously hover-gated, which hid it from touch users at rest. */
   opacity: 1;
 }
 /* Dark mode override removed — .card now uses var(--surface) which
@@ -436,11 +436,9 @@
   justify-content: flex-start;
   align-items: baseline;
   gap: 8px;
-  /* Reserve room for the absolute kebab (top:6/right:6, ~26px glyph) on every
-     width so the company and score never render under the ⋯ — on touch the
-     kebab is always visible, on desktop it appears on hover. Consistent across
-     all views. */
-  padding-right: 30px;
+  /* Reserve the full 44px touch target at the logical end. The desktop 32px
+     button fits the same slot without a responsive layout fork. */
+  padding-inline-end: 44px;
 }
 .card-company {
   flex: 0 1 auto;

--- a/src/app/styles/pipeline-inline.css
+++ b/src/app/styles/pipeline-inline.css
@@ -183,6 +183,10 @@
 }
 .column {
   flex: 0 0 340px;
+  /* Flex items default to min-width:auto, which lets a long nowrap company
+     name expand the entire column past its 340px basis before ellipsis can
+     engage. Keep the column at its declared width and let card content shrink. */
+  min-width: 0;
   background: transparent;
   border-radius: var(--radius);
   display: flex;

--- a/src/features/chat/chat-threads-sidebar.tsx
+++ b/src/features/chat/chat-threads-sidebar.tsx
@@ -10,7 +10,7 @@
 // all mirror `.chat-session-menu*` (see app/styles/chat-threads.css) so the
 // two thread surfaces can never drift apart visually.
 
-import { Archive, ArchiveRestore, Pencil, Plus, Trash2 } from 'lucide-react';
+import { Archive, ArchiveRestore, EllipsisVertical, Pencil, Plus, Trash2 } from 'lucide-react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { KebabActionsMenu, type KebabItem } from '@/components/domain/kebab-actions-menu';
@@ -52,7 +52,7 @@ function RowKebab({ label, items }: { label: string; items: KebabItem[] }) {
         data-open={open || undefined}
         onClick={() => setOpen(o => !o)}
       >
-        ⋮
+        <EllipsisVertical className="menu-dots-icon" aria-hidden="true" />
       </button>
       {open && (
         <KebabActionsMenu

--- a/src/features/chat/session-menu.tsx
+++ b/src/features/chat/session-menu.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Archive, ArchiveRestore, ChevronDown, Pencil, Plus, Trash2 } from 'lucide-react';
+import {
+  Archive,
+  ArchiveRestore,
+  ChevronDown,
+  EllipsisVertical,
+  Pencil,
+  Plus,
+  Trash2,
+} from 'lucide-react';
 import { Fragment, useRef, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/behavior/popover';
 import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
@@ -51,7 +59,7 @@ function SessionRowKebab({ label, items }: { label: string; items: KebabItem[] }
         data-open={open || undefined}
         onClick={() => setOpen(o => !o)}
       >
-        ⋮
+        <EllipsisVertical className="menu-dots-icon" aria-hidden="true" />
       </button>
       {open && (
         <KebabActionsMenu

--- a/src/features/home/followups-section.tsx
+++ b/src/features/home/followups-section.tsx
@@ -10,7 +10,7 @@
 // each section.
 
 import { useMutation } from '@tanstack/react-query';
-import { BadgeCheck, Send } from 'lucide-react';
+import { BadgeCheck, EllipsisVertical, Send } from 'lucide-react';
 import type { Route } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -48,7 +48,7 @@ function RowKebab({ label, items }: { label: string; items: KebabItem[] }) {
         data-open={open || undefined}
         onClick={() => setOpen(o => !o)}
       >
-        ⋮
+        <EllipsisVertical className="menu-dots-icon" aria-hidden="true" />
       </button>
       {open && (
         <KebabActionsMenu

--- a/src/features/home/pending-offers-section.tsx
+++ b/src/features/home/pending-offers-section.tsx
@@ -11,7 +11,7 @@
 // confirm modal, which PATCHes status→evaluated and spawns the evaluation
 // job; evaluated rows get the terminal picks, Mark applied / Discard.
 
-import { BadgeCheck, Sparkles, Trash2 } from 'lucide-react';
+import { BadgeCheck, EllipsisVertical, Sparkles, Trash2 } from 'lucide-react';
 import type { Route } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -45,7 +45,7 @@ function RowKebab({ label, items }: { label: string; items: KebabItem[] }) {
         data-open={open || undefined}
         onClick={() => setOpen(o => !o)}
       >
-        ⋮
+        <EllipsisVertical className="menu-dots-icon" aria-hidden="true" />
       </button>
       {open && (
         <KebabActionsMenu

--- a/src/features/pipeline/board-card.tsx
+++ b/src/features/pipeline/board-card.tsx
@@ -6,6 +6,7 @@
 // pills row (archetype, seniority, work_mode), meta = Location · Comp · date.
 // Ported from legacy pipeline.html renderCard(); drag + click handlers unchanged.
 
+import { EllipsisVertical } from 'lucide-react';
 import { useRef } from 'react';
 import { CompanyAvatar } from '@/components/domain/company-avatar';
 import { scoreLevel } from '@/components/domain/score-chip';
@@ -137,11 +138,7 @@ export function BoardCard({
           aria-expanded={statusPopoverOpen}
           data-num={row.num}
           onClick={e => onActionsClick(e, row.num)}
-          icon={
-            <span aria-hidden="true" className="icon-ellipsis">
-              ⋯
-            </span>
-          }
+          icon={<EllipsisVertical className="menu-dots-icon" aria-hidden="true" />}
         />
       </div>
       <div className="card-chips">

--- a/src/features/report/report-page.tsx
+++ b/src/features/report/report-page.tsx
@@ -9,7 +9,7 @@
 // All of the legacy "polish" / scroll-spy / overflow logic runs in a
 // useEffect after the host's innerHTML is filled.
 
-import { MoreHorizontal, Undo2 } from 'lucide-react';
+import { Ellipsis, Undo2 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef } from 'react';
@@ -172,7 +172,7 @@ export function ReportPage({ filename, initialEntry }: ReportPageProps) {
           data-pill-overflow-trigger
           data-num={num ?? ''}
           onClick={onOverflowClick}
-          icon={<MoreHorizontal aria-hidden="true" strokeWidth={2} size={16} />}
+          icon={<Ellipsis className="menu-dots-icon" aria-hidden="true" />}
         />
       </Topbar>
 

--- a/src/features/table/offers-drawer.tsx
+++ b/src/features/table/offers-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, ChevronRight, ChevronsRight, Maximize2, MoreHorizontal } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ChevronsRight, Ellipsis, Maximize2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { IconButton } from '@/components/primitives';
@@ -299,7 +299,7 @@ function DrawerNavRow({
           title="More actions"
           aria-haspopup="menu"
           onClick={onKebab}
-          icon={<MoreHorizontal aria-hidden="true" strokeWidth={2} size={16} />}
+          icon={<Ellipsis className="menu-dots-icon" aria-hidden="true" />}
         />
       </div>
     </div>

--- a/src/features/table/table-row-actions.tsx
+++ b/src/features/table/table-row-actions.tsx
@@ -31,10 +31,6 @@ export function TableRowActions({ row, lockedNums: _lockedNums }: TableRowAction
 
   return (
     <>
-      {/* TODO: verify 44x44 mobile hit-target after
-       * IconButton migration via 3-width screenshot gate. Legacy .row-actions
-       * had 18px font + 44x44 padding; IconButton default size is 32x32. If
-       * WCAG 2.5.5 AAA regresses, add size="lg" or a padding decoration. */}
       <IconButton
         ref={kebabRef}
         label={`Row actions for ${row.company}`}

--- a/src/features/table/table-row-actions.tsx
+++ b/src/features/table/table-row-actions.tsx
@@ -2,7 +2,7 @@
 
 /* features/table/table-row-actions.tsx
  *
- * Per-row kebab in the offers table. Renders the ⋯ trigger button and opens
+ * Per-row kebab in the offers table. Renders the vertical-dots trigger and opens
  * the shared full row menu (links · apply/follow-up · AI generation · delete)
  * via <RowActionsMenu> in ./row-actions-menu.tsx.
  *
@@ -10,6 +10,7 @@
  * locked-row affordances move in with the job-runner wiring.
  */
 
+import { EllipsisVertical } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { IconButton } from '@/components/primitives';
 import { RowActionsMenu } from './row-actions-menu';
@@ -45,11 +46,7 @@ export function TableRowActions({ row, lockedNums: _lockedNums }: TableRowAction
           e.stopPropagation();
           setMenuOpen(v => !v);
         }}
-        icon={
-          <span aria-hidden="true" className="icon-ellipsis">
-            ⋯
-          </span>
-        }
+        icon={<EllipsisVertical className="menu-dots-icon" aria-hidden="true" />}
       />
       <RowActionsMenu open={menuOpen} anchorRef={kebabRef} row={row} onClose={closeMenu} />
     </>

--- a/test/e2e/pipeline-card-visual.spec.ts
+++ b/test/e2e/pipeline-card-visual.spec.ts
@@ -47,6 +47,9 @@ for (const viewport of viewports) {
       if (!cardBox || !companyBox || !scoreBox || !menuBox || !iconBox) return;
 
       expect(scoreBox.x).toBeGreaterThan(companyBox.x);
+      expect(companyBox.x + companyBox.width).toBeLessThanOrEqual(scoreBox.x + 1);
+      expect(companyBox.y + companyBox.height).toBeGreaterThan(scoreBox.y);
+      expect(scoreBox.y + scoreBox.height).toBeGreaterThan(companyBox.y);
       expect(scoreBox.x + scoreBox.width).toBeLessThanOrEqual(menuBox.x + 1);
       expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
       expect(iconBox.width).toBeCloseTo(16, 0);

--- a/test/e2e/pipeline-card-visual.spec.ts
+++ b/test/e2e/pipeline-card-visual.spec.ts
@@ -15,48 +15,51 @@ for (const viewport of viewports) {
       hasTouch: viewport.name !== 'desktop',
       isMobile: viewport.name === 'mobile',
     });
-    const page = await context.newPage();
-    await page.goto('/offers?view=kanban');
+    try {
+      const page = await context.newPage();
+      await page.goto('/offers?view=kanban');
 
-    const card = page.locator('.board .card').first();
-    test.skip((await card.count()) === 0, 'No local offer fixture is available for visual QA');
-    await expect(card).toBeVisible();
+      const card = page.locator('.board .card').first();
+      test.skip((await card.count()) === 0, 'No local offer fixture is available for visual QA');
+      await expect(card).toBeVisible();
 
-    const company = card.locator('.card-company');
-    const score = card.locator('.score-num');
-    const menu = card.locator('.board-card-kebab');
-    const icon = menu.locator('svg.menu-dots-icon.lucide-ellipsis-vertical');
-    await expect(company).toBeVisible();
-    await expect(score).toBeVisible();
-    await expect(menu).toBeVisible();
-    await expect(icon).toBeVisible();
+      const company = card.locator('.card-company');
+      const score = card.locator('.score-num');
+      const menu = card.locator('.board-card-kebab');
+      const icon = menu.locator('svg.menu-dots-icon.lucide-ellipsis-vertical');
+      await expect(company).toBeVisible();
+      await expect(score).toBeVisible();
+      await expect(menu).toBeVisible();
+      await expect(icon).toBeVisible();
 
-    const [cardBox, companyBox, scoreBox, menuBox, iconBox] = await Promise.all([
-      card.boundingBox(),
-      company.boundingBox(),
-      score.boundingBox(),
-      menu.boundingBox(),
-      icon.boundingBox(),
-    ]);
-    expect(cardBox).not.toBeNull();
-    expect(companyBox).not.toBeNull();
-    expect(scoreBox).not.toBeNull();
-    expect(menuBox).not.toBeNull();
-    expect(iconBox).not.toBeNull();
-    if (!cardBox || !companyBox || !scoreBox || !menuBox || !iconBox) return;
+      const [cardBox, companyBox, scoreBox, menuBox, iconBox] = await Promise.all([
+        card.boundingBox(),
+        company.boundingBox(),
+        score.boundingBox(),
+        menu.boundingBox(),
+        icon.boundingBox(),
+      ]);
+      expect(cardBox).not.toBeNull();
+      expect(companyBox).not.toBeNull();
+      expect(scoreBox).not.toBeNull();
+      expect(menuBox).not.toBeNull();
+      expect(iconBox).not.toBeNull();
+      if (!cardBox || !companyBox || !scoreBox || !menuBox || !iconBox) return;
 
-    expect(scoreBox.x).toBeGreaterThan(companyBox.x);
-    expect(scoreBox.x + scoreBox.width).toBeLessThanOrEqual(menuBox.x + 1);
-    expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
-    expect(iconBox.width).toBeCloseTo(16, 0);
-    expect(iconBox.height).toBeCloseTo(16, 0);
+      expect(scoreBox.x).toBeGreaterThan(companyBox.x);
+      expect(scoreBox.x + scoreBox.width).toBeLessThanOrEqual(menuBox.x + 1);
+      expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+      expect(iconBox.width).toBeCloseTo(16, 0);
+      expect(iconBox.height).toBeCloseTo(16, 0);
 
-    await page.screenshot({
-      path: testInfo.outputPath(
-        `pipeline-card-${viewport.name}-${viewport.width}x${viewport.height}.png`,
-      ),
-      fullPage: true,
-    });
-    await context.close();
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `pipeline-card-${viewport.name}-${viewport.width}x${viewport.height}.png`,
+        ),
+        fullPage: true,
+      });
+    } finally {
+      await context.close();
+    }
   });
 }

--- a/test/e2e/pipeline-card-visual.spec.ts
+++ b/test/e2e/pipeline-card-visual.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+const viewports = [
+  { name: 'desktop', width: 1280, height: 800 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 375, height: 667 },
+] as const;
+
+for (const viewport of viewports) {
+  test(`kanban score and vertical menu stay aligned at ${viewport.name}`, async ({
+    browser,
+  }, testInfo) => {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      hasTouch: viewport.name !== 'desktop',
+      isMobile: viewport.name === 'mobile',
+    });
+    const page = await context.newPage();
+    await page.goto('/offers?view=kanban');
+
+    const card = page.locator('.board .card').first();
+    test.skip((await card.count()) === 0, 'No local offer fixture is available for visual QA');
+    await expect(card).toBeVisible();
+
+    const company = card.locator('.card-company');
+    const score = card.locator('.score-num');
+    const menu = card.locator('.board-card-kebab');
+    const icon = menu.locator('svg.menu-dots-icon.lucide-ellipsis-vertical');
+    await expect(company).toBeVisible();
+    await expect(score).toBeVisible();
+    await expect(menu).toBeVisible();
+    await expect(icon).toBeVisible();
+
+    const [cardBox, companyBox, scoreBox, menuBox, iconBox] = await Promise.all([
+      card.boundingBox(),
+      company.boundingBox(),
+      score.boundingBox(),
+      menu.boundingBox(),
+      icon.boundingBox(),
+    ]);
+    expect(cardBox).not.toBeNull();
+    expect(companyBox).not.toBeNull();
+    expect(scoreBox).not.toBeNull();
+    expect(menuBox).not.toBeNull();
+    expect(iconBox).not.toBeNull();
+    if (!cardBox || !companyBox || !scoreBox || !menuBox || !iconBox) return;
+
+    expect(scoreBox.x).toBeGreaterThan(companyBox.x);
+    expect(scoreBox.x + scoreBox.width).toBeLessThanOrEqual(menuBox.x + 1);
+    expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+    expect(iconBox.width).toBeCloseTo(16, 0);
+    expect(iconBox.height).toBeCloseTo(16, 0);
+
+    await page.screenshot({
+      path: testInfo.outputPath(
+        `pipeline-card-${viewport.name}-${viewport.width}x${viewport.height}.png`,
+      ),
+      fullPage: true,
+    });
+    await context.close();
+  });
+}

--- a/test/e2e/table-row-kebab-a11y.spec.ts
+++ b/test/e2e/table-row-kebab-a11y.spec.ts
@@ -147,3 +147,45 @@ test('open kebab menu never overlaps its trigger; re-click toggles closed withou
     expect(actionPosts, `kebab #${i}: dismiss-click must not fire a menu item`).toBe(before);
   }
 });
+
+const rowActionViewports = [
+  { name: 'desktop', width: 1280, height: 800, minTarget: 32 },
+  { name: 'tablet', width: 768, height: 1024, minTarget: 44 },
+  { name: 'mobile', width: 375, height: 667, minTarget: 44 },
+] as const;
+
+for (const viewport of rowActionViewports) {
+  test(`row kebab keeps its required hit target at ${viewport.name}`, async ({
+    browser,
+  }, testInfo) => {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      hasTouch: viewport.name !== 'desktop',
+      isMobile: viewport.name === 'mobile',
+    });
+    try {
+      const page = await context.newPage();
+      await page.goto('/offers');
+
+      const trigger = page.locator('table.offers tbody tr .col-kebab button').first();
+      test.skip((await trigger.count()) === 0, 'No local offer fixture is available for visual QA');
+      await trigger.scrollIntoViewIfNeeded();
+      await expect(trigger).toBeVisible();
+
+      const box = await trigger.boundingBox();
+      expect(box).not.toBeNull();
+      if (!box) return;
+      expect(box.width).toBeGreaterThanOrEqual(viewport.minTarget);
+      expect(box.height).toBeGreaterThanOrEqual(viewport.minTarget);
+
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `table-row-kebab-${viewport.name}-${viewport.width}x${viewport.height}.png`,
+        ),
+        fullPage: true,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+}

--- a/test/menu-dots-icon-contract.test.ts
+++ b/test/menu-dots-icon-contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const read = (path: string) => readFileSync(join(ROOT, path), 'utf-8');
+
+const KEBAB_SOURCES = [
+  'src/features/pipeline/board-card.tsx',
+  'src/features/table/table-row-actions.tsx',
+  'src/features/home/followups-section.tsx',
+  'src/features/home/pending-offers-section.tsx',
+  'src/features/chat/session-menu.tsx',
+  'src/features/chat/chat-threads-sidebar.tsx',
+];
+
+const MEATBALL_SOURCES = [
+  'src/features/report/report-page.tsx',
+  'src/features/table/offers-drawer.tsx',
+];
+
+describe('menu dots icon contract', () => {
+  it.each(KEBAB_SOURCES)('%s uses the canonical vertical Lucide kebab', path => {
+    const source = read(path);
+    expect(source).toContain('<EllipsisVertical');
+    expect(source).toContain('className="menu-dots-icon"');
+    expect(source).not.toMatch(/>\s*[⋮⋯]\s*</u);
+  });
+
+  it.each(MEATBALL_SOURCES)('%s uses the canonical horizontal Lucide meatball', path => {
+    const source = read(path);
+    expect(source).toContain('<Ellipsis');
+    expect(source).not.toContain('<EllipsisVertical');
+    expect(source).toContain('className="menu-dots-icon"');
+  });
+
+  it('keeps both glyph orientations at the shared 16px / 2px-stroke size', () => {
+    const css = read('src/app/styles/chrome.css');
+    const block = css.match(/\.menu-dots-icon\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(block).toMatch(/width:\s*16px/);
+    expect(block).toMatch(/height:\s*16px/);
+    expect(block).toMatch(/stroke-width:\s*2/);
+  });
+});

--- a/test/menu-dots-icon-contract.test.ts
+++ b/test/menu-dots-icon-contract.test.ts
@@ -36,7 +36,7 @@ describe('menu dots icon contract', () => {
 
   it('keeps both glyph orientations at the shared 16px / 2px-stroke size', () => {
     const css = read('src/app/styles/chrome.css');
-    const block = css.match(/\.menu-dots-icon\s*\{([^}]*)\}/)?.[1] ?? '';
+    const block = css.match(/\.icon-btn\s+svg\.menu-dots-icon\s*\{([^}]*)\}/)?.[1] ?? '';
     expect(block).toMatch(/width:\s*16px/);
     expect(block).toMatch(/height:\s*16px/);
     expect(block).toMatch(/stroke-width:\s*2/);

--- a/test/pipeline-card-style-contract.test.ts
+++ b/test/pipeline-card-style-contract.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const root = process.cwd();
@@ -22,17 +23,87 @@ function declarationsFor(source: string, selector: string): Map<string, string> 
   );
 }
 
-function cardIdLineSubtree(source: string): { markup: string; end: number } {
-  const opening = '<div className="card-id-line">';
-  const start = source.indexOf(opening);
-  expect(start, 'Expected .card-id-line JSX').toBeGreaterThan(-1);
+interface DirectJsxChild {
+  tag: string;
+  className: string | null;
+}
 
-  const end = source.indexOf('</div>', start) + '</div>'.length;
-  expect(end, 'Expected .card-id-line closing tag').toBeGreaterThan(start + opening.length);
-  return { markup: source.slice(start, end), end };
+function classNameFor(element: ts.JsxOpeningLikeElement, sourceFile: ts.SourceFile): string | null {
+  for (const property of element.attributes.properties) {
+    if (!ts.isJsxAttribute(property) || property.name.getText(sourceFile) !== 'className') continue;
+    const initializer = property.initializer;
+    if (!initializer) return null;
+    if (ts.isStringLiteral(initializer)) return initializer.text;
+    if (!ts.isJsxExpression(initializer) || !initializer.expression) return null;
+    if (
+      ts.isStringLiteral(initializer.expression) ||
+      ts.isNoSubstitutionTemplateLiteral(initializer.expression)
+    ) {
+      return initializer.expression.text;
+    }
+    if (ts.isTemplateExpression(initializer.expression)) {
+      return initializer.expression.getText(sourceFile).slice(1, -1);
+    }
+    return null;
+  }
+  return null;
+}
+
+function cardIdLineShape(source: string): { directChildren: DirectJsxChild[]; end: number } {
+  const sourceFile = ts.createSourceFile(
+    'board-card.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let cardIdLine: ts.JsxElement | undefined;
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxElement(node) && classNameFor(node.openingElement, sourceFile) === 'card-id-line') {
+      cardIdLine = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  expect(cardIdLine, 'Expected .card-id-line JSX').toBeDefined();
+  if (!cardIdLine) throw new Error('Expected .card-id-line JSX');
+
+  const directChildren = cardIdLine.children
+    .filter(
+      (child): child is ts.JsxElement | ts.JsxSelfClosingElement =>
+        ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child),
+    )
+    .map(child => {
+      const opening = ts.isJsxElement(child) ? child.openingElement : child;
+      return {
+        tag: opening.tagName.getText(sourceFile),
+        className: classNameFor(opening, sourceFile),
+      };
+    });
+
+  return { directChildren, end: cardIdLine.end };
 }
 
 describe('pipeline card style contract', () => {
+  it('does not treat nested spans as direct identity-line children', () => {
+    const nestedFixture = `
+      const card = (
+        <div className="card-id-line">
+          <div className="unexpected-wrapper">
+            <span className="card-company">Acme</span>
+            <span className={\`score-num high\`}>5.0</span>
+          </div>
+        </div>
+      );
+    `;
+    const { directChildren } = cardIdLineShape(nestedFixture);
+
+    expect(directChildren).toEqual([{ tag: 'div', className: 'unexpected-wrapper' }]);
+  });
+
   it('keeps the score beside a shrinkable company name and clear of the overflow menu', () => {
     const cardIdLine = declarationsFor(pipelineCss, '.card-id-line');
     const cardCompany = declarationsFor(pipelineCss, '.card-company');
@@ -49,14 +120,13 @@ describe('pipeline card style contract', () => {
   });
 
   it('keeps company and score as ordered siblings inside the identity-line subtree', () => {
-    const { markup, end } = cardIdLineSubtree(boardCard);
-    const childClasses = [...markup.matchAll(/<span className=(?:"([^"]+)"|\{`([^`]+)`\})/g)].map(
-      match => match[1] ?? match[2],
-    );
+    const { directChildren, end } = cardIdLineShape(boardCard);
     const kebabIndex = boardCard.indexOf('className="board-card-kebab"', end);
 
-    expect(childClasses).toEqual(['card-company', 'score-num ${scoreLevel(score)}']);
-    expect(markup).not.toContain('board-card-kebab');
+    expect(directChildren).toEqual([
+      { tag: 'span', className: 'card-company' },
+      { tag: 'span', className: 'score-num ${scoreLevel(score)}' },
+    ]);
     expect(kebabIndex).toBeGreaterThan(end);
   });
 });

--- a/test/pipeline-card-style-contract.test.ts
+++ b/test/pipeline-card-style-contract.test.ts
@@ -6,40 +6,57 @@ const root = process.cwd();
 const pipelineCss = readFileSync(join(root, 'src/app/styles/pipeline-inline.css'), 'utf8');
 const boardCard = readFileSync(join(root, 'src/features/pipeline/board-card.tsx'), 'utf8');
 
-function ruleBlocks(source: string, selector: string): string {
+function declarationsFor(source: string, selector: string): Map<string, string> {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const matches = [
     ...source.matchAll(new RegExp(`(?:^|\\n)\\s*${escapedSelector}\\s*\\{([^}]*)\\}`, 'g')),
   ];
 
-  expect(matches.length, `Expected a CSS rule for ${selector}`).toBeGreaterThan(0);
-  return matches.map(match => match[1]).join('\n');
+  expect(matches, `Expected exactly one CSS rule for ${selector}`).toHaveLength(1);
+
+  const blockWithoutComments = matches[0][1].replace(/\/\*[\s\S]*?\*\//g, '');
+  return new Map(
+    [...blockWithoutComments.matchAll(/(?:^|;)\s*([\w-]+)\s*:\s*([^;]+?)\s*(?=;|$)/g)].map(
+      match => [match[1], match[2].trim()],
+    ),
+  );
+}
+
+function cardIdLineSubtree(source: string): { markup: string; end: number } {
+  const opening = '<div className="card-id-line">';
+  const start = source.indexOf(opening);
+  expect(start, 'Expected .card-id-line JSX').toBeGreaterThan(-1);
+
+  const end = source.indexOf('</div>', start) + '</div>'.length;
+  expect(end, 'Expected .card-id-line closing tag').toBeGreaterThan(start + opening.length);
+  return { markup: source.slice(start, end), end };
 }
 
 describe('pipeline card style contract', () => {
   it('keeps the score beside a shrinkable company name and clear of the overflow menu', () => {
-    const cardIdLine = ruleBlocks(pipelineCss, '.card-id-line');
-    const cardCompany = ruleBlocks(pipelineCss, '.card-company');
-    const scoreNum = ruleBlocks(pipelineCss, '.card .score-num');
+    const cardIdLine = declarationsFor(pipelineCss, '.card-id-line');
+    const cardCompany = declarationsFor(pipelineCss, '.card-company');
+    const scoreNum = declarationsFor(pipelineCss, '.card .score-num');
 
-    expect(cardIdLine).toContain('justify-content: flex-start');
-    expect(cardIdLine).not.toContain('justify-content: space-between');
-    expect(cardIdLine).toContain('align-items: baseline');
-    expect(cardIdLine).toContain('gap: 8px');
-    expect(cardIdLine).toContain('padding-right: 30px');
-    expect(cardCompany).toContain('flex: 0 1 auto');
-    expect(cardCompany).toContain('min-width: 0');
-    expect(scoreNum).toContain('flex: 0 0 auto');
+    expect(cardIdLine.get('justify-content')).toBe('flex-start');
+    expect(cardIdLine.get('align-items')).toBe('baseline');
+    expect(cardIdLine.get('gap')).toBe('8px');
+    expect(cardIdLine.get('padding-inline-end')).toBe('44px');
+    expect(cardIdLine.has('padding-right')).toBe(false);
+    expect(cardCompany.get('flex')).toBe('0 1 auto');
+    expect(cardCompany.get('min-width')).toBe('0');
+    expect(scoreNum.get('flex')).toBe('0 0 auto');
   });
 
-  it('renders company, score, then the card actions menu in that order', () => {
-    const cardMarkup = boardCard.slice(boardCard.indexOf('<div className="card-top">'));
-    const companyIndex = cardMarkup.indexOf('className="card-company"');
-    const scoreIndex = cardMarkup.indexOf('className={`score-num');
-    const kebabIndex = cardMarkup.indexOf('className="board-card-kebab"');
+  it('keeps company and score as ordered siblings inside the identity-line subtree', () => {
+    const { markup, end } = cardIdLineSubtree(boardCard);
+    const childClasses = [...markup.matchAll(/<span className=(?:"([^"]+)"|\{`([^`]+)`\})/g)].map(
+      match => match[1] ?? match[2],
+    );
+    const kebabIndex = boardCard.indexOf('className="board-card-kebab"', end);
 
-    expect(companyIndex).toBeGreaterThan(-1);
-    expect(scoreIndex).toBeGreaterThan(companyIndex);
-    expect(kebabIndex).toBeGreaterThan(scoreIndex);
+    expect(childClasses).toEqual(['card-company', 'score-num ${scoreLevel(score)}']);
+    expect(markup).not.toContain('board-card-kebab');
+    expect(kebabIndex).toBeGreaterThan(end);
   });
 });

--- a/test/pipeline-card-style-contract.test.ts
+++ b/test/pipeline-card-style-contract.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const pipelineCss = readFileSync(join(root, 'src/app/styles/pipeline-inline.css'), 'utf8');
+const boardCard = readFileSync(join(root, 'src/features/pipeline/board-card.tsx'), 'utf8');
+
+function ruleBlocks(source: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const matches = [
+    ...source.matchAll(new RegExp(`(?:^|\\n)\\s*${escapedSelector}\\s*\\{([^}]*)\\}`, 'g')),
+  ];
+
+  expect(matches.length, `Expected a CSS rule for ${selector}`).toBeGreaterThan(0);
+  return matches.map(match => match[1]).join('\n');
+}
+
+describe('pipeline card style contract', () => {
+  it('keeps the score beside a shrinkable company name and clear of the overflow menu', () => {
+    const cardIdLine = ruleBlocks(pipelineCss, '.card-id-line');
+    const cardCompany = ruleBlocks(pipelineCss, '.card-company');
+    const scoreNum = ruleBlocks(pipelineCss, '.card .score-num');
+
+    expect(cardIdLine).toContain('justify-content: flex-start');
+    expect(cardIdLine).not.toContain('justify-content: space-between');
+    expect(cardIdLine).toContain('align-items: baseline');
+    expect(cardIdLine).toContain('gap: 8px');
+    expect(cardIdLine).toContain('padding-right: 30px');
+    expect(cardCompany).toContain('flex: 0 1 auto');
+    expect(cardCompany).toContain('min-width: 0');
+    expect(scoreNum).toContain('flex: 0 0 auto');
+  });
+
+  it('renders company, score, then the card actions menu in that order', () => {
+    const cardMarkup = boardCard.slice(boardCard.indexOf('<div className="card-top">'));
+    const companyIndex = cardMarkup.indexOf('className="card-company"');
+    const scoreIndex = cardMarkup.indexOf('className={`score-num');
+    const kebabIndex = cardMarkup.indexOf('className="board-card-kebab"');
+
+    expect(companyIndex).toBeGreaterThan(-1);
+    expect(scoreIndex).toBeGreaterThan(companyIndex);
+    expect(kebabIndex).toBeGreaterThan(scoreIndex);
+  });
+});

--- a/test/pipeline-card-style-contract.test.ts
+++ b/test/pipeline-card-style-contract.test.ts
@@ -7,20 +7,26 @@ const root = process.cwd();
 const pipelineCss = readFileSync(join(root, 'src/app/styles/pipeline-inline.css'), 'utf8');
 const boardCard = readFileSync(join(root, 'src/features/pipeline/board-card.tsx'), 'utf8');
 
-function declarationsFor(source: string, selector: string): Map<string, string> {
+function allDeclarationsFor(source: string, selector: string): Map<string, string>[] {
   const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const matches = [
     ...source.matchAll(new RegExp(`(?:^|\\n)\\s*${escapedSelector}\\s*\\{([^}]*)\\}`, 'g')),
   ];
 
-  expect(matches, `Expected exactly one CSS rule for ${selector}`).toHaveLength(1);
+  return matches.map(match => {
+    const blockWithoutComments = match[1].replace(/\/\*[\s\S]*?\*\//g, '');
+    return new Map(
+      [...blockWithoutComments.matchAll(/(?:^|;)\s*([\w-]+)\s*:\s*([^;]+?)\s*(?=;|$)/g)].map(
+        declaration => [declaration[1], declaration[2].trim()],
+      ),
+    );
+  });
+}
 
-  const blockWithoutComments = matches[0][1].replace(/\/\*[\s\S]*?\*\//g, '');
-  return new Map(
-    [...blockWithoutComments.matchAll(/(?:^|;)\s*([\w-]+)\s*:\s*([^;]+?)\s*(?=;|$)/g)].map(
-      match => [match[1], match[2].trim()],
-    ),
-  );
+function declarationsFor(source: string, selector: string): Map<string, string> {
+  const matches = allDeclarationsFor(source, selector);
+  expect(matches, `Expected exactly one CSS rule for ${selector}`).toHaveLength(1);
+  return matches[0];
 }
 
 interface DirectJsxChild {
@@ -105,10 +111,15 @@ describe('pipeline card style contract', () => {
   });
 
   it('keeps the score beside a shrinkable company name and clear of the overflow menu', () => {
+    const column = allDeclarationsFor(pipelineCss, '.column').find(
+      declarations => declarations.get('flex') === '0 0 340px',
+    );
     const cardIdLine = declarationsFor(pipelineCss, '.card-id-line');
     const cardCompany = declarationsFor(pipelineCss, '.card-company');
     const scoreNum = declarationsFor(pipelineCss, '.card .score-num');
 
+    expect(column, 'Expected the base 340px pipeline column rule').toBeDefined();
+    expect(column?.get('min-width')).toBe('0');
     expect(cardIdLine.get('justify-content')).toBe('flex-start');
     expect(cardIdLine.get('align-items')).toBe('baseline');
     expect(cardIdLine.get('gap')).toBe('8px');


### PR DESCRIPTION
## What changed

- place Kanban scores directly beside company names before the action menu
- constrain long company names so scores and controls stay visible
- standardize vertical kebab and horizontal meatball icons with correctly sized Lucide ellipses
- add contract coverage plus desktop, tablet, and mobile browser verification

## Why

Scores were visually detached from company names, long names could squeeze controls, and menu-dot direction and sizing were inconsistent across surfaces.

## Validation

- `npm run test:quick`
- `npm run build`
- `PLAYWRIGHT_START_SERVER=1 PLAYWRIGHT_PORT=3102 npx playwright test test/e2e/pipeline-card-visual.spec.ts` (3 passed)
- visually inspected 1280x800, 768x1024, and 375x667 screenshots