### PR TITLE
feat(update): add resilient one-click self-updates

### DIFF
--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -103,6 +103,8 @@ executable policy is the exact allowlist.
 | `update-system.mjs`                | Update, rollback, and update-check logic                                   |
 | `test-all.mjs`                     | Local and CI quick gate                                                    |
 | `scripts/sync-release-version.mjs` | Release version synchronizer                                               |
+| `scripts/update-worker.mjs`        | Detached update, restart, verification, and recovery worker                |
+| `scripts/web.mjs`                  | Managed local, production, and Tailscale web launcher                      |
 | `batch/batch-prompt.md`            | Batch worker prompt                                                        |
 | `batch/batch-runner.sh`            | Batch orchestrator                                                         |
 | `.claude/skills/sur9e/*`           | Project-owned sur9e skill                                                  |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,6 +5,7 @@
 - An AI coding CLI — at least one of [Claude Code](https://claude.com/claude-code) (the most polished path), [Codex](https://github.com/openai/codex), or [OpenCode](https://opencode.ai) — installed and authenticated
 - Node.js 20+ (for the web UI and CLI scripts)
 - Python 3.10+ (for the batch job scanner) — on macOS the installer auto-installs this via [Homebrew](https://brew.sh) if it's missing
+- POSIX `ps` plus `lsof` (used by the managed web launcher to verify process ownership); macOS includes both, while minimal Linux installs may need `procps` and `lsof`
 
 ## Quick Start (4 steps)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "sur9e",
       "version": "0.3.2",
+      "type": "module",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "sur9e",
+  "type": "module",
   "version": "0.3.2",
   "description": "AI-powered job search pipeline built on Claude Code",
   "engines": {

--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -21,6 +21,12 @@ const HEALTH_TIMEOUT_MS = 120_000;
 const HEALTH_INTERVAL_MS = 1_000;
 const CLAIM_PENDING_LEASE_MS = 60_000;
 const TERMINAL_PHASES = new Set(['succeeded', 'rolled-back', 'failed']);
+const POST_ROLLBACK_CHECKPOINTS = new Set([
+  'rollback-complete',
+  'dependencies-restored',
+  'recovery-build-complete',
+  'recovery-server-started',
+]);
 const COMMAND_TIMEOUTS_MS = {
   apply: 15 * 60_000,
   stop: 2 * 60_000,
@@ -102,13 +108,24 @@ function runCommand(
     let settled = false;
     let timedOut = false;
     let escalation = null;
+    let terminationPoll = null;
     const finish = callback => value => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       if (escalation) clearTimeout(escalation);
+      if (terminationPoll) clearTimeout(terminationPoll);
       if (heartbeat) clearInterval(heartbeat);
       callback(value);
+    };
+    const ownedGroupAlive = () => {
+      if (!child.pid) return false;
+      try {
+        process.kill(-child.pid, 0);
+        return true;
+      } catch (error) {
+        return error?.code !== 'ESRCH';
+      }
     };
     const timer = setTimeout(() => {
       if (settled) return;
@@ -124,19 +141,26 @@ function runCommand(
         } catch {
           // The owned command group already exited.
         }
-        finish(reject)(new Error('Command timed out'));
+        const waitForTermination = () => {
+          if (!ownedGroupAlive()) {
+            finish(reject)(new Error('Command timed out'));
+            return;
+          }
+          terminationPoll = setTimeout(waitForTermination, 50);
+          terminationPoll.unref?.();
+        };
+        waitForTermination();
       }, 2_000);
       escalation.unref?.();
     }, timeoutMs);
     timer.unref?.();
     const heartbeat = onHeartbeat ? setInterval(onHeartbeat, heartbeatMs) : null;
     heartbeat?.unref?.();
-    child.once('error', finish(reject));
+    child.once('error', error => {
+      if (!timedOut) finish(reject)(error);
+    });
     child.once('exit', (code, signal) => {
-      if (timedOut) {
-        finish(reject)(new Error('Command timed out'));
-        return;
-      }
+      if (timedOut) return;
       if (code === 0 && signal === null) finish(resolvePromise)();
       else finish(reject)(new Error('Command failed'));
     });
@@ -264,7 +288,7 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps, optio
         });
       }
       recoveryStage = 'rollback';
-      if (job.checkpoint !== 'rollback-complete' && runtime.readVersion(root) !== job.fromVersion) {
+      if (!POST_ROLLBACK_CHECKPOINTS.has(job.checkpoint)) {
         await runPhaseCommand(process.execPath, [join(root, 'update-system.mjs'), 'rollback'], {
           cwd: root,
           timeoutMs: COMMAND_TIMEOUTS_MS.rollback,

--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { closeSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { UpdateJob } from '../src/lib/schemas/update-job.ts';
+
+const HEALTH_URL = 'http://127.0.0.1:3000';
+const HEALTH_TIMEOUT_MS = 120_000;
+const HEALTH_INTERVAL_MS = 1_000;
+
+const UPDATE_FAILURES = {
+  stopping: 'Update restart failed while stopping',
+  rebuilding: 'Update restart failed while rebuilding',
+  restarting: 'Update restart failed while restarting',
+  verifying: 'Update restart failed while verifying',
+};
+
+const RECOVERY_FAILURES = {
+  cleanup: 'stopping the updated server',
+  rollback: 'rolling back the checkout',
+  install: 'installing previous dependencies',
+  rebuild: 'rebuilding the previous version',
+  restart: 'restarting the previous version',
+  verification: 'verifying the previous version',
+};
+
+function jobPath(root, jobId) {
+  return join(root, 'data/update/jobs', `${jobId}.json`);
+}
+
+function pidPath(root, jobId) {
+  return join(root, 'data/update/jobs', `${jobId}.pid`);
+}
+
+function claimPid(root, jobId, pid) {
+  const path = pidPath(root, jobId);
+  let descriptor;
+  try {
+    descriptor = openSync(path, 'wx');
+    writeFileSync(descriptor, `${pid}\n`, 'utf-8');
+  } catch (error) {
+    if (descriptor !== undefined) {
+      closeSync(descriptor);
+      rmSync(path, { force: true });
+    }
+    throw error;
+  }
+  closeSync(descriptor);
+}
+
+function loadJob(root, jobId) {
+  return UpdateJob.parse(JSON.parse(readFileSync(jobPath(root, jobId), 'utf-8')));
+}
+
+function persistJob(root, job) {
+  const parsed = UpdateJob.parse(job);
+  const destination = jobPath(root, parsed.id);
+  const temporary = `${destination}.${randomBytes(4).toString('hex')}.tmp`;
+  try {
+    writeFileSync(temporary, `${JSON.stringify(parsed, null, 2)}\n`, 'utf-8');
+    renameSync(temporary, destination);
+  } catch (error) {
+    rmSync(temporary, { force: true });
+    throw error;
+  }
+}
+
+function runCommand(command, args, options) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { ...options, shell: false, stdio: 'ignore' });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0 && signal === null) resolvePromise();
+      else reject(new Error('Command failed'));
+    });
+  });
+}
+
+async function waitForHealth(url, { timeoutMs, intervalMs }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(Math.max(1, Math.min(intervalMs, remaining))),
+      });
+      if (response.ok) return;
+    } catch {
+      // The server may still be starting.
+    }
+    if (Date.now() >= deadline) break;
+    await new Promise(resolvePromise => setTimeout(resolvePromise, intervalMs));
+  }
+  throw new Error('Health verification timed out');
+}
+
+const defaultDeps = {
+  pid: process.pid,
+  clock: () => new Date(),
+  claimPid,
+  persistJob,
+  runCommand,
+  waitForHealth,
+};
+
+/**
+ * Apply an update and restart the managed web server while preserving its
+ * persisted dev/prod and Tailscale launch mode. All process and health effects
+ * are dependencies so the state machine can be tested without touching a real
+ * checkout, server, port, or Tailscale process.
+ */
+export async function runUpdateRestartJob(root, jobId, deps = defaultDeps) {
+  const runtime = { ...defaultDeps, ...deps };
+  try {
+    runtime.claimPid(root, jobId, runtime.pid);
+  } catch {
+    return { status: 'failed' };
+  }
+
+  let job;
+  try {
+    job = loadJob(root, jobId);
+  } catch {
+    return { status: 'failed' };
+  }
+  const transition = (phase, error) => {
+    const { error: _previousError, ...current } = job;
+    job = UpdateJob.parse({
+      ...current,
+      phase,
+      launchState: 'owned',
+      pid: runtime.pid,
+      updatedAt: runtime.clock().toISOString(),
+      ...(error === undefined ? {} : { error }),
+    });
+    runtime.persistJob(root, job);
+  };
+
+  const startServer = () => {
+    const startArgs = [join(root, 'scripts/web.mjs')];
+    if (job.mode.prod) startArgs.push('--prod');
+    else if (job.mode.tailscale) startArgs.push('--dev');
+    if (job.mode.tailscale) startArgs.push('--tailscale');
+    startArgs.push('--detach');
+    return runtime.runCommand(process.execPath, startArgs, {
+      cwd: root,
+      ...(job.mode.prod ? { env: { ...process.env, SUR9E_WEB_SKIP_BUILD: '1' } } : {}),
+    });
+  };
+
+  const verifyHealth = () =>
+    runtime.waitForHealth(HEALTH_URL, {
+      timeoutMs: HEALTH_TIMEOUT_MS,
+      intervalMs: HEALTH_INTERVAL_MS,
+    });
+
+  transition('applying');
+  try {
+    await runtime.runCommand(process.execPath, [join(root, 'update-system.mjs'), 'apply'], {
+      cwd: root,
+    });
+  } catch {
+    transition('failed', 'Update failed while applying the new version');
+    return { status: 'failed' };
+  }
+
+  let failedPhase;
+  try {
+    failedPhase = 'stopping';
+    transition(failedPhase);
+    await runtime.runCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
+      cwd: root,
+    });
+    if (job.mode.prod) {
+      failedPhase = 'rebuilding';
+      transition(failedPhase);
+      await runtime.runCommand('npm', ['run', 'build'], { cwd: root });
+    }
+    failedPhase = 'restarting';
+    transition(failedPhase);
+    await startServer();
+    failedPhase = 'verifying';
+    transition(failedPhase);
+    await verifyHealth();
+    transition('succeeded');
+    return { status: 'succeeded' };
+  } catch {
+    const originalError = UPDATE_FAILURES[failedPhase] ?? 'Update restart failed';
+    transition('recovering', originalError);
+
+    let recoveryStage = 'cleanup';
+    try {
+      if (failedPhase === 'restarting' || failedPhase === 'verifying') {
+        await runtime.runCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
+          cwd: root,
+        });
+      }
+      recoveryStage = 'rollback';
+      await runtime.runCommand(process.execPath, [join(root, 'update-system.mjs'), 'rollback'], {
+        cwd: root,
+      });
+      recoveryStage = 'install';
+      await runtime.runCommand('npm', ['install', '--silent'], { cwd: root });
+      if (job.mode.prod) {
+        recoveryStage = 'rebuild';
+        await runtime.runCommand('npm', ['run', 'build'], { cwd: root });
+      }
+      recoveryStage = 'restart';
+      await startServer();
+      recoveryStage = 'verification';
+      await verifyHealth();
+      transition('rolled-back', originalError);
+      return { status: 'rolled-back' };
+    } catch {
+      const recoveryError = RECOVERY_FAILURES[recoveryStage] ?? 'recovering the previous version';
+      transition('failed', `${originalError}; recovery failed while ${recoveryError}`);
+      return { status: 'failed' };
+    }
+  }
+}
+
+function parseCliArgs(argv) {
+  const rootIndex = argv.indexOf('--root');
+  const jobIdIndex = argv.indexOf('--job-id');
+  if (rootIndex < 0 || !argv[rootIndex + 1] || jobIdIndex < 0 || !argv[jobIdIndex + 1]) {
+    throw new Error('Missing worker arguments');
+  }
+  return { root: argv[rootIndex + 1], jobId: argv[jobIdIndex + 1] };
+}
+
+const isDirectExecution =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isDirectExecution) {
+  try {
+    const { root, jobId } = parseCliArgs(process.argv.slice(2));
+    await runUpdateRestartJob(root, jobId);
+  } catch {
+    console.error('Update worker failed');
+    process.exitCode = 1;
+  }
+}

--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -2,14 +2,33 @@
 
 import { spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { closeSync, openSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { UpdateJob } from '../src/lib/schemas/update-job.ts';
 
-const HEALTH_URL = 'http://127.0.0.1:3000';
+const HEALTH_URL = 'http://127.0.0.1:3000/api/version';
 const HEALTH_TIMEOUT_MS = 120_000;
 const HEALTH_INTERVAL_MS = 1_000;
+const CLAIM_PENDING_LEASE_MS = 60_000;
+const TERMINAL_PHASES = new Set(['succeeded', 'rolled-back', 'failed']);
+const COMMAND_TIMEOUTS_MS = {
+  apply: 15 * 60_000,
+  stop: 2 * 60_000,
+  build: 15 * 60_000,
+  start: 2 * 60_000,
+  rollback: 10 * 60_000,
+  install: 10 * 60_000,
+};
 
 const UPDATE_FAILURES = {
   stopping: 'Update restart failed while stopping',
@@ -68,26 +87,77 @@ function persistJob(root, job) {
   }
 }
 
-function runCommand(command, args, options) {
+function runCommand(
+  command,
+  args,
+  { timeoutMs = 10 * 60_000, onHeartbeat, heartbeatMs = 10_000, ...options },
+) {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(command, args, { ...options, shell: false, stdio: 'ignore' });
-    child.once('error', reject);
+    const child = spawn(command, args, {
+      ...options,
+      detached: true,
+      shell: false,
+      stdio: 'ignore',
+    });
+    let settled = false;
+    let timedOut = false;
+    let escalation = null;
+    const finish = callback => value => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (escalation) clearTimeout(escalation);
+      if (heartbeat) clearInterval(heartbeat);
+      callback(value);
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      timedOut = true;
+      try {
+        if (child.pid) process.kill(-child.pid, 'SIGTERM');
+      } catch {
+        // The command may have exited between the timeout and the signal.
+      }
+      escalation = setTimeout(() => {
+        try {
+          if (child.pid) process.kill(-child.pid, 'SIGKILL');
+        } catch {
+          // The owned command group already exited.
+        }
+        finish(reject)(new Error('Command timed out'));
+      }, 2_000);
+      escalation.unref?.();
+    }, timeoutMs);
+    timer.unref?.();
+    const heartbeat = onHeartbeat ? setInterval(onHeartbeat, heartbeatMs) : null;
+    heartbeat?.unref?.();
+    child.once('error', finish(reject));
     child.once('exit', (code, signal) => {
-      if (code === 0 && signal === null) resolvePromise();
-      else reject(new Error('Command failed'));
+      if (timedOut) {
+        finish(reject)(new Error('Command timed out'));
+        return;
+      }
+      if (code === 0 && signal === null) finish(resolvePromise)();
+      else finish(reject)(new Error('Command failed'));
     });
   });
 }
 
-async function waitForHealth(url, { timeoutMs, intervalMs }) {
+export async function waitForSur9eHealth(
+  url,
+  { timeoutMs, intervalMs, expectedVersion, launchId, fetchImpl = fetch },
+) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const remaining = deadline - Date.now();
     try {
-      const response = await fetch(url, {
+      const response = await fetchImpl(url, {
         signal: AbortSignal.timeout(Math.max(1, Math.min(intervalMs, remaining))),
       });
-      if (response.ok) return;
+      if (response.ok) {
+        const payload = await response.json();
+        if (payload?.version === expectedVersion && payload?.launchId === launchId) return;
+      }
     } catch {
       // The server may still be starting.
     }
@@ -97,13 +167,27 @@ async function waitForHealth(url, { timeoutMs, intervalMs }) {
   throw new Error('Health verification timed out');
 }
 
+function readLaunchIdentity(root) {
+  const value = JSON.parse(readFileSync(join(root, 'data/web/web.json'), 'utf-8'));
+  if (typeof value?.launchId !== 'string' || value.launchId.length === 0) {
+    throw new Error('Managed launch identity is missing');
+  }
+  return { launchId: value.launchId };
+}
+
+function readVersion(root) {
+  return readFileSync(join(root, 'VERSION'), 'utf-8').trim();
+}
+
 const defaultDeps = {
   pid: process.pid,
   clock: () => new Date(),
   claimPid,
   persistJob,
   runCommand,
-  waitForHealth,
+  waitForHealth: waitForSur9eHealth,
+  readLaunchIdentity,
+  readVersion,
 };
 
 /**
@@ -112,7 +196,7 @@ const defaultDeps = {
  * are dependencies so the state machine can be tested without touching a real
  * checkout, server, port, or Tailscale process.
  */
-export async function runUpdateRestartJob(root, jobId, deps = defaultDeps) {
+export async function runUpdateRestartJob(root, jobId, deps = defaultDeps, options = {}) {
   const runtime = { ...defaultDeps, ...deps };
   try {
     runtime.claimPid(root, jobId, runtime.pid);
@@ -126,7 +210,7 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps) {
   } catch {
     return { status: 'failed' };
   }
-  const transition = (phase, error) => {
+  const transition = (phase, error, checkpoint = job.checkpoint) => {
     const { error: _previousError, ...current } = job;
     job = UpdateJob.parse({
       ...current,
@@ -134,10 +218,17 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps) {
       launchState: 'owned',
       pid: runtime.pid,
       updatedAt: runtime.clock().toISOString(),
+      ...(checkpoint === undefined ? {} : { checkpoint }),
       ...(error === undefined ? {} : { error }),
     });
     runtime.persistJob(root, job);
   };
+
+  const runPhaseCommand = (command, args, commandOptions) =>
+    runtime.runCommand(command, args, {
+      ...commandOptions,
+      onHeartbeat: () => transition(job.phase, job.error, job.checkpoint),
+    });
 
   const startServer = () => {
     const startArgs = [join(root, 'scripts/web.mjs')];
@@ -145,81 +236,189 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps) {
     else if (job.mode.tailscale) startArgs.push('--dev');
     if (job.mode.tailscale) startArgs.push('--tailscale');
     startArgs.push('--detach');
-    return runtime.runCommand(process.execPath, startArgs, {
+    return runPhaseCommand(process.execPath, startArgs, {
       cwd: root,
+      timeoutMs: COMMAND_TIMEOUTS_MS.start,
       ...(job.mode.prod ? { env: { ...process.env, SUR9E_WEB_SKIP_BUILD: '1' } } : {}),
     });
   };
 
-  const verifyHealth = () =>
-    runtime.waitForHealth(HEALTH_URL, {
+  const verifyHealth = expectedVersion => {
+    const { launchId } = runtime.readLaunchIdentity(root);
+    return runtime.waitForHealth(HEALTH_URL, {
       timeoutMs: HEALTH_TIMEOUT_MS,
       intervalMs: HEALTH_INTERVAL_MS,
+      expectedVersion,
+      launchId,
     });
+  };
 
-  transition('applying');
-  try {
-    await runtime.runCommand(process.execPath, [join(root, 'update-system.mjs'), 'apply'], {
-      cwd: root,
-    });
-  } catch {
-    transition('failed', 'Update failed while applying the new version');
-    return { status: 'failed' };
-  }
-
-  let failedPhase;
-  try {
-    failedPhase = 'stopping';
-    transition(failedPhase);
-    await runtime.runCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
-      cwd: root,
-    });
-    if (job.mode.prod) {
-      failedPhase = 'rebuilding';
-      transition(failedPhase);
-      await runtime.runCommand('npm', ['run', 'build'], { cwd: root });
-    }
-    failedPhase = 'restarting';
-    transition(failedPhase);
-    await startServer();
-    failedPhase = 'verifying';
-    transition(failedPhase);
-    await verifyHealth();
-    transition('succeeded');
-    return { status: 'succeeded' };
-  } catch {
-    const originalError = UPDATE_FAILURES[failedPhase] ?? 'Update restart failed';
+  const recover = async originalError => {
     transition('recovering', originalError);
-
     let recoveryStage = 'cleanup';
     try {
-      if (failedPhase === 'restarting' || failedPhase === 'verifying') {
-        await runtime.runCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
+      if (job.checkpoint !== 'server-stopped' && job.checkpoint !== 'rollback-complete') {
+        await runPhaseCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
           cwd: root,
+          timeoutMs: COMMAND_TIMEOUTS_MS.stop,
         });
       }
       recoveryStage = 'rollback';
-      await runtime.runCommand(process.execPath, [join(root, 'update-system.mjs'), 'rollback'], {
-        cwd: root,
-      });
+      if (job.checkpoint !== 'rollback-complete' && runtime.readVersion(root) !== job.fromVersion) {
+        await runPhaseCommand(process.execPath, [join(root, 'update-system.mjs'), 'rollback'], {
+          cwd: root,
+          timeoutMs: COMMAND_TIMEOUTS_MS.rollback,
+        });
+      }
+      transition('recovering', originalError, 'rollback-complete');
       recoveryStage = 'install';
-      await runtime.runCommand('npm', ['install', '--silent'], { cwd: root });
+      await runPhaseCommand('npm', ['ci', '--no-audit', '--no-fund'], {
+        cwd: root,
+        timeoutMs: COMMAND_TIMEOUTS_MS.install,
+      });
+      transition('recovering', originalError, 'dependencies-restored');
       if (job.mode.prod) {
         recoveryStage = 'rebuild';
-        await runtime.runCommand('npm', ['run', 'build'], { cwd: root });
+        await runPhaseCommand('npm', ['run', 'build'], {
+          cwd: root,
+          timeoutMs: COMMAND_TIMEOUTS_MS.build,
+        });
+        transition('recovering', originalError, 'recovery-build-complete');
       }
       recoveryStage = 'restart';
       await startServer();
+      transition('recovering', originalError, 'recovery-server-started');
       recoveryStage = 'verification';
-      await verifyHealth();
-      transition('rolled-back', originalError);
+      await verifyHealth(job.fromVersion);
+      transition('rolled-back', originalError, 'recovery-server-started');
       return { status: 'rolled-back' };
     } catch {
       const recoveryError = RECOVERY_FAILURES[recoveryStage] ?? 'recovering the previous version';
       transition('failed', `${originalError}; recovery failed while ${recoveryError}`);
       return { status: 'failed' };
     }
+  };
+
+  if (options.recoveryOnly) {
+    return recover(job.error ?? 'Update worker stopped before completion');
   }
+
+  transition('applying', undefined, 'apply-started');
+  try {
+    await runPhaseCommand(process.execPath, [join(root, 'update-system.mjs'), 'apply'], {
+      cwd: root,
+      timeoutMs: COMMAND_TIMEOUTS_MS.apply,
+    });
+  } catch {
+    transition('failed', 'Update failed while applying the new version', 'apply-started');
+    return { status: 'failed' };
+  }
+
+  let failedPhase;
+  try {
+    failedPhase = 'stopping';
+    transition(failedPhase, undefined, 'applied');
+    await runPhaseCommand(process.execPath, [join(root, 'scripts/web.mjs'), 'stop'], {
+      cwd: root,
+      timeoutMs: COMMAND_TIMEOUTS_MS.stop,
+    });
+    if (job.mode.prod) {
+      failedPhase = 'rebuilding';
+      transition(failedPhase, undefined, 'server-stopped');
+      await runPhaseCommand('npm', ['run', 'build'], {
+        cwd: root,
+        timeoutMs: COMMAND_TIMEOUTS_MS.build,
+      });
+    }
+    failedPhase = 'restarting';
+    transition(failedPhase, undefined, 'server-stopped');
+    await startServer();
+    failedPhase = 'verifying';
+    transition(failedPhase, undefined, 'server-restarted');
+    await verifyHealth(job.toVersion ?? job.fromVersion);
+    transition('succeeded');
+    return { status: 'succeeded' };
+  } catch {
+    return recover(UPDATE_FAILURES[failedPhase] ?? 'Update restart failed');
+  }
+}
+
+/**
+ * Launcher preflight for a reboot or killed update supervisor. It only adopts
+ * jobs whose prior owner is provably dead (or whose unclaimed recovery lease
+ * expired), then runs the idempotent recovery path in this launcher process.
+ */
+export async function recoverInterruptedUpdateOnStartup(root, deps = {}) {
+  const runtime = {
+    clock: () => new Date(),
+    pidAlive: pid => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    runJob: runUpdateRestartJob,
+    ...deps,
+  };
+  const directory = join(root, 'data/update/jobs');
+  if (!existsSync(directory)) return { status: 'none' };
+
+  const jobs = readdirSync(directory)
+    .filter(file => file.endsWith('.json'))
+    .map(file => {
+      try {
+        return loadJob(root, file.slice(0, -'.json'.length));
+      } catch {
+        return null;
+      }
+    })
+    .filter(job => job && !TERMINAL_PHASES.has(job.phase))
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
+
+  const job = jobs[0];
+  if (!job || job.phase === 'queued') return { status: 'none' };
+  if (job.launchState === 'owned' && job.pid !== undefined && runtime.pidAlive(job.pid)) {
+    return { status: 'active', jobId: job.id };
+  }
+  if (job.launchState === 'claim-pending') {
+    const sidecar = pidPath(root, job.id);
+    if (existsSync(sidecar)) {
+      const sidecarPid = Number(readFileSync(sidecar, 'utf-8').trim());
+      if (Number.isInteger(sidecarPid) && sidecarPid > 0 && runtime.pidAlive(sidecarPid)) {
+        return { status: 'active', jobId: job.id };
+      }
+    }
+    if (runtime.clock().getTime() - Date.parse(job.updatedAt) < CLAIM_PENDING_LEASE_MS) {
+      return { status: 'active', jobId: job.id };
+    }
+  }
+
+  const sidecar = pidPath(root, job.id);
+  if (existsSync(sidecar)) {
+    const sidecarPid = Number(readFileSync(sidecar, 'utf-8').trim());
+    if (Number.isInteger(sidecarPid) && sidecarPid > 0 && runtime.pidAlive(sidecarPid)) {
+      return { status: 'active', jobId: job.id };
+    }
+    rmSync(sidecar, { force: true });
+  }
+  const result = await runtime.runJob(root, job.id, defaultDeps, { recoveryOnly: true });
+  return { status: 'recovered', jobId: job.id, result };
+}
+
+export function hasInterruptedUpdateOnStartup(root) {
+  const directory = join(root, 'data/update/jobs');
+  if (!existsSync(directory)) return false;
+  return readdirSync(directory).some(file => {
+    if (!file.endsWith('.json')) return false;
+    try {
+      const job = loadJob(root, file.slice(0, -'.json'.length));
+      return job.phase !== 'queued' && !TERMINAL_PHASES.has(job.phase);
+    } catch {
+      return false;
+    }
+  });
 }
 
 function parseCliArgs(argv) {
@@ -228,7 +427,11 @@ function parseCliArgs(argv) {
   if (rootIndex < 0 || !argv[rootIndex + 1] || jobIdIndex < 0 || !argv[jobIdIndex + 1]) {
     throw new Error('Missing worker arguments');
   }
-  return { root: argv[rootIndex + 1], jobId: argv[jobIdIndex + 1] };
+  return {
+    root: argv[rootIndex + 1],
+    jobId: argv[jobIdIndex + 1],
+    recoveryOnly: argv.includes('--recover'),
+  };
 }
 
 const isDirectExecution =
@@ -236,8 +439,9 @@ const isDirectExecution =
 
 if (isDirectExecution) {
   try {
-    const { root, jobId } = parseCliArgs(process.argv.slice(2));
-    await runUpdateRestartJob(root, jobId);
+    const { root, jobId, recoveryOnly } = parseCliArgs(process.argv.slice(2));
+    const result = await runUpdateRestartJob(root, jobId, defaultDeps, { recoveryOnly });
+    if (result.status === 'failed') process.exitCode = 1;
   } catch {
     console.error('Update worker failed');
     process.exitCode = 1;

--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -60,6 +60,17 @@ function pidPath(root, jobId) {
   return join(root, 'data/update/jobs', `${jobId}.pid`);
 }
 
+function inspectSidecarOwner(root, jobId, pidAlive) {
+  const path = pidPath(root, jobId);
+  if (!existsSync(path)) return { path, exists: false, alive: false };
+  const pid = Number(readFileSync(path, 'utf-8').trim());
+  return {
+    path,
+    exists: true,
+    alive: Number.isInteger(pid) && pid > 0 && pidAlive(pid),
+  };
+}
+
 function claimPid(root, jobId, pid) {
   const path = pidPath(root, jobId);
   let descriptor;
@@ -147,7 +158,6 @@ function runCommand(
             return;
           }
           terminationPoll = setTimeout(waitForTermination, 50);
-          terminationPoll.unref?.();
         };
         waitForTermination();
       }, 2_000);
@@ -407,25 +417,17 @@ export async function recoverInterruptedUpdateOnStartup(root, deps = {}) {
     return { status: 'active', jobId: job.id };
   }
   if (job.launchState === 'claim-pending') {
-    const sidecar = pidPath(root, job.id);
-    if (existsSync(sidecar)) {
-      const sidecarPid = Number(readFileSync(sidecar, 'utf-8').trim());
-      if (Number.isInteger(sidecarPid) && sidecarPid > 0 && runtime.pidAlive(sidecarPid)) {
-        return { status: 'active', jobId: job.id };
-      }
-    }
+    const sidecarOwner = inspectSidecarOwner(root, job.id, runtime.pidAlive);
+    if (sidecarOwner.alive) return { status: 'active', jobId: job.id };
     if (runtime.clock().getTime() - Date.parse(job.updatedAt) < CLAIM_PENDING_LEASE_MS) {
       return { status: 'active', jobId: job.id };
     }
   }
 
-  const sidecar = pidPath(root, job.id);
-  if (existsSync(sidecar)) {
-    const sidecarPid = Number(readFileSync(sidecar, 'utf-8').trim());
-    if (Number.isInteger(sidecarPid) && sidecarPid > 0 && runtime.pidAlive(sidecarPid)) {
-      return { status: 'active', jobId: job.id };
-    }
-    rmSync(sidecar, { force: true });
+  const sidecarOwner = inspectSidecarOwner(root, job.id, runtime.pidAlive);
+  if (sidecarOwner.alive) return { status: 'active', jobId: job.id };
+  if (sidecarOwner.exists) {
+    rmSync(sidecarOwner.path, { force: true });
   }
   const result = await runtime.runJob(root, job.id, defaultDeps, { recoveryOnly: true });
   return { status: 'recovered', jobId: job.id, result };

--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -62,8 +62,14 @@ function pidPath(root, jobId) {
 
 function inspectSidecarOwner(root, jobId, pidAlive) {
   const path = pidPath(root, jobId);
-  if (!existsSync(path)) return { path, exists: false, alive: false };
-  const pid = Number(readFileSync(path, 'utf-8').trim());
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') return { path, exists: false, alive: false };
+    throw error;
+  }
+  const pid = Number(raw.trim());
   return {
     path,
     exists: true,

--- a/scripts/web.mjs
+++ b/scripts/web.mjs
@@ -23,6 +23,10 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  hasInterruptedUpdateOnStartup,
+  recoverInterruptedUpdateOnStartup,
+} from './update-worker.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 // Exported so the runtime commands (and any caller) can resolve the
@@ -283,6 +287,8 @@ export async function cmdStart(opts, deps = {}) {
     root = ROOT,
     launchId: launchIdFactory = randomUUID,
     inspectProcess = pid => inspectLiveProcess(pid, { exec }),
+    recoverUpdate = recoverInterruptedUpdateOnStartup,
+    hasInterruptedUpdate = hasInterruptedUpdateOnStartup,
   } = deps;
   const launchId = env.SUR9E_WEB_LAUNCH_ID || launchIdFactory();
 
@@ -291,6 +297,18 @@ export async function cmdStart(opts, deps = {}) {
     error(`:${PORT} is already in use by PID ${listener.pid} (${listener.command}).`);
     error('Not starting a second server. `npm run web:status` to inspect it.');
     return 1;
+  }
+
+  if (hasInterruptedUpdate(root)) {
+    const recovery = await recoverUpdate(root);
+    if (recovery.status === 'recovered') {
+      if (recovery.result.status === 'failed') {
+        error('Interrupted update recovery failed — the server was not started.');
+        return 1;
+      }
+      log('Recovered the previous Sur9e version after an interrupted update.');
+      return 0;
+    }
   }
 
   // Prod always rebuilds; a failed build aborts with nothing left running.

--- a/scripts/web.mjs
+++ b/scripts/web.mjs
@@ -126,8 +126,37 @@ function readMeta(stateDir) {
   }
 }
 
-function clearState(stateDir) {
+function writeMeta(stateDir, meta) {
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(pidFile(stateDir), String(meta.pid));
+  writeFileSync(metaFile(stateDir), JSON.stringify(meta, null, 2));
+}
+
+function clearState(stateDir, expectedPid) {
+  if (expectedPid !== undefined) {
+    const pid = readPid(stateDir);
+    const meta = readMeta(stateDir);
+    if (pid !== expectedPid || meta?.pid !== expectedPid) return false;
+  }
   for (const f of [pidFile(stateDir), metaFile(stateDir)]) rmSync(f, { force: true });
+  return true;
+}
+
+function readManagedMeta(stateDir) {
+  const pid = readPid(stateDir);
+  const meta = readMeta(stateDir);
+  if (
+    !pid ||
+    !meta ||
+    meta.pid !== pid ||
+    typeof meta.prod !== 'boolean' ||
+    typeof meta.tailscale !== 'boolean' ||
+    typeof meta.startedAt !== 'string' ||
+    !Number.isFinite(Date.parse(meta.startedAt))
+  ) {
+    return null;
+  }
+  return meta;
 }
 
 /** Command line of a live process, or null when the PID is dead.
@@ -140,6 +169,14 @@ function psCommand(pid, { exec }) {
 /** True when `pid` is a live process whose command line is this launcher. */
 function isOurLauncher(pid, { exec }) {
   return psCommand(pid, { exec })?.includes('scripts/web.mjs') ?? false;
+}
+
+/** Persisted launch mode for server-side orchestrators. Stale, foreign, or
+ * malformed state falls back to the local dev mode with no tailnet exposure. */
+export function getWebLaunchMode({ stateDir = DEFAULT_STATE_DIR, exec = defaultExec } = {}) {
+  const meta = readManagedMeta(stateDir);
+  if (!meta || !isOurLauncher(meta.pid, { exec })) return { prod: false, tailscale: false };
+  return { prod: meta.prod, tailscale: meta.tailscale };
 }
 
 // ── Tailscale serve (tailnet-internal HTTPS; NEVER funnel) ──
@@ -197,6 +234,8 @@ export async function cmdStart(opts, deps = {}) {
     error = console.error,
     stateDir = DEFAULT_STATE_DIR,
     env = process.env,
+    processImpl = process,
+    now = () => new Date().toISOString(),
   } = deps;
 
   const listener = getListener({ exec });
@@ -221,11 +260,36 @@ export async function cmdStart(opts, deps = {}) {
     }
   }
 
-  if (opts.detach) return detachSelf(opts, { log, error, stateDir, exec, exists });
-  return runForeground(opts, { exec, spawnImpl, exists, log, error, stateDir });
+  if (opts.detach) {
+    return detachSelf(opts, {
+      log,
+      error,
+      stateDir,
+      exec,
+      exists,
+      spawnImpl,
+      env,
+      processImpl,
+      now,
+    });
+  }
+  return runForeground(opts, {
+    exec,
+    spawnImpl,
+    exists,
+    log,
+    error,
+    stateDir,
+    env,
+    processImpl,
+    now,
+  });
 }
 
-function detachSelf(opts, { log, error: _error, stateDir, exec, exists }) {
+function detachSelf(
+  opts,
+  { log, error: _error, stateDir, exec, exists, spawnImpl, env, processImpl, now },
+) {
   mkdirSync(stateDir, { recursive: true });
   const fd = openSync(logFile(stateDir), 'a');
   const args = [fileURLToPath(import.meta.url)];
@@ -234,26 +298,18 @@ function detachSelf(opts, { log, error: _error, stateDir, exec, exists }) {
   // explicit --dev so a `--dev --tailscale` start stays dev after re-spawn.
   else if (opts.tailscale) args.push('--dev');
   if (opts.tailscale) args.push('--tailscale');
-  const child = spawn(process.execPath, args, {
+  const child = spawnImpl(processImpl.execPath, args, {
     cwd: ROOT,
     detached: true,
     stdio: ['ignore', fd, fd],
-    env: { ...process.env, SUR9E_WEB_SKIP_BUILD: '1' },
+    env: { ...env, SUR9E_WEB_SKIP_BUILD: '1' },
   });
-  writeFileSync(pidFile(stateDir), String(child.pid));
-  writeFileSync(
-    metaFile(stateDir),
-    JSON.stringify(
-      {
-        pid: child.pid,
-        prod: opts.prod,
-        tailscale: opts.tailscale,
-        startedAt: new Date().toISOString(),
-      },
-      null,
-      2,
-    ),
-  );
+  writeMeta(stateDir, {
+    pid: child.pid,
+    prod: opts.prod,
+    tailscale: opts.tailscale,
+    startedAt: now(),
+  });
   child.unref();
   log(
     `Started detached (PID ${child.pid}, mode: ${opts.prod ? 'prod' : 'dev'}${opts.tailscale ? ' + tailscale' : ''}).`,
@@ -268,7 +324,10 @@ function detachSelf(opts, { log, error: _error, stateDir, exec, exists }) {
   return 0;
 }
 
-function runForeground(opts, { exec, spawnImpl, exists, log, error }) {
+function runForeground(
+  opts,
+  { exec, spawnImpl, exists, log, error, stateDir, env: inheritedEnv, processImpl, now },
+) {
   // Spawn the local next binary DIRECTLY — an npx intermediary does not
   // reliably forward SIGTERM to its child, so `stop` would orphan the
   // actual server while the port stays bound.
@@ -280,12 +339,19 @@ function runForeground(opts, { exec, spawnImpl, exists, log, error }) {
   // the tailnet hostname so next.config.ts can list it in
   // allowedDevOrigins. Prod builds don't have the restriction but the
   // env var is harmless there.
-  const env = { ...process.env };
+  const env = { ...inheritedEnv };
   if (opts.tailscale) {
     const url = getTailnetUrl({ exec, exists });
     if (url) env.SUR9E_TAILNET_HOST = new URL(url).hostname;
   }
   const child = spawnImpl(NEXT_BIN, args, { cwd: ROOT, stdio: 'inherit', env });
+  const ownerPid = processImpl.pid;
+  writeMeta(stateDir, {
+    pid: ownerPid,
+    prod: opts.prod,
+    tailscale: opts.tailscale,
+    startedAt: now(),
+  });
 
   let serveEnabled = false;
   if (opts.tailscale) {
@@ -304,11 +370,12 @@ function runForeground(opts, { exec, spawnImpl, exists, log, error }) {
     if (serveEnabled) resetServe({ exec, exists, error });
     child.kill('SIGTERM');
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  processImpl.on('SIGINT', shutdown);
+  processImpl.on('SIGTERM', shutdown);
   child.on('exit', code => {
     if (serveEnabled) resetServe({ exec, exists, error });
-    process.exit(code ?? 0);
+    clearState(stateDir, ownerPid);
+    processImpl.exit(code ?? 0);
   });
   return new Promise(() => {}); // lifetime owned by the child's exit handler
 }

--- a/scripts/web.mjs
+++ b/scripts/web.mjs
@@ -362,7 +362,7 @@ function detachSelf(
   opts,
   {
     log,
-    error: _error,
+    error,
     stateDir,
     exec,
     exists,
@@ -390,7 +390,12 @@ function detachSelf(
     env: { ...env, SUR9E_WEB_SKIP_BUILD: '1', SUR9E_WEB_LAUNCH_ID: launchId },
   });
   const identity = inspectProcess(child.pid);
-  if (!identity) throw new Error('Could not identify detached web launcher process');
+  if (!identity) {
+    error('Could not verify detached web launcher ownership — stopping it.');
+    child.kill('SIGTERM');
+    child.unref();
+    return 1;
+  }
   writeMeta(stateDir, {
     pid: child.pid,
     prod: opts.prod,
@@ -448,10 +453,13 @@ function runForeground(
     const url = getTailnetUrl({ exec, exists });
     if (url) env.SUR9E_TAILNET_HOST = new URL(url).hostname;
   }
-  const child = spawnImpl(NEXT_BIN, args, { cwd: ROOT, stdio: 'inherit', env });
   const ownerPid = processImpl.pid;
   const identity = inspectProcess(ownerPid);
-  if (!identity) throw new Error('Could not identify foreground web launcher process');
+  if (!identity) {
+    error('Could not verify foreground web launcher ownership — nothing started.');
+    return 1;
+  }
+  const child = spawnImpl(NEXT_BIN, args, { cwd: ROOT, stdio: 'inherit', env });
   const launchMeta = {
     pid: ownerPid,
     prod: opts.prod,
@@ -682,6 +690,9 @@ export async function cmdStop(deps = {}) {
 // Same direct-execution guard pattern as batch/screen.mjs.
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  // Ownership metadata is rooted to this checkout. Normalize direct launches
+  // from subdirectories before inspecting the wrapper process cwd.
+  process.chdir(ROOT);
   let opts;
   try {
     opts = parseWebArgs(process.argv.slice(2));

--- a/scripts/web.mjs
+++ b/scripts/web.mjs
@@ -19,6 +19,7 @@
 // `tailscale serve` (tailnet-internal) — never funnel.
 
 import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -132,11 +133,19 @@ function writeMeta(stateDir, meta) {
   writeFileSync(metaFile(stateDir), JSON.stringify(meta, null, 2));
 }
 
-function clearState(stateDir, expectedPid) {
-  if (expectedPid !== undefined) {
+function clearState(stateDir, expected) {
+  if (expected !== undefined) {
     const pid = readPid(stateDir);
     const meta = readMeta(stateDir);
-    if (pid !== expectedPid || meta?.pid !== expectedPid) return false;
+    if (
+      pid !== expected.pid ||
+      meta?.pid !== expected.pid ||
+      meta?.root !== expected.root ||
+      meta?.processStart !== expected.processStart ||
+      meta?.launchId !== expected.launchId
+    ) {
+      return false;
+    }
   }
   for (const f of [pidFile(stateDir), metaFile(stateDir)]) rmSync(f, { force: true });
   return true;
@@ -152,11 +161,32 @@ function readManagedMeta(stateDir) {
     typeof meta.prod !== 'boolean' ||
     typeof meta.tailscale !== 'boolean' ||
     typeof meta.startedAt !== 'string' ||
-    !Number.isFinite(Date.parse(meta.startedAt))
+    !Number.isFinite(Date.parse(meta.startedAt)) ||
+    typeof meta.root !== 'string' ||
+    typeof meta.processStart !== 'string' ||
+    !meta.processStart ||
+    typeof meta.launchId !== 'string' ||
+    !meta.launchId
   ) {
     return null;
   }
   return meta;
+}
+
+function inspectLiveProcess(pid, { exec = defaultExec } = {}) {
+  const info = psPidInfo(pid, { exec });
+  if (!info) return null;
+  const start = exec('ps', ['-p', String(pid), '-o', 'lstart=']);
+  const cwd = exec('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn']);
+  const cwdPath = /^n(.+)$/m.exec(cwd.stdout ?? '')?.[1];
+  if (start.status !== 0 || !start.stdout?.trim() || cwd.status !== 0 || !cwdPath) return null;
+  return {
+    pid,
+    ppid: info.ppid,
+    command: info.command,
+    cwd: resolve(cwdPath),
+    start: start.stdout.trim(),
+  };
 }
 
 /** Command line of a live process, or null when the PID is dead.
@@ -166,16 +196,30 @@ function psCommand(pid, { exec }) {
   return res.status === 0 ? res.stdout.trim() : null;
 }
 
-/** True when `pid` is a live process whose command line is this launcher. */
-function isOurLauncher(pid, { exec }) {
-  return psCommand(pid, { exec })?.includes('scripts/web.mjs') ?? false;
+function isManagedLauncher(meta, { root, inspectProcess }) {
+  if (resolve(meta.root) !== resolve(root)) return false;
+  const identity = inspectProcess(meta.pid);
+  return Boolean(
+    identity &&
+      identity.pid === meta.pid &&
+      identity.start === meta.processStart &&
+      resolve(identity.cwd) === resolve(root) &&
+      identity.command.includes('scripts/web.mjs'),
+  );
 }
 
 /** Persisted launch mode for server-side orchestrators. Stale, foreign, or
  * malformed state falls back to the local dev mode with no tailnet exposure. */
-export function getWebLaunchMode({ stateDir = DEFAULT_STATE_DIR, exec = defaultExec } = {}) {
+export function getWebLaunchMode({
+  stateDir = DEFAULT_STATE_DIR,
+  exec = defaultExec,
+  root = ROOT,
+  inspectProcess = pid => inspectLiveProcess(pid, { exec }),
+} = {}) {
   const meta = readManagedMeta(stateDir);
-  if (!meta || !isOurLauncher(meta.pid, { exec })) return { prod: false, tailscale: false };
+  if (!meta || !isManagedLauncher(meta, { root, inspectProcess })) {
+    return { prod: false, tailscale: false };
+  }
   return { prod: meta.prod, tailscale: meta.tailscale };
 }
 
@@ -236,7 +280,11 @@ export async function cmdStart(opts, deps = {}) {
     env = process.env,
     processImpl = process,
     now = () => new Date().toISOString(),
+    root = ROOT,
+    launchId: launchIdFactory = randomUUID,
+    inspectProcess = pid => inspectLiveProcess(pid, { exec }),
   } = deps;
+  const launchId = env.SUR9E_WEB_LAUNCH_ID || launchIdFactory();
 
   const listener = getListener({ exec });
   if (listener) {
@@ -271,6 +319,9 @@ export async function cmdStart(opts, deps = {}) {
       env,
       processImpl,
       now,
+      root,
+      launchId,
+      inspectProcess,
     });
   }
   return runForeground(opts, {
@@ -283,12 +334,28 @@ export async function cmdStart(opts, deps = {}) {
     env,
     processImpl,
     now,
+    root,
+    launchId,
+    inspectProcess,
   });
 }
 
 function detachSelf(
   opts,
-  { log, error: _error, stateDir, exec, exists, spawnImpl, env, processImpl, now },
+  {
+    log,
+    error: _error,
+    stateDir,
+    exec,
+    exists,
+    spawnImpl,
+    env,
+    processImpl,
+    now,
+    root,
+    launchId,
+    inspectProcess,
+  },
 ) {
   mkdirSync(stateDir, { recursive: true });
   const fd = openSync(logFile(stateDir), 'a');
@@ -302,13 +369,18 @@ function detachSelf(
     cwd: ROOT,
     detached: true,
     stdio: ['ignore', fd, fd],
-    env: { ...env, SUR9E_WEB_SKIP_BUILD: '1' },
+    env: { ...env, SUR9E_WEB_SKIP_BUILD: '1', SUR9E_WEB_LAUNCH_ID: launchId },
   });
+  const identity = inspectProcess(child.pid);
+  if (!identity) throw new Error('Could not identify detached web launcher process');
   writeMeta(stateDir, {
     pid: child.pid,
     prod: opts.prod,
     tailscale: opts.tailscale,
     startedAt: now(),
+    root: resolve(root),
+    processStart: identity.start,
+    launchId,
   });
   child.unref();
   log(
@@ -326,7 +398,20 @@ function detachSelf(
 
 function runForeground(
   opts,
-  { exec, spawnImpl, exists, log, error, stateDir, env: inheritedEnv, processImpl, now },
+  {
+    exec,
+    spawnImpl,
+    exists,
+    log,
+    error,
+    stateDir,
+    env: inheritedEnv,
+    processImpl,
+    now,
+    root,
+    launchId,
+    inspectProcess,
+  },
 ) {
   // Spawn the local next binary DIRECTLY — an npx intermediary does not
   // reliably forward SIGTERM to its child, so `stop` would orphan the
@@ -340,18 +425,25 @@ function runForeground(
   // allowedDevOrigins. Prod builds don't have the restriction but the
   // env var is harmless there.
   const env = { ...inheritedEnv };
+  env.SUR9E_WEB_LAUNCH_ID = launchId;
   if (opts.tailscale) {
     const url = getTailnetUrl({ exec, exists });
     if (url) env.SUR9E_TAILNET_HOST = new URL(url).hostname;
   }
   const child = spawnImpl(NEXT_BIN, args, { cwd: ROOT, stdio: 'inherit', env });
   const ownerPid = processImpl.pid;
-  writeMeta(stateDir, {
+  const identity = inspectProcess(ownerPid);
+  if (!identity) throw new Error('Could not identify foreground web launcher process');
+  const launchMeta = {
     pid: ownerPid,
     prod: opts.prod,
     tailscale: opts.tailscale,
     startedAt: now(),
-  });
+    root: resolve(root),
+    processStart: identity.start,
+    launchId,
+  };
+  writeMeta(stateDir, launchMeta);
 
   let serveEnabled = false;
   if (opts.tailscale) {
@@ -374,7 +466,7 @@ function runForeground(
   processImpl.on('SIGTERM', shutdown);
   child.on('exit', code => {
     if (serveEnabled) resetServe({ exec, exists, error });
-    clearState(stateDir, ownerPid);
+    clearState(stateDir, launchMeta);
     processImpl.exit(code ?? 0);
   });
   return new Promise(() => {}); // lifetime owned by the child's exit handler
@@ -395,6 +487,8 @@ export function cmdStatus(deps = {}) {
     exists = existsSync,
     log = console.log,
     stateDir = DEFAULT_STATE_DIR,
+    root = ROOT,
+    inspectProcess = processPid => inspectLiveProcess(processPid, { exec }),
   } = deps;
   const listener = getListener({ exec });
   if (!listener) {
@@ -402,17 +496,17 @@ export function cmdStatus(deps = {}) {
     return 1;
   }
   log(`Listening on :${PORT} — PID ${listener.pid} (${listener.command})`);
-  const pid = readPid(stateDir);
-  const meta = readMeta(stateDir);
-  if (pid && isOurLauncher(pid, { exec })) {
+  const meta = readManagedMeta(stateDir);
+  const managed = meta ? isManagedLauncher(meta, { root, inspectProcess }) : false;
+  if (managed) {
     log(
-      `Managed by the sur9e launcher (wrapper PID ${pid}, mode: ${meta?.prod ? 'prod' : 'dev'}${meta?.tailscale ? ' + tailscale' : ''}, started ${meta?.startedAt ?? 'unknown'}).`,
+      `Managed by the sur9e launcher (wrapper PID ${meta.pid}, mode: ${meta.prod ? 'prod' : 'dev'}${meta.tailscale ? ' + tailscale' : ''}, started ${meta.startedAt}).`,
     );
   } else {
     log('Not managed by the sur9e launcher (started elsewhere).');
   }
   log(`Local: http://localhost:${PORT}`);
-  if (meta?.tailscale) {
+  if (managed && meta.tailscale) {
     const url = getTailnetUrl({ exec, exists });
     if (url) log(`Tailnet: ${url}`);
   }
@@ -426,6 +520,32 @@ function safeKill(kill, pid, signal) {
   } catch {
     /* process already gone between poll and kill — fine */
   }
+}
+
+function signalManagedLauncher(meta, signal, { inspectProcess, kill, root }) {
+  if (!isManagedLauncher(meta, { inspectProcess, root })) return false;
+  safeKill(kill, meta.pid, signal);
+  return true;
+}
+
+function ownedDescendantSnapshot(pid, meta, { inspectProcess, root }) {
+  const target = inspectProcess(pid);
+  if (!target || !isManagedLauncher(meta, { inspectProcess, root })) return null;
+  let current = target;
+  for (let depth = 0; current && depth < 16; depth += 1) {
+    if (current.pid === meta.pid) return { pid: target.pid, start: target.start };
+    if (!Number.isInteger(current.ppid) || current.ppid <= 1) return null;
+    current = inspectProcess(current.ppid);
+  }
+  return null;
+}
+
+function signalOwnedDescendant(snapshot, meta, signal, deps) {
+  const current = deps.inspectProcess(snapshot.pid);
+  if (!current || current.start !== snapshot.start) return false;
+  if (!ownedDescendantSnapshot(snapshot.pid, meta, deps)) return false;
+  safeKill(deps.kill, snapshot.pid, signal);
+  return true;
 }
 
 /** Poll until :3000 is free or `ms` elapses. Returns true once it clears. */
@@ -445,31 +565,6 @@ function psPidInfo(pid, { exec }) {
   return m ? { ppid: Number(m[1]), command: m[2] } : null;
 }
 
-/** True when the :3000 listener belongs to THIS checkout — an untracked
- *  foreground `npm run web` (no state file), vs a genuinely foreign app we must
- *  never touch. next renames its listener to "next-server (vX)", so the holder's
- *  own command rarely names the repo; walk the parent chain, where `node
- *  scripts/web.mjs` and this checkout's `next dev` both carry identifying strings. */
-function isOwnDevServer(pid, { exec, root }) {
-  for (let cur = pid, i = 0; cur > 1 && i < 8; i++) {
-    const info = psPidInfo(cur, { exec });
-    if (!info) break;
-    if (info.command.includes('scripts/web.mjs') || (root && info.command.includes(root))) {
-      return true;
-    }
-    cur = info.ppid;
-  }
-  return false;
-}
-
-/** Process-group id of a pid, or null — lets us kill the whole foreground
- *  tree (launcher + next + build workers) in one shot. */
-function processGroup(pid, { exec }) {
-  const res = exec('ps', ['-p', String(pid), '-o', 'pgid=']);
-  const n = res.status === 0 ? Number(res.stdout.trim()) : Number.NaN;
-  return Number.isInteger(n) && n > 0 ? n : null;
-}
-
 export async function cmdStop(deps = {}) {
   const {
     exec = defaultExec,
@@ -484,31 +579,46 @@ export async function cmdStop(deps = {}) {
     termWaitMs = 8_000,
     killWaitMs = 5_000,
     pollMs = 250,
+    inspectProcess = processPid => inspectLiveProcess(processPid, { exec }),
   } = deps;
   const pid = readPid(stateDir);
-  const meta = readMeta(stateDir);
+  const meta = readManagedMeta(stateDir);
   // Three distinct PID-file cases: live launcher (kill), dead process
   // (stale state — just clean up), live foreign process (refuse loudly).
-  const cmdline = pid ? psCommand(pid, { exec }) : null;
+  const identity = pid ? inspectProcess(pid) : null;
+  const managed = pid && meta ? isManagedLauncher(meta, { root, inspectProcess }) : false;
 
   let portFree = true; // is :3000 free (or was never ours) when we return?
   let keepState = false; // preserve web.pid so a retry can still target the PID
 
-  if (pid && cmdline?.includes('scripts/web.mjs')) {
+  if (pid && managed) {
     // SIGCONT first: a suspended (Ctrl-Z'd, state "T") tree never acts on
     // SIGTERM until it's resumed — that is how a stopped dev server keeps
     // :3000 bound while shrugging off `web:stop`. Resume, then ask it to exit.
-    safeKill(kill, pid, 'SIGCONT');
-    safeKill(kill, pid, 'SIGTERM');
-    portFree = await waitForPortClear({ exec, pollMs }, termWaitMs);
-    if (!portFree) {
+    const continued = signalManagedLauncher(meta, 'SIGCONT', { inspectProcess, kill, root });
+    const terminated =
+      continued && signalManagedLauncher(meta, 'SIGTERM', { inspectProcess, kill, root });
+    if (!continued || !terminated) {
+      error(`PID ${pid} changed ownership before shutdown — refusing to signal it.`);
+      portFree = false;
+      keepState = true;
+    } else {
+      portFree = await waitForPortClear({ exec, pollMs }, termWaitMs);
+    }
+    if (continued && terminated && !portFree) {
       // Graceful stop didn't free the port. Escalate to SIGKILL — and kill
       // whatever still holds :3000 directly, since the `next` child can outlive
       // a SIGKILL'd wrapper (SIGKILL is never forwarded).
       error(`PID ${pid} didn't release :${PORT} on SIGTERM — escalating to SIGKILL.`);
       const held = getListener({ exec });
-      safeKill(kill, pid, 'SIGKILL');
-      if (held && held.pid !== pid) safeKill(kill, held.pid, 'SIGKILL');
+      const heldSnapshot =
+        held && held.pid !== pid
+          ? ownedDescendantSnapshot(held.pid, meta, { inspectProcess, root })
+          : null;
+      if (heldSnapshot) {
+        signalOwnedDescendant(heldSnapshot, meta, 'SIGKILL', { inspectProcess, kill, root });
+      }
+      signalManagedLauncher(meta, 'SIGKILL', { inspectProcess, kill, root });
       portFree = await waitForPortClear({ exec, pollMs }, killWaitMs);
     }
     if (portFree) {
@@ -523,36 +633,28 @@ export async function cmdStop(deps = {}) {
       );
       keepState = true;
     }
-  } else if (pid && cmdline === null) {
+  } else if (pid && identity === null && psCommand(pid, { exec }) === null) {
     log(`Stale state: PID ${pid} is no longer running — cleaning up.`);
   } else if (pid) {
-    error(`PID ${pid} from the state file is not a sur9e launcher — not killing it.`);
+    error(`PID ${pid} failed managed ownership verification — not killing it.`);
+    portFree = false;
+    keepState = true;
   } else {
-    // No state file. A foreground `npm run web` doesn't track state, so a
-    // Ctrl-Z'd dev server lands here. Kill it only if it's identifiably OURS
-    // (command line references this checkout); never touch a foreign app.
+    // Without persisted identity there is no safe way to distinguish a prior
+    // launcher child from PID reuse or a process owned by another checkout.
     const listener = getListener({ exec });
     if (!listener) {
       log('No server running.');
-    } else if (isOwnDevServer(listener.pid, { exec, root })) {
-      log(`:${PORT} is an untracked sur9e dev server (PID ${listener.pid}) — stopping it.`);
-      safeKill(kill, listener.pid, 'SIGCONT'); // resume if Ctrl-Z'd
-      const pgid = processGroup(listener.pid, { exec });
-      if (pgid) safeKill(kill, -pgid, 'SIGKILL'); // whole foreground tree
-      safeKill(kill, listener.pid, 'SIGKILL'); // fallback: the listener itself
-      portFree = await waitForPortClear({ exec, pollMs }, killWaitMs);
-      if (portFree) log(`Stopped (PID ${listener.pid}).`);
-      else error(`Could not free :${PORT} — run: kill -9 ${listener.pid}`);
     } else {
       portFree = false;
       error(
-        `:${PORT} is PID ${listener.pid} (${listener.command}) — not a sur9e server; not killing it.\n` +
+        `:${PORT} is PID ${listener.pid} (${listener.command}), but there is no verified sur9e launch metadata — not killing it.\n` +
           `  If you're sure it's yours, run: kill -9 ${listener.pid}`,
       );
     }
   }
 
-  if (meta?.tailscale) resetServe({ exec, exists, error });
+  if (managed && meta.tailscale) resetServe({ exec, exists, error });
   if (!keepState) clearState(stateDir);
   return portFree ? 0 : 1;
 }

--- a/src/app/api/update/apply/__tests__/route.test.ts
+++ b/src/app/api/update/apply/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+import type { StartUpdateJobResult } from '@/lib/server/update-orchestrator';
+
+const mocks = vi.hoisted(() => ({
+  getWebLaunchMode: vi.fn(),
+  runUpdateSystem: vi.fn(),
+  startUpdateJob: vi.fn(),
+}));
+
+vi.mock('@/lib/server/update-orchestrator', () => ({
+  startUpdateJob: mocks.startUpdateJob,
+}));
+
+// Regression guard: the route must not retain the old synchronous updater.
+vi.mock('@/lib/server/update-system', () => ({
+  runUpdateSystem: mocks.runUpdateSystem,
+}));
+
+vi.mock('../../../../../../scripts/web.mjs', () => ({
+  getWebLaunchMode: mocks.getWebLaunchMode,
+}));
+
+const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+
+function job(overrides: Partial<UpdateJob> = {}): UpdateJob {
+  return {
+    id: JOB_ID,
+    phase: 'queued',
+    launchState: 'claim-pending',
+    mode: { prod: false, tailscale: false },
+    fromVersion: '0.3.2',
+    createdAt: '2026-07-31T20:00:00.000Z',
+    updatedAt: '2026-07-31T20:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function request(
+  body?: string,
+  {
+    origin = 'http://localhost:3000',
+    host = 'localhost:3000',
+    url = 'http://localhost:3000/api/update/apply',
+  }: { origin?: string; host?: string; url?: string } = {},
+): Request {
+  return new Request(url, {
+    method: 'POST',
+    headers: {
+      host,
+      ...(origin === '' ? {} : { origin }),
+      ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+    },
+    ...(body === undefined ? {} : { body }),
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  mocks.getWebLaunchMode.mockReset().mockReturnValue({ prod: false, tailscale: false });
+  mocks.runUpdateSystem.mockReset();
+  mocks.startUpdateJob.mockReset().mockReturnValue({ status: 'started', job: job() });
+});
+
+describe('POST /api/update/apply', () => {
+  it('starts a durable update job and returns its id with 202', async () => {
+    const { POST } = await import('../route');
+    const response = await POST(request());
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ jobId: JOB_ID });
+    expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        fromVersion: '0.3.2',
+        mode: { prod: false, tailscale: false },
+      }),
+    );
+    expect(mocks.runUpdateSystem).not.toHaveBeenCalled();
+  });
+
+  it('accepts a strict optional toVersion body and forwards the version', async () => {
+    const { POST } = await import('../route');
+    const response = await POST(request(JSON.stringify({ toVersion: '0.4.0' })));
+
+    expect(response.status).toBe(202);
+    expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ toVersion: '0.4.0' }),
+    );
+  });
+
+  it.each([
+    ['malformed JSON', '{'],
+    ['an unknown property', JSON.stringify({ output: '/private/repo' })],
+    ['a non-string version', JSON.stringify({ toVersion: 4 })],
+    ['an empty version', JSON.stringify({ toVersion: '' })],
+  ])('returns 400 for %s', async (_label, body) => {
+    const { POST } = await import('../route');
+    const response = await POST(request(body));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid request body' });
+    expect(mocks.startUpdateJob).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['cross-origin', 'https://attacker.example'],
+    ['malformed', 'not a URL'],
+  ])('rejects a %s Origin before parsing or launching', async (_label, origin) => {
+    const { POST } = await import('../route');
+    const response = await POST(request('{', { origin }));
+
+    expect(response.status).toBe(403);
+    expect(mocks.getWebLaunchMode).not.toHaveBeenCalled();
+    expect(mocks.startUpdateJob).not.toHaveBeenCalled();
+  });
+
+  it('returns a safe 409 with the active job id', async () => {
+    mocks.startUpdateJob.mockReturnValue({ status: 'busy', job: job() });
+    const { POST } = await import('../route');
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'An update is already running', jobId: JOB_ID });
+  });
+
+  it('returns a safe 409 without a job id when the launch lock is held', async () => {
+    mocks.startUpdateJob.mockReturnValue({ status: 'busy', job: null });
+    const { POST } = await import('../route');
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'An update is already running' });
+  });
+
+  it.each([
+    ['reported failure', { status: 'failed', job: job({ phase: 'failed' }) }],
+    ['thrown failure', new Error('/private/repo: spawn output')],
+  ])('returns a safe 500 for a %s', async (_label, outcome) => {
+    if (outcome instanceof Error)
+      mocks.startUpdateJob.mockImplementation(() => Promise.reject(outcome));
+    else mocks.startUpdateJob.mockReturnValue(outcome as StartUpdateJobResult);
+    const { POST } = await import('../route');
+    const response = await POST(request());
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Failed to start update' });
+    expect(JSON.stringify(body)).not.toContain('/private/repo');
+  });
+
+  it('uses authoritative persisted launcher metadata', async () => {
+    mocks.getWebLaunchMode.mockReturnValue({ prod: true, tailscale: true });
+    const { POST } = await import('../route');
+    await POST(request());
+
+    expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ mode: { prod: true, tailscale: true } }),
+    );
+  });
+
+  it.each(['localhost', '127.0.0.1'])(
+    'falls back to production without inferring Tailscale on %s',
+    async hostname => {
+      vi.stubEnv('NODE_ENV', 'production');
+      const { POST } = await import('../route');
+      await POST(
+        request(undefined, {
+          origin: `http://${hostname}:3000`,
+          host: `${hostname}:3000`,
+          url: `http://${hostname}:3000/api/update/apply`,
+        }),
+      );
+
+      expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ mode: { prod: true, tailscale: false } }),
+      );
+    },
+  );
+
+  it('does not infer Tailscale from an HTTP ts.net origin', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const { POST } = await import('../route');
+    await POST(
+      request(undefined, {
+        origin: 'http://sur9e.example-tailnet.ts.net',
+        host: 'sur9e.example-tailnet.ts.net',
+        url: 'http://sur9e.example-tailnet.ts.net/api/update/apply',
+      }),
+    );
+
+    expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ mode: { prod: false, tailscale: false } }),
+    );
+  });
+
+  it('may infer Tailscale from an HTTPS ts.net origin', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const { POST } = await import('../route');
+    await POST(
+      request(undefined, {
+        origin: 'https://sur9e.example-tailnet.ts.net',
+        host: 'sur9e.example-tailnet.ts.net',
+        url: 'https://sur9e.example-tailnet.ts.net/api/update/apply',
+      }),
+    );
+
+    expect(mocks.startUpdateJob).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ mode: { prod: false, tailscale: true } }),
+    );
+  });
+});

--- a/src/app/api/update/apply/route.ts
+++ b/src/app/api/update/apply/route.ts
@@ -1,18 +1,39 @@
 export const runtime = 'nodejs';
 
 import { jsonError } from '@/lib/http-errors';
-import { runUpdateSystem } from '@/lib/server/update-system';
+import { ROOT } from '@/lib/root';
+import { rejectCrossOrigin } from '@/lib/server/same-origin';
+import { parseUpdateApplyBody, resolveUpdateLaunchMode } from '@/lib/server/update-api';
+import { startUpdateJob } from '@/lib/server/update-orchestrator';
+import packageJson from '../../../../../package.json';
 
-export function POST(req: Request) {
-  const origin = req.headers.get('origin');
-  const host = req.headers.get('host');
-  if (origin && new URL(origin).host !== host) {
-    return new Response('Forbidden', { status: 403 });
-  }
+export async function POST(request: Request) {
+  const forbidden = rejectCrossOrigin(request);
+  if (forbidden) return forbidden;
+
+  const body = await parseUpdateApplyBody(request);
+  if (!body) return jsonError('Invalid request body', 400);
+
   try {
-    const out = runUpdateSystem('apply', 120000);
-    return Response.json({ ok: true, output: out });
-  } catch (error) {
-    return jsonError(error instanceof Error ? error.message : 'Failed to apply update', 500);
+    const result = await startUpdateJob(ROOT, {
+      mode: resolveUpdateLaunchMode(request),
+      fromVersion: packageJson.version,
+      ...(body.toVersion === undefined ? {} : { toVersion: body.toVersion }),
+    });
+    if (result.status === 'started') {
+      return Response.json({ jobId: result.job.id }, { status: 202 });
+    }
+    if (result.status === 'busy') {
+      return Response.json(
+        {
+          error: 'An update is already running',
+          ...(result.job ? { jobId: result.job.id } : {}),
+        },
+        { status: 409 },
+      );
+    }
+    return jsonError('Failed to start update', 500);
+  } catch {
+    return jsonError('Failed to start update', 500);
   }
 }

--- a/src/app/api/update/status/[id]/__tests__/route.test.ts
+++ b/src/app/api/update/status/[id]/__tests__/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UpdateJob } from '@/lib/schemas/update-job';
 
-const mocks = vi.hoisted(() => ({ loadUpdateJob: vi.fn() }));
+const mocks = vi.hoisted(() => ({ reconcileUpdateJob: vi.fn() }));
 
 vi.mock('@/lib/server/update-orchestrator', () => ({
-  loadUpdateJob: mocks.loadUpdateJob,
+  reconcileUpdateJob: mocks.reconcileUpdateJob,
 }));
 
 const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
@@ -28,7 +28,7 @@ function context(id: string) {
 }
 
 beforeEach(() => {
-  mocks.loadUpdateJob.mockReset();
+  mocks.reconcileUpdateJob.mockReset();
 });
 
 describe('GET /api/update/status/[id]', () => {
@@ -41,11 +41,11 @@ describe('GET /api/update/status/[id]', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'Invalid update job id' });
-    expect(mocks.loadUpdateJob).not.toHaveBeenCalled();
+    expect(mocks.reconcileUpdateJob).not.toHaveBeenCalled();
   });
 
   it('returns 404 for an unknown job', async () => {
-    mocks.loadUpdateJob.mockReturnValue(null);
+    mocks.reconcileUpdateJob.mockReturnValue(null);
     const { GET } = await import('../route');
     const response = await GET(
       new Request(`http://localhost/api/update/status/${JOB_ID}`),
@@ -57,7 +57,7 @@ describe('GET /api/update/status/[id]', () => {
   });
 
   it('returns a schema-validated safe job document', async () => {
-    mocks.loadUpdateJob.mockReturnValue(job());
+    mocks.reconcileUpdateJob.mockReturnValue(job());
     const { GET } = await import('../route');
     const response = await GET(
       new Request(`http://localhost/api/update/status/${JOB_ID}`),
@@ -69,7 +69,7 @@ describe('GET /api/update/status/[id]', () => {
   });
 
   it('does not expose invalid persisted fields or loader error details', async () => {
-    mocks.loadUpdateJob.mockReturnValue({
+    mocks.reconcileUpdateJob.mockReturnValue({
       ...job(),
       output: '/private/repo\nsecret command output',
     });

--- a/src/app/api/update/status/[id]/__tests__/route.test.ts
+++ b/src/app/api/update/status/[id]/__tests__/route.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UpdateJob } from '@/lib/schemas/update-job';
 
-const mocks = vi.hoisted(() => ({ reconcileUpdateJob: vi.fn() }));
+const mocks = vi.hoisted(() => ({ loadUpdateJob: vi.fn(), reconcileUpdateJob: vi.fn() }));
 
 vi.mock('@/lib/server/update-orchestrator', () => ({
+  loadUpdateJob: mocks.loadUpdateJob,
   reconcileUpdateJob: mocks.reconcileUpdateJob,
 }));
 
@@ -28,6 +29,7 @@ function context(id: string) {
 }
 
 beforeEach(() => {
+  mocks.loadUpdateJob.mockReset();
   mocks.reconcileUpdateJob.mockReset();
 });
 
@@ -41,11 +43,11 @@ describe('GET /api/update/status/[id]', () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'Invalid update job id' });
-    expect(mocks.reconcileUpdateJob).not.toHaveBeenCalled();
+    expect(mocks.loadUpdateJob).not.toHaveBeenCalled();
   });
 
   it('returns 404 for an unknown job', async () => {
-    mocks.reconcileUpdateJob.mockReturnValue(null);
+    mocks.loadUpdateJob.mockReturnValue(null);
     const { GET } = await import('../route');
     const response = await GET(
       new Request(`http://localhost/api/update/status/${JOB_ID}`),
@@ -57,7 +59,7 @@ describe('GET /api/update/status/[id]', () => {
   });
 
   it('returns a schema-validated safe job document', async () => {
-    mocks.reconcileUpdateJob.mockReturnValue(job());
+    mocks.loadUpdateJob.mockReturnValue(job());
     const { GET } = await import('../route');
     const response = await GET(
       new Request(`http://localhost/api/update/status/${JOB_ID}`),
@@ -69,7 +71,7 @@ describe('GET /api/update/status/[id]', () => {
   });
 
   it('does not expose invalid persisted fields or loader error details', async () => {
-    mocks.reconcileUpdateJob.mockReturnValue({
+    mocks.loadUpdateJob.mockReturnValue({
       ...job(),
       output: '/private/repo\nsecret command output',
     });
@@ -83,5 +85,63 @@ describe('GET /api/update/status/[id]', () => {
     const body = await response.json();
     expect(body).toEqual({ error: 'Failed to load update job' });
     expect(JSON.stringify(body)).not.toContain('/private/repo');
+  });
+
+  it('returns a generic 500 when loading persisted state throws', async () => {
+    mocks.loadUpdateJob.mockImplementation(() => {
+      throw new Error('private storage detail');
+    });
+    const { GET } = await import('../route');
+
+    const response = await GET(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Failed to load update job' });
+  });
+});
+
+describe('POST /api/update/status/[id]', () => {
+  it('rejects cross-origin reconciliation', async () => {
+    const { POST } = await import('../route');
+    const response = await POST(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`, {
+        method: 'POST',
+        headers: { host: 'localhost', origin: 'https://evil.example' },
+      }),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.reconcileUpdateJob).not.toHaveBeenCalled();
+  });
+
+  it('returns the reconciled safe job document', async () => {
+    mocks.reconcileUpdateJob.mockReturnValue(job());
+    const { POST } = await import('../route');
+    const response = await POST(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`, { method: 'POST' }),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(job());
+  });
+
+  it('returns a generic 500 when reconciliation throws', async () => {
+    mocks.reconcileUpdateJob.mockImplementation(() => {
+      throw new Error('private recovery detail');
+    });
+    const { POST } = await import('../route');
+
+    const response = await POST(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`, { method: 'POST' }),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Failed to load update job' });
   });
 });

--- a/src/app/api/update/status/[id]/__tests__/route.test.ts
+++ b/src/app/api/update/status/[id]/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+
+const mocks = vi.hoisted(() => ({ loadUpdateJob: vi.fn() }));
+
+vi.mock('@/lib/server/update-orchestrator', () => ({
+  loadUpdateJob: mocks.loadUpdateJob,
+}));
+
+const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+
+function job(): UpdateJob {
+  return {
+    id: JOB_ID,
+    phase: 'restarting',
+    launchState: 'owned',
+    pid: 4321,
+    mode: { prod: true, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: '2026-07-31T20:00:00.000Z',
+    updatedAt: '2026-07-31T20:01:00.000Z',
+  };
+}
+
+function context(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  mocks.loadUpdateJob.mockReset();
+});
+
+describe('GET /api/update/status/[id]', () => {
+  it('returns 400 for an invalid UUID without reading storage', async () => {
+    const { GET } = await import('../route');
+    const response = await GET(
+      new Request('http://localhost/api/update/status/nope'),
+      context('nope'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid update job id' });
+    expect(mocks.loadUpdateJob).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for an unknown job', async () => {
+    mocks.loadUpdateJob.mockReturnValue(null);
+    const { GET } = await import('../route');
+    const response = await GET(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Update job not found' });
+  });
+
+  it('returns a schema-validated safe job document', async () => {
+    mocks.loadUpdateJob.mockReturnValue(job());
+    const { GET } = await import('../route');
+    const response = await GET(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(job());
+  });
+
+  it('does not expose invalid persisted fields or loader error details', async () => {
+    mocks.loadUpdateJob.mockReturnValue({
+      ...job(),
+      output: '/private/repo\nsecret command output',
+    });
+    const { GET } = await import('../route');
+    const response = await GET(
+      new Request(`http://localhost/api/update/status/${JOB_ID}`),
+      context(JOB_ID),
+    );
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Failed to load update job' });
+    expect(JSON.stringify(body)).not.toContain('/private/repo');
+  });
+});

--- a/src/app/api/update/status/[id]/route.ts
+++ b/src/app/api/update/status/[id]/route.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
 import { UpdateJob } from '@/lib/schemas/update-job';
-import { loadUpdateJob } from '@/lib/server/update-orchestrator';
+import { reconcileUpdateJob } from '@/lib/server/update-orchestrator';
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -17,7 +17,7 @@ export async function GET(_request: Request, { params }: Params) {
   if (!UpdateJobId.safeParse(id).success) return jsonError('Invalid update job id', 400);
 
   try {
-    const persisted = loadUpdateJob(ROOT, id);
+    const persisted = reconcileUpdateJob(ROOT, id);
     if (!persisted) return jsonError('Update job not found', 404);
     const parsed = UpdateJob.safeParse(persisted);
     if (!parsed.success) return jsonError('Failed to load update job', 500);

--- a/src/app/api/update/status/[id]/route.ts
+++ b/src/app/api/update/status/[id]/route.ts
@@ -1,0 +1,28 @@
+export const runtime = 'nodejs';
+
+import { z } from 'zod';
+import { jsonError } from '@/lib/http-errors';
+import { ROOT } from '@/lib/root';
+import { UpdateJob } from '@/lib/schemas/update-job';
+import { loadUpdateJob } from '@/lib/server/update-orchestrator';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+const UpdateJobId = z.string().uuid();
+
+export async function GET(_request: Request, { params }: Params) {
+  const { id } = await params;
+  if (!UpdateJobId.safeParse(id).success) return jsonError('Invalid update job id', 400);
+
+  try {
+    const persisted = loadUpdateJob(ROOT, id);
+    if (!persisted) return jsonError('Update job not found', 404);
+    const parsed = UpdateJob.safeParse(persisted);
+    if (!parsed.success) return jsonError('Failed to load update job', 500);
+    return Response.json(parsed.data);
+  } catch {
+    return jsonError('Failed to load update job', 500);
+  }
+}

--- a/src/app/api/update/status/[id]/route.ts
+++ b/src/app/api/update/status/[id]/route.ts
@@ -1,18 +1,34 @@
 export const runtime = 'nodejs';
 
-import { z } from 'zod';
 import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
-import { UpdateJob } from '@/lib/schemas/update-job';
-import { reconcileUpdateJob } from '@/lib/server/update-orchestrator';
+import { UpdateJob, UpdateJobId } from '@/lib/schemas/update-job';
+import { rejectCrossOrigin } from '@/lib/server/same-origin';
+import { loadUpdateJob, reconcileUpdateJob } from '@/lib/server/update-orchestrator';
 
 interface Params {
   params: Promise<{ id: string }>;
 }
 
-const UpdateJobId = z.string().uuid();
-
 export async function GET(_request: Request, { params }: Params) {
+  const { id } = await params;
+  if (!UpdateJobId.safeParse(id).success) return jsonError('Invalid update job id', 400);
+
+  try {
+    const persisted = loadUpdateJob(ROOT, id);
+    if (!persisted) return jsonError('Update job not found', 404);
+    const parsed = UpdateJob.safeParse(persisted);
+    if (!parsed.success) return jsonError('Failed to load update job', 500);
+    return Response.json(parsed.data);
+  } catch {
+    return jsonError('Failed to load update job', 500);
+  }
+}
+
+export async function POST(request: Request, { params }: Params) {
+  const forbidden = rejectCrossOrigin(request);
+  if (forbidden) return forbidden;
+
   const { id } = await params;
   if (!UpdateJobId.safeParse(id).success) return jsonError('Invalid update job id', 400);
 

--- a/src/app/api/update/status/__tests__/route.test.ts
+++ b/src/app/api/update/status/__tests__/route.test.ts
@@ -1,0 +1,77 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+import { loadUpdateJob, writeUpdateJob } from '@/lib/server/update-orchestrator';
+
+const TEST_ROOT = join(tmpdir(), 'sur9e-active-update-route-test');
+const FIRST_JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+const SECOND_JOB_ID = '5a7a13e7-c6e0-4df4-a0f1-70d4a52f4530';
+const TERMINAL_JOB_ID = 'a471c52d-c9c6-4371-832e-3fab8ff185b4';
+
+vi.mock('@/lib/root', () => ({ ROOT: TEST_ROOT }));
+
+function job(id: string, phase: UpdateJob['phase'], updatedAt: string): UpdateJob {
+  const activeWorker = ![
+    'queued',
+    'recovery-queued',
+    'succeeded',
+    'rolled-back',
+    'failed',
+  ].includes(phase);
+  return {
+    id,
+    phase,
+    mode: { prod: false, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt,
+    ...(phase === 'queued' || phase === 'recovery-queued'
+      ? { launchState: 'claim-pending' as const }
+      : activeWorker
+        ? { launchState: 'owned' as const, pid: 4242 }
+        : {}),
+  };
+}
+
+beforeEach(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe('GET /api/update/status', () => {
+  it('returns null when there is no durable active update job', async () => {
+    const { GET } = await import('../route');
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ job: null });
+  });
+
+  it('returns the latest nonterminal job, including recovery-queued', async () => {
+    writeUpdateJob(TEST_ROOT, job(FIRST_JOB_ID, 'restarting', '2026-08-01T10:02:00Z'));
+    const latest = job(SECOND_JOB_ID, 'recovery-queued', '2026-08-01T10:02:00.500Z');
+    writeUpdateJob(TEST_ROOT, latest);
+    writeUpdateJob(TEST_ROOT, job(TERMINAL_JOB_ID, 'succeeded', '2026-08-01T10:03:00.000Z'));
+    const { GET } = await import('../route');
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ job: latest });
+  });
+
+  it('does not mutate or reconcile the discovered job', async () => {
+    const staleClaim = job(FIRST_JOB_ID, 'queued', '2026-07-01T10:01:00.000Z');
+    writeUpdateJob(TEST_ROOT, staleClaim);
+    const { GET } = await import('../route');
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ job: staleClaim });
+    expect(loadUpdateJob(TEST_ROOT, FIRST_JOB_ID)).toEqual(staleClaim);
+  });
+});

--- a/src/app/api/update/status/route.ts
+++ b/src/app/api/update/status/route.ts
@@ -1,0 +1,18 @@
+export const runtime = 'nodejs';
+
+import { jsonError } from '@/lib/http-errors';
+import { ROOT } from '@/lib/root';
+import { UpdateJob } from '@/lib/schemas/update-job';
+import { loadLatestActiveUpdateJob } from '@/lib/server/update-orchestrator';
+
+export async function GET() {
+  try {
+    const persisted = loadLatestActiveUpdateJob(ROOT);
+    if (!persisted) return Response.json({ job: null });
+    const parsed = UpdateJob.safeParse(persisted);
+    if (!parsed.success) return jsonError('Failed to load active update job', 500);
+    return Response.json({ job: parsed.data });
+  } catch {
+    return jsonError('Failed to load active update job', 500);
+  }
+}

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -9,5 +9,8 @@ export function GET() {
   const versionPath = join(ROOT, 'VERSION');
   const raw = readFileOrNull(versionPath);
   if (raw == null) return jsonError('Version file not found', 404);
-  return Response.json({ version: raw.trim() });
+  return Response.json({
+    version: raw.trim(),
+    launchId: process.env.SUR9E_WEB_LAUNCH_ID ?? null,
+  });
 }

--- a/src/app/styles/settings-inline.css
+++ b/src/app/styles/settings-inline.css
@@ -172,6 +172,204 @@
   gap: 10px;
   flex-wrap: wrap;
 }
+
+/* Updates & about — status-led command center. */
+.system-update-panel {
+  display: grid;
+  grid-template-columns: minmax(128px, auto) minmax(0, 1fr);
+  gap: var(--space-3) var(--space-5);
+  align-items: center;
+  min-width: 0;
+  min-height: 188px;
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+.system-update-panel--success {
+  border-color: var(--border-good-strong);
+  background: var(--surface-good);
+}
+.system-update-panel--available,
+.system-update-panel--updating,
+.system-update-panel--checking,
+.system-update-panel--recovered {
+  border-color: color-mix(in oklab, var(--accent), var(--border) 50%);
+}
+.system-update-panel--danger {
+  border-color: var(--border-danger-strong);
+  background: var(--surface-danger);
+}
+.system-update-panel__version {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.system-update-panel__eyebrow,
+.system-update-row__label {
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-3);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.system-update-panel__version strong {
+  font-family: var(--font-display);
+  font-size: 25px;
+  line-height: 1.1;
+  color: var(--text);
+}
+.system-update-panel__status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.system-update-panel__badge {
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.system-update-panel--success .system-update-panel__badge {
+  border-color: var(--border-good-strong);
+  color: var(--st-success);
+}
+.system-update-panel--available .system-update-panel__badge,
+.system-update-panel--updating .system-update-panel__badge,
+.system-update-panel--checking .system-update-panel__badge,
+.system-update-panel--recovered .system-update-panel__badge {
+  border-color: color-mix(in oklab, var(--accent), var(--border) 40%);
+  color: var(--accent-text);
+}
+.system-update-panel--danger .system-update-panel__badge {
+  border-color: var(--border-danger-strong);
+  color: var(--st-danger);
+}
+.system-update-panel__detail,
+.system-update-row__help {
+  color: var(--text-2);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.system-update-panel__changelog,
+.system-update-panel__error {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.system-update-panel__changelog {
+  border-left: 3px solid var(--accent);
+  background: var(--surface);
+  color: var(--text-2);
+}
+.system-update-panel__changelog strong,
+.system-update-panel__error strong {
+  color: var(--text);
+  font-weight: 600;
+}
+.system-update-panel__error {
+  border: 1px solid var(--border-danger);
+  background: var(--surface-danger);
+  color: var(--text-2);
+}
+.system-update-panel__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  min-height: 44px;
+}
+.system-update-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+.system-update-row--recovery {
+  border-bottom: 0;
+}
+.system-update-row__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.system-update-row__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1) var(--space-2);
+  min-width: 0;
+  color: var(--text-2);
+  font-size: 13px;
+}
+.system-update-row__summary code {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+.system-update-source-fields {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 0.45fr);
+  gap: var(--space-4);
+  padding: var(--space-3) 0 var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+@media (max-width: 640px) {
+  .system-update-panel {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-3);
+    min-height: 246px;
+    padding: var(--space-4);
+  }
+  .system-update-panel__changelog,
+  .system-update-panel__error,
+  .system-update-panel__actions {
+    grid-column: 1;
+  }
+  .system-update-panel__actions .btn,
+  .system-update-row > .btn {
+    width: 100%;
+  }
+  .system-update-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .system-update-source-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .system-update-panel,
+  .system-update-panel *,
+  .system-update-row,
+  .system-update-row * {
+    scroll-behavior: auto;
+    transition-duration: 0.01ms;
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+  }
+}
 .settings-link {
   color: var(--accent-text);
   /* axe link-in-text-block: links inside settings copy must be

--- a/src/app/styles/settings-inline.css
+++ b/src/app/styles/settings-inline.css
@@ -180,7 +180,7 @@
   gap: var(--space-3) var(--space-5);
   align-items: center;
   min-width: 0;
-  min-height: 188px;
+  min-height: var(--update-panel-min-height);
   padding: var(--space-5);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -230,7 +230,7 @@
 .system-update-panel__badge {
   width: fit-content;
   max-width: 100%;
-  padding: 4px 9px;
+  padding: var(--update-badge-padding-block) var(--update-badge-padding-inline);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-pill);
   background: var(--surface);
@@ -275,7 +275,7 @@
   overflow-wrap: anywhere;
 }
 .system-update-panel__changelog {
-  border-left: 3px solid var(--accent);
+  border-left: var(--update-emphasis-border-width) solid var(--accent);
   background: var(--surface);
   color: var(--text-2);
 }
@@ -294,7 +294,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
-  min-height: 44px;
+  min-height: var(--update-actions-min-height);
 }
 .system-update-row {
   display: flex;
@@ -338,7 +338,7 @@
   .system-update-panel {
     grid-template-columns: minmax(0, 1fr);
     gap: var(--space-3);
-    min-height: 246px;
+    min-height: var(--update-panel-mobile-min-height);
     padding: var(--space-4);
   }
   .system-update-panel__changelog,

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -97,6 +97,14 @@
   --space-9: 96px;
   --space-10: 128px;
 
+  /* ─── Update controls ─── */
+  --update-badge-padding-block: 4px;
+  --update-badge-padding-inline: 9px;
+  --update-panel-min-height: 188px;
+  --update-panel-mobile-min-height: 246px;
+  --update-actions-min-height: 44px;
+  --update-emphasis-border-width: 3px;
+
   /* ─── Layout (unchanged) ─── */
   --rail-w: 64px;
   --rail-w-full: 220px;

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -1,0 +1,372 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useToastStore } from '@/components/toast/toast-store';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+import type { SettingsFormValues } from '../../types';
+import { SystemSection } from '../system-section';
+
+const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+const RETURN_HREF_KEY = 'sur9e.update.return-href';
+const ACTIVE_JOB_KEY = 'sur9e.update.active-job';
+const RESULT_NOTICE_KEY = 'sur9e.update.result';
+
+const mocks = vi.hoisted(() => ({
+  version: { isPending: false, data: { version: '0.3.2' } } as Record<string, unknown>,
+  check: {
+    isPending: false,
+    mutateAsync: vi.fn(),
+  } as Record<string, unknown>,
+  apply: {
+    isPending: false,
+    mutateAsync: vi.fn(),
+  } as Record<string, unknown>,
+  job: {
+    data: undefined,
+    isError: false,
+    error: null,
+  } as Record<string, unknown>,
+  rollback: {
+    isPending: false,
+    mutateAsync: vi.fn(),
+  } as Record<string, unknown>,
+  requestedJobIds: [] as Array<string | null | undefined>,
+}));
+
+vi.mock('@/hooks/use-system', () => ({
+  useVersion: () => mocks.version,
+  useUpdateCheck: () => mocks.check,
+  useUpdateApply: () => mocks.apply,
+  useUpdateJob: (jobId: string | null | undefined) => {
+    mocks.requestedJobIds.push(jobId);
+    return mocks.job;
+  },
+  useRollback: () => mocks.rollback,
+}));
+
+function makeJob(overrides: Partial<UpdateJob> = {}): UpdateJob {
+  return {
+    id: JOB_ID,
+    phase: 'queued',
+    launchState: 'claim-pending',
+    mode: { prod: false, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: '2026-07-31T20:00:00.000Z',
+    updatedAt: '2026-07-31T20:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const methods = useForm<SettingsFormValues>({
+    defaultValues: {
+      system: {
+        update_source: 'https://github.com/arspesk/sur9e.git',
+        update_branch: 'main',
+      },
+    } as SettingsFormValues,
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+function renderSection(props: { navigate?: (href: string) => void } = {}) {
+  return render(<SystemSection {...props} />, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  window.history.replaceState({}, '', '/settings');
+  useToastStore.setState({ toasts: [] });
+  mocks.version = { isPending: false, data: { version: '0.3.2' } };
+  mocks.check = { isPending: false, mutateAsync: vi.fn() };
+  mocks.apply = { isPending: false, mutateAsync: vi.fn() };
+  mocks.job = { data: undefined, isError: false, error: null };
+  mocks.rollback = { isPending: false, mutateAsync: vi.fn() };
+  mocks.requestedJobIds = [];
+  Object.assign(window, {
+    deleteConfirmModal: { confirm: vi.fn(async () => true) },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SystemSection update status', () => {
+  it('discards a corrupt retained job id instead of trapping the controls', () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, 'not-a-job-id');
+    renderSection();
+
+    expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBeNull();
+    expect(screen.getByText('Not checked yet')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeEnabled();
+  });
+
+  it('starts neutral and gates Update now behind an available check result', async () => {
+    const check = vi.fn().mockResolvedValue({
+      status: 'update-available',
+      local: '0.3.2',
+      remote: '0.4.0',
+      changelog: 'Faster restart. Improved update recovery.',
+    });
+    mocks.check = { isPending: false, mutateAsync: check };
+    renderSection();
+
+    expect(screen.getByRole('heading', { name: 'Updates & about' })).toBeTruthy();
+    expect(screen.getByText('Keep Sur9e current without losing your place.')).toBeTruthy();
+    expect(screen.getByText('Installed version')).toBeTruthy();
+    expect(screen.getByText('v0.3.2')).toBeTruthy();
+    expect(screen.getByText('Not checked yet')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Update now' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+
+    expect(await screen.findByText('v0.4.0 available')).toBeTruthy();
+    expect(screen.getByText('Faster restart. Improved update recovery.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Update now' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
+  });
+
+  it('shows checking and up-to-date states with one clear action', async () => {
+    let resolveCheck: ((value: unknown) => void) | undefined;
+    const pendingCheck = new Promise(resolve => {
+      resolveCheck = resolve;
+    });
+    mocks.check = { isPending: false, mutateAsync: vi.fn(() => pendingCheck) };
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+    expect(screen.getByText('Checking for updates…')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Checking…' })).toBeDisabled();
+
+    resolveCheck?.({ status: 'up-to-date', local: '0.3.2', remote: '0.3.2' });
+    expect(await screen.findByText('Up to date')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Update now' })).toBeNull();
+  });
+
+  it('expands the existing RHF source fields from the compact summary', () => {
+    renderSection();
+
+    expect(screen.getByText('https://github.com/arspesk/sur9e.git')).toBeTruthy();
+    expect(screen.getByText('main')).toBeTruthy();
+    expect(screen.queryByLabelText('Update source')).toBeNull();
+    expect(screen.queryByLabelText('Update branch')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit update source' }));
+
+    expect(screen.getByLabelText('Update source')).toHaveValue(
+      'https://github.com/arspesk/sur9e.git',
+    );
+    expect(screen.getByLabelText('Update branch')).toHaveValue('main');
+  });
+
+  it('keeps failures visible with recovery guidance and accessible status', async () => {
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockRejectedValue(new Error('update service unavailable')),
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('update service unavailable');
+    expect(alert).toHaveTextContent('Try checking again');
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
+  });
+});
+
+describe('SystemSection applying and returning', () => {
+  it('confirms versions, downtime, and protected data before starting an update', async () => {
+    const confirm = vi.fn(async () => false);
+    Object.assign(window, { deleteConfirmModal: { confirm } });
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: 'Faster restart.',
+      }),
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Update now' }));
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('v0.3.2'),
+        target: expect.stringContaining('v0.3.2 → v0.4.0'),
+        bodyText: expect.stringMatching(/briefly.*offline/i),
+        warningText: expect.stringMatching(/CV.*profile.*tracker.*reports.*untouched/i),
+        confirmLabel: 'Update now',
+      }),
+    );
+    expect(mocks.apply.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('stores the exact href and job id, then announces durable progress', async () => {
+    window.history.replaceState({}, '', '/settings?view=system#system');
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: '',
+      }),
+    };
+    mocks.apply = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({ jobId: JOB_ID }),
+    };
+    const view = renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Update now' }));
+
+    await waitFor(() =>
+      expect(mocks.apply.mutateAsync).toHaveBeenCalledWith({ toVersion: '0.4.0' }),
+    );
+    expect(window.sessionStorage.getItem(RETURN_HREF_KEY)).toBe(
+      'http://localhost:3000/settings?view=system#system',
+    );
+    expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBe(JOB_ID);
+    expect(mocks.requestedJobIds).toContain(JOB_ID);
+
+    mocks.job = {
+      data: makeJob({
+        phase: 'rebuilding',
+        launchState: 'owned',
+        pid: 4242,
+      }),
+      isError: false,
+      error: null,
+    };
+    view.rerender(<SystemSection />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Rebuilding');
+    expect(screen.getByRole('button', { name: 'Rebuilding' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeDisabled();
+  });
+
+  it('shows a failed terminal job with its phase and manual recovery guidance', () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    mocks.job = {
+      data: makeJob({ phase: 'failed', error: 'Restart verification timed out' }),
+      isError: false,
+      error: null,
+    };
+    renderSection();
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Update failed');
+    expect(alert).toHaveTextContent('Restart verification timed out');
+    expect(alert).toHaveTextContent('Roll back');
+  });
+
+  it('keeps the last durable phase visible through expected restart downtime', () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    mocks.job = {
+      data: makeJob({
+        phase: 'restarting',
+        launchState: 'owned',
+        pid: 4242,
+      }),
+      isError: true,
+      error: new TypeError('Failed to fetch'),
+    };
+    renderSection();
+
+    expect(screen.getByRole('status')).toHaveTextContent('Restarting');
+    expect(screen.getByRole('status')).toHaveTextContent('Reconnecting');
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Restarting' })).toBeDisabled();
+  });
+
+  it.each([
+    ['succeeded', 'succeeded'],
+    ['rolled-back', 'rolled-back'],
+  ] as const)('stores a one-load %s result and restores the exact saved URL', (phase, kind) => {
+    const exactHref = 'http://localhost:3000/settings?view=system#system';
+    const navigate = vi.fn();
+    window.sessionStorage.setItem(RETURN_HREF_KEY, exactHref);
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    mocks.job = {
+      data: makeJob({
+        phase,
+        ...(phase === 'rolled-back' ? { error: 'Updated build did not become ready' } : {}),
+      }),
+      isError: false,
+      error: null,
+    };
+
+    renderSection({ navigate });
+
+    expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBeNull();
+    expect(JSON.parse(window.sessionStorage.getItem(RESULT_NOTICE_KEY) ?? '{}')).toMatchObject({
+      kind,
+      version: phase === 'succeeded' ? '0.4.0' : '0.3.2',
+    });
+    expect(navigate).toHaveBeenCalledWith(exactHref);
+  });
+
+  it('uses shared confirmation for manual rollback and disables it while pending', async () => {
+    const confirm = vi.fn(async () => true);
+    Object.assign(window, { deleteConfirmModal: { confirm } });
+    mocks.rollback = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({ ok: true }),
+    };
+    const first = renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Roll back' }));
+
+    await waitFor(() => expect(mocks.rollback.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ confirmLabel: 'Roll back' }));
+    first.unmount();
+
+    mocks.rollback = { isPending: true, mutateAsync: vi.fn() };
+    renderSection();
+    expect(screen.getByRole('button', { name: 'Roll back' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Check for updates' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Edit update source' })).toBeDisabled();
+  });
+
+  it('consumes success and automatic rollback notices exactly once', () => {
+    window.sessionStorage.setItem(
+      RESULT_NOTICE_KEY,
+      JSON.stringify({ kind: 'succeeded', version: '0.4.0' }),
+    );
+    const first = renderSection();
+
+    expect(window.sessionStorage.getItem(RESULT_NOTICE_KEY)).toBeNull();
+    expect(useToastStore.getState().toasts.at(-1)).toMatchObject({
+      tone: 'success',
+      message: expect.stringMatching(/updated to v0\.4\.0/i),
+    });
+    expect(first.getByRole('status')).toHaveTextContent('Update complete');
+    first.unmount();
+
+    renderSection();
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    window.sessionStorage.setItem(
+      RESULT_NOTICE_KEY,
+      JSON.stringify({ kind: 'rolled-back', version: '0.3.2', error: 'Build failed' }),
+    );
+    const recovered = renderSection();
+    expect(useToastStore.getState().toasts.at(-1)).toMatchObject({
+      tone: 'warning',
+      message: expect.stringMatching(/automatically recovered.*v0\.3\.2/i),
+    });
+    expect(recovered.container.querySelector('[role="status"]')).toHaveTextContent(
+      'Recovered automatically',
+    );
+  });
+});

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { useToastStore } from '@/components/toast/toast-store';
 import type { UpdateJob } from '@/lib/schemas/update-job';
 import type { SettingsFormValues } from '../../types';
@@ -40,7 +41,7 @@ vi.mock('@/hooks/use-system', () => ({
   useUpdateApply: () => mocks.apply,
   useUpdateJob: (jobId: string | null | undefined) => {
     mocks.requestedJobIds.push(jobId);
-    return mocks.job;
+    return jobId ? mocks.job : { data: undefined, isError: false, error: null };
   },
   useRollback: () => mocks.rollback,
 }));
@@ -79,6 +80,7 @@ beforeEach(() => {
   window.sessionStorage.clear();
   window.history.replaceState({}, '', '/settings');
   useToastStore.setState({ toasts: [] });
+  useDeleteConfirmStore.setState({ visible: false, options: {}, _resolve: null });
   mocks.version = { isPending: false, data: { version: '0.3.2' } };
   mocks.check = { isPending: false, mutateAsync: vi.fn() };
   mocks.apply = { isPending: false, mutateAsync: vi.fn() };
@@ -210,6 +212,32 @@ describe('SystemSection applying and returning', () => {
     expect(mocks.apply.mutateAsync).not.toHaveBeenCalled();
   });
 
+  it('opens the mounted shared confirmation modal when no legacy window bridge exists', async () => {
+    delete (window as typeof window & { deleteConfirmModal?: unknown }).deleteConfirmModal;
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: 'Faster restart.',
+      }),
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Update now' }));
+
+    expect(useDeleteConfirmStore.getState()).toMatchObject({
+      visible: true,
+      options: {
+        title: 'Update Sur9e from v0.3.2 to v0.4.0?',
+        confirmLabel: 'Update now',
+      },
+    });
+    useDeleteConfirmStore.getState()._settle(false);
+  });
+
   it('stores the exact href and job id, then announces durable progress', async () => {
     window.history.replaceState({}, '', '/settings?view=system#system');
     mocks.check = {
@@ -268,6 +296,32 @@ describe('SystemSection applying and returning', () => {
     expect(alert).toHaveTextContent('Update failed');
     expect(alert).toHaveTextContent('Restart verification timed out');
     expect(alert).toHaveTextContent('Roll back');
+  });
+
+  it('releases a failed retained job so a fresh check can retry after reload', async () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    mocks.job = {
+      data: makeJob({ phase: 'failed', error: 'Restart verification timed out' }),
+      isError: false,
+      error: null,
+    };
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: 'Retry the update safely.',
+      }),
+    };
+    renderSection();
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Restart verification timed out');
+    await waitFor(() => expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBeNull());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+
+    expect(await screen.findByRole('button', { name: 'Update now' })).toBeEnabled();
   });
 
   it('keeps the last durable phase visible through expected restart downtime', () => {

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -28,17 +28,27 @@ const mocks = vi.hoisted(() => ({
     isError: false,
     error: null,
   } as Record<string, unknown>,
+  active: {
+    data: { job: null },
+    isError: false,
+    error: null,
+  } as Record<string, unknown>,
   rollback: {
     isPending: false,
     mutateAsync: vi.fn(),
   } as Record<string, unknown>,
   requestedJobIds: [] as Array<string | null | undefined>,
+  activeEnabled: [] as boolean[],
 }));
 
 vi.mock('@/hooks/use-system', () => ({
   useVersion: () => mocks.version,
   useUpdateCheck: () => mocks.check,
   useUpdateApply: () => mocks.apply,
+  useActiveUpdateJob: (enabled: boolean) => {
+    mocks.activeEnabled.push(enabled);
+    return mocks.active;
+  },
   useUpdateJob: (jobId: string | null | undefined) => {
     mocks.requestedJobIds.push(jobId);
     return jobId ? mocks.job : { data: undefined, isError: false, error: null };
@@ -85,8 +95,10 @@ beforeEach(() => {
   mocks.check = { isPending: false, mutateAsync: vi.fn() };
   mocks.apply = { isPending: false, mutateAsync: vi.fn() };
   mocks.job = { data: undefined, isError: false, error: null };
+  mocks.active = { data: { job: null }, isError: false, error: null };
   mocks.rollback = { isPending: false, mutateAsync: vi.fn() };
   mocks.requestedJobIds = [];
+  mocks.activeEnabled = [];
   Object.assign(window, {
     deleteConfirmModal: { confirm: vi.fn(async () => true) },
   });
@@ -97,6 +109,41 @@ afterEach(() => {
 });
 
 describe('SystemSection update status', () => {
+  it('discovers and attaches the latest durable job when this tab has no retained id', async () => {
+    window.history.replaceState({}, '', '/settings?view=system#system');
+    mocks.active = {
+      data: { job: makeJob({ phase: 'recovery-queued' }) },
+      isError: false,
+      error: null,
+    };
+    mocks.job = {
+      data: makeJob({ phase: 'recovery-queued' }),
+      isError: false,
+      error: null,
+    };
+
+    renderSection();
+
+    await waitFor(() => expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBe(JOB_ID));
+    expect(window.sessionStorage.getItem(RETURN_HREF_KEY)).toBe(
+      'http://localhost:3000/settings?view=system#system',
+    );
+    expect(mocks.activeEnabled).toContain(true);
+    expect(mocks.activeEnabled.at(-1)).toBe(false);
+    expect(mocks.requestedJobIds).toContain(JOB_ID);
+    expect(screen.getByRole('status')).toHaveTextContent('Preparing recovery');
+  });
+
+  it('does not run discovery when sessionStorage already retains a job id', () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    mocks.job = { data: makeJob(), isError: false, error: null };
+
+    renderSection();
+
+    expect(mocks.activeEnabled.length).toBeGreaterThan(0);
+    expect(mocks.activeEnabled.every(enabled => !enabled)).toBe(true);
+  });
+
   it('discards a corrupt retained job id instead of trapping the controls', () => {
     window.sessionStorage.setItem(ACTIVE_JOB_KEY, 'not-a-job-id');
     renderSection();

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { useToastStore } from '@/components/toast/toast-store';
+import { FetchJsonError } from '@/lib/api/fetch-json';
 import type { UpdateJob } from '@/lib/schemas/update-job';
 import type { SettingsFormValues } from '../../types';
 import { SystemSection } from '../system-section';
@@ -388,6 +389,24 @@ describe('SystemSection applying and returning', () => {
     expect(screen.getByRole('status')).toHaveTextContent('Reconnecting');
     expect(screen.queryByRole('alert')).toBeNull();
     expect(screen.getByRole('button', { name: 'Restarting' })).toBeDisabled();
+  });
+
+  it('releases missing retained progress so controls stop polling and become usable', async () => {
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, JOB_ID);
+    window.sessionStorage.setItem(RETURN_HREF_KEY, 'http://localhost:3000/settings');
+    mocks.job = {
+      data: undefined,
+      isError: true,
+      error: new FetchJsonError(404, 'Update job not found'),
+    };
+
+    renderSection();
+
+    await waitFor(() => expect(window.sessionStorage.getItem(ACTIVE_JOB_KEY)).toBeNull());
+    expect(window.sessionStorage.getItem(RETURN_HREF_KEY)).toBeNull();
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeEnabled();
+    expect(screen.queryByText('Starting update…')).toBeNull();
+    expect(mocks.activeEnabled.at(-1)).toBe(false);
   });
 
   it.each([

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -179,6 +179,16 @@ describe('SystemSection update status', () => {
     expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
   });
 
+  it('uses the shared medium Settings button size for update actions', () => {
+    renderSection();
+
+    for (const name of ['Check for updates', 'Edit update source', 'Roll back']) {
+      const button = screen.getByRole('button', { name });
+      expect(button).toHaveClass('btn-md');
+      expect(button).not.toHaveClass('btn-lg');
+    }
+  });
+
   it('shows checking and up-to-date states with one clear action', async () => {
     let resolveCheck: ((value: unknown) => void) | undefined;
     const pendingCheck = new Promise(resolve => {

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -395,17 +395,16 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
 
         <div className="system-update-panel__actions">
           {jobRunning ? (
-            <Button variant="primary" size="lg" disabled>
+            <Button variant="primary" disabled>
               {phaseLabel}
             </Button>
           ) : canUpdate ? (
-            <Button variant="primary" size="lg" onClick={applyUpdate} disabled={actionsPending}>
+            <Button variant="primary" onClick={applyUpdate} disabled={actionsPending}>
               {isApplying ? 'Starting update…' : 'Update now'}
             </Button>
           ) : null}
           <Button
             variant="secondary"
-            size="lg"
             id="checkUpdates"
             onClick={checkUpdates}
             disabled={actionsPending}
@@ -426,7 +425,6 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
         </div>
         <Button
           variant="secondary"
-          size="lg"
           onClick={() => setEditingSource(value => !value)}
           disabled={actionsPending}
           aria-expanded={editingSource}
@@ -477,7 +475,6 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
         </div>
         <Button
           variant="secondary"
-          size="lg"
           id="rollback"
           title="Roll back to the previous installed version (asks to confirm)"
           onClick={rollback}

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -1,55 +1,228 @@
 'use client';
 
-// sections/system-section.tsx — Updates & about (merged system + about)
-// Section ID: "system" (single anchor; former "about" id removed)
-//
-// The About content is not form data — version + update controls go
-// through the useSystem hooks (TanStack Query/Mutation per the CLAUDE.md
-// client-read rule); only the update source/branch inputs are rhf-managed.
-
-import { useCallback } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { Button, HelperText, Input, Label } from '@/components/primitives';
 import { useToastStore } from '@/components/toast/toast-store';
-import { useRollback, useUpdateCheck, useVersion } from '@/hooks/use-system';
+import {
+  type UpdateCheckResponse,
+  useRollback,
+  useUpdateApply,
+  useUpdateCheck,
+  useUpdateJob,
+  useVersion,
+} from '@/hooks/use-system';
+import type { UpdateJob, UpdateJobPhase } from '@/lib/schemas/update-job';
 import type { SettingsFormValues } from '../types';
 
-type ToneFn = (tone: 'info' | 'success' | 'warning' | 'danger', message: string) => void;
+const RETURN_HREF_KEY = 'sur9e.update.return-href';
+const ACTIVE_JOB_KEY = 'sur9e.update.active-job';
+const RESULT_NOTICE_KEY = 'sur9e.update.result';
+const UPDATE_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export function SystemSection() {
-  const { register, getValues } = useFormContext<SettingsFormValues>();
-  const pushToast = useToastStore(s => s.push) as ToneFn;
+const TERMINAL_PHASES = new Set<UpdateJobPhase>(['succeeded', 'rolled-back', 'failed']);
+
+const PHASE_LABEL: Record<UpdateJobPhase, string> = {
+  queued: 'Starting update…',
+  applying: 'Updating files',
+  stopping: 'Preparing to restart',
+  rebuilding: 'Rebuilding',
+  restarting: 'Restarting',
+  verifying: 'Verifying restart',
+  recovering: 'Recovering previous version',
+  succeeded: 'Update complete',
+  'rolled-back': 'Recovered automatically',
+  failed: 'Update failed',
+};
+
+interface ResultNotice {
+  kind: 'succeeded' | 'rolled-back';
+  version: string;
+  error?: string;
+}
+
+interface ConfirmOptions {
+  title: string;
+  target: string;
+  bodyText: string;
+  warningText: string;
+  confirmLabel: string;
+}
+
+interface SystemSectionProps {
+  navigate?: (href: string) => void;
+}
+
+function defaultNavigate(href: string) {
+  window.location.replace(href);
+}
+
+function getConfirmation(): ((options: ConfirmOptions) => Promise<boolean>) | undefined {
+  return (
+    window as typeof window & {
+      deleteConfirmModal?: { confirm: (options: ConfirmOptions) => Promise<boolean> };
+    }
+  ).deleteConfirmModal?.confirm;
+}
+
+function changelogExcerpt(changelog: string) {
+  const normalized = changelog.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 180) return normalized;
+  return `${normalized.slice(0, 177).trimEnd()}…`;
+}
+
+function readActiveJobId() {
+  if (typeof window === 'undefined') return null;
+  const jobId = window.sessionStorage.getItem(ACTIVE_JOB_KEY);
+  if (!jobId || UPDATE_JOB_ID.test(jobId)) return jobId;
+  window.sessionStorage.removeItem(ACTIVE_JOB_KEY);
+  return null;
+}
+
+function readResultNotice(): ResultNotice | null {
+  const raw = window.sessionStorage.getItem(RESULT_NOTICE_KEY);
+  if (!raw) return null;
+  window.sessionStorage.removeItem(RESULT_NOTICE_KEY);
+  try {
+    const parsed = JSON.parse(raw) as Partial<ResultNotice>;
+    if (
+      (parsed.kind === 'succeeded' || parsed.kind === 'rolled-back') &&
+      typeof parsed.version === 'string'
+    ) {
+      return parsed as ResultNotice;
+    }
+  } catch {
+    // Invalid one-load notices are discarded above so they cannot toast forever.
+  }
+  return null;
+}
+
+function resultFromJob(job: UpdateJob): ResultNotice | null {
+  if (job.phase === 'succeeded') {
+    return { kind: 'succeeded', version: job.toVersion ?? job.fromVersion };
+  }
+  if (job.phase === 'rolled-back') {
+    return { kind: 'rolled-back', version: job.fromVersion, error: job.error };
+  }
+  return null;
+}
+
+export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps = {}) {
+  const { register, control } = useFormContext<SettingsFormValues>();
+  const source = useWatch({ control, name: 'system.update_source' }) ?? '?';
+  const branch = useWatch({ control, name: 'system.update_branch' }) ?? '?';
+  const pushToast = useToastStore(state => state.push);
+  const [editingSource, setEditingSource] = useState(false);
+  const [checkResult, setCheckResult] = useState<UpdateCheckResponse | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(readActiveJobId);
+  const [resultNotice, setResultNotice] = useState<ResultNotice | null>(null);
 
   const versionQuery = useVersion();
-  const version = versionQuery.isPending ? '…' : (versionQuery.data?.version ?? '?');
-
+  const installedVersion = versionQuery.isPending ? '…' : (versionQuery.data?.version ?? '?');
   const updateCheck = useUpdateCheck();
+  const updateApply = useUpdateApply();
+  const updateJob = useUpdateJob(jobId);
+  const rollbackMutation = useRollback();
+  const job = updateJob.data;
+  const jobRunning = Boolean(jobId && (!job || !TERMINAL_PHASES.has(job.phase)));
+  const actionsPending =
+    isChecking ||
+    isApplying ||
+    jobRunning ||
+    updateCheck.isPending ||
+    updateApply.isPending ||
+    rollbackMutation.isPending;
+
+  useEffect(() => {
+    const notice = readResultNotice();
+    if (!notice) return;
+    setResultNotice(notice);
+    if (notice.kind === 'succeeded') {
+      pushToast('success', `Sur9e updated to v${notice.version}.`);
+    } else {
+      pushToast(
+        'warning',
+        `Sur9e automatically recovered v${notice.version} after the update failed.`,
+      );
+    }
+  }, [pushToast]);
+
+  useEffect(() => {
+    if (!job) return;
+    const notice = resultFromJob(job);
+    if (!notice) return;
+
+    const href = window.sessionStorage.getItem(RETURN_HREF_KEY) ?? window.location.href;
+    window.sessionStorage.setItem(RESULT_NOTICE_KEY, JSON.stringify(notice));
+    window.sessionStorage.removeItem(ACTIVE_JOB_KEY);
+    window.sessionStorage.removeItem(RETURN_HREF_KEY);
+    setResultNotice(notice);
+    setJobId(null);
+    navigate(href);
+  }, [job, navigate]);
+
   const checkUpdates = useCallback(async () => {
+    setIsChecking(true);
+    setCheckError(null);
     try {
-      const r = await updateCheck.mutateAsync();
-      const STATUS_LABEL: Record<string, string> = {
-        'update-available':
-          'Update available — run "npm run update:apply" or ask your agent to update sur9e',
-        'up-to-date': 'You are up to date',
-        dismissed: 'Update check dismissed',
-        offline: 'Could not reach the update server',
-      };
-      pushToast?.('info', STATUS_LABEL[r?.status ?? ''] || r?.status || 'Check complete');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      pushToast?.('danger', `Update check failed (${msg}) — try again later.`);
+      const result = await updateCheck.mutateAsync();
+      setCheckResult(result);
+      if (result.status === 'offline') {
+        setCheckError('Could not reach the update service. Try checking again.');
+      } else if (result.status === 'dismissed') {
+        setCheckError('The update check was dismissed. Try checking again when you are ready.');
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setCheckError(`Update check failed: ${message}. Try checking again.`);
+      pushToast('danger', `Update check failed (${message}) — try again later.`);
+    } finally {
+      setIsChecking(false);
     }
   }, [pushToast, updateCheck]);
 
-  const rollbackMutation = useRollback();
+  const applyUpdate = useCallback(async () => {
+    if (checkResult?.status !== 'update-available') return;
+    const fromVersion = checkResult.local;
+    const toVersion = checkResult.remote;
+    const confirm = getConfirmation();
+    const ok = confirm
+      ? await confirm({
+          title: `Update Sur9e from v${fromVersion} to v${toVersion}?`,
+          target: `v${fromVersion} → v${toVersion}`,
+          bodyText: 'Sur9e will briefly go offline while it updates and restarts in this tab.',
+          warningText: 'Your CV, profile, tracker, and reports are untouched.',
+          confirmLabel: 'Update now',
+        })
+      : window.confirm(
+          `Update Sur9e from v${fromVersion} to v${toVersion}?\n\nSur9e will briefly go offline while it updates and restarts. Your CV, profile, tracker, and reports are untouched.`,
+        );
+    if (!ok) return;
+
+    setIsApplying(true);
+    setCheckError(null);
+    window.sessionStorage.setItem(RETURN_HREF_KEY, window.location.href);
+    try {
+      const result = await updateApply.mutateAsync({ toVersion });
+      window.sessionStorage.setItem(ACTIVE_JOB_KEY, result.jobId);
+      setJobId(result.jobId);
+    } catch (error) {
+      window.sessionStorage.removeItem(RETURN_HREF_KEY);
+      const message = error instanceof Error ? error.message : String(error);
+      setCheckError(`Update could not start: ${message}. Try again or use Roll back for recovery.`);
+      pushToast('danger', `Update could not start (${message}).`);
+    } finally {
+      setIsApplying(false);
+    }
+  }, [checkResult, pushToast, updateApply]);
+
   const rollback = useCallback(async () => {
-    const w = window as unknown as {
-      deleteConfirmModal?: {
-        confirm: (opts: Record<string, unknown>) => Promise<boolean>;
-      };
-    };
-    const ok = w.deleteConfirmModal
-      ? await w.deleteConfirmModal.confirm({
+    const confirm = getConfirmation();
+    const ok = confirm
+      ? await confirm({
           title: 'Roll back to the previous version?',
           target: 'sur9e installation',
           bodyText:
@@ -58,82 +231,219 @@ export function SystemSection() {
           confirmLabel: 'Roll back',
         })
       : window.confirm(
-          'Roll back sur9e to the previous installed version?\nYour data (CV, profile, tracker, reports) will not be touched.',
+          'Roll back Sur9e to the previous installed version?\nYour data (CV, profile, tracker, reports) will not be touched.',
         );
     if (!ok) return;
     try {
-      const r = await rollbackMutation.mutateAsync();
-      pushToast?.(
-        r?.ok ? 'success' : 'danger',
-        r?.ok
-          ? 'Rolled back to the previous version'
-          : `Rollback failed (${r?.error || 'unknown'}) — see logs.`,
+      const result = await rollbackMutation.mutateAsync();
+      pushToast(
+        result?.ok ? 'success' : 'danger',
+        result?.ok
+          ? 'Rolled back to the previous version.'
+          : `Rollback failed (${result?.error || 'unknown'}) — see logs.`,
       );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      pushToast?.('danger', `Rollback failed (${msg}) — see logs.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      pushToast('danger', `Rollback failed (${message}) — see logs.`);
     }
   }, [pushToast, rollbackMutation]);
 
-  // Derive about source from rhf (reads current form value, not legacy ref)
-  const aboutSource = getValues('system.update_source') ?? '?';
+  const status = useMemo(() => {
+    if (resultNotice?.kind === 'rolled-back') {
+      return {
+        tone: 'recovered',
+        badge: 'Recovered automatically',
+        detail: `The previous version (v${resultNotice.version}) is running.`,
+      } as const;
+    }
+    if (resultNotice?.kind === 'succeeded') {
+      return {
+        tone: 'success',
+        badge: 'Update complete',
+        detail: `Sur9e is now running v${resultNotice.version}.`,
+      } as const;
+    }
+    if (job?.phase === 'failed') {
+      return {
+        tone: 'danger',
+        badge: 'Update failed',
+        detail: job.error ?? 'The update did not complete.',
+      } as const;
+    }
+    if (jobRunning) {
+      const phase = job?.phase;
+      return {
+        tone: phase === 'recovering' ? 'recovered' : 'updating',
+        badge: phase ? PHASE_LABEL[phase] : 'Starting update…',
+        detail: updateJob.isError
+          ? 'The server is restarting. Reconnecting to retained update progress…'
+          : 'Keep this tab open. Sur9e will return here when it is ready.',
+      } as const;
+    }
+    if (isChecking) {
+      return {
+        tone: 'checking',
+        badge: 'Checking for updates…',
+        detail: 'Comparing your installed version with the configured update source.',
+      } as const;
+    }
+    if (checkError) {
+      return { tone: 'danger', badge: 'Check failed', detail: checkError } as const;
+    }
+    if (checkResult?.status === 'up-to-date') {
+      return {
+        tone: 'success',
+        badge: 'Up to date',
+        detail: `v${checkResult.local} is the latest available version.`,
+      } as const;
+    }
+    if (checkResult?.status === 'update-available') {
+      return {
+        tone: 'available',
+        badge: `v${checkResult.remote} available`,
+        detail: `Ready to update from v${checkResult.local}.`,
+      } as const;
+    }
+    return {
+      tone: 'neutral',
+      badge: 'Not checked yet',
+      detail: 'Check when you are ready. Updates never run automatically.',
+    } as const;
+  }, [checkError, checkResult, isChecking, job, jobRunning, resultNotice, updateJob.isError]);
+
+  const phaseLabel = job?.phase ? PHASE_LABEL[job.phase] : 'Starting update…';
+  const canUpdate = checkResult?.status === 'update-available' && !jobId && !resultNotice;
+  const checkLabel = isChecking
+    ? 'Checking…'
+    : checkResult || checkError
+      ? 'Check again'
+      : 'Check for updates';
 
   return (
     <section className="form-section anim-enter" id="system">
       <h2 className="form-section__title">Updates &amp; about</h2>
-      <p className="form-section__desc">
-        Which repo and branch update checks pull from — point at a fork to track your own builds.
-        Stored in <code>system.*</code>.
-      </p>
-      <div className="form-grid form-grid--cols-2">
-        <div className="form-field">
-          <Label htmlFor="settings-system-update-source">Update source</Label>
-          <Input
-            id="settings-system-update-source"
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            data-adv-text="system.update_source"
-            {...register('system.update_source')}
-          />
-          <HelperText>
-            Git remote used by <code>update-system.mjs</code>.
-          </HelperText>
+      <p className="form-section__desc">Keep Sur9e current without losing your place.</p>
+
+      <div className={`system-update-panel system-update-panel--${status.tone}`}>
+        <div className="system-update-panel__version">
+          <span className="system-update-panel__eyebrow">Installed version</span>
+          <strong id="aboutVersion">v{installedVersion}</strong>
         </div>
-        <div className="form-field">
-          <Label htmlFor="settings-system-update-branch">Update branch</Label>
-          <Input
-            id="settings-system-update-branch"
-            type="text"
-            autoComplete="off"
-            spellCheck={false}
-            data-adv-text="system.update_branch"
-            {...register('system.update_branch')}
-          />
-          <HelperText>
-            Branch <code>update-system.mjs</code> tracks.
-          </HelperText>
+        <div
+          className="system-update-panel__status"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          <span className="system-update-panel__badge">{status.badge}</span>
+          <span className="system-update-panel__detail">{status.detail}</span>
+        </div>
+
+        {checkResult?.status === 'update-available' && checkResult.changelog.trim() ? (
+          <p className="system-update-panel__changelog">
+            <strong>What&rsquo;s new:</strong> {changelogExcerpt(checkResult.changelog)}
+          </p>
+        ) : null}
+
+        {job?.phase === 'failed' || checkError ? (
+          <div className="system-update-panel__error" role="alert">
+            <strong>
+              {job?.phase === 'failed' ? 'Update failed.' : 'Could not check for updates.'}
+            </strong>{' '}
+            {job?.phase === 'failed' ? job.error : checkError} Use Roll back below if the installed
+            version needs recovery; otherwise try checking again.
+          </div>
+        ) : null}
+
+        <div className="system-update-panel__actions">
+          {jobRunning ? (
+            <Button variant="primary" size="lg" disabled>
+              {phaseLabel}
+            </Button>
+          ) : canUpdate ? (
+            <Button variant="primary" size="lg" onClick={applyUpdate} disabled={actionsPending}>
+              {isApplying ? 'Starting update…' : 'Update now'}
+            </Button>
+          ) : null}
+          <Button
+            variant="secondary"
+            size="lg"
+            id="checkUpdates"
+            onClick={checkUpdates}
+            disabled={actionsPending}
+          >
+            {checkLabel}
+          </Button>
         </div>
       </div>
-      <p className="form-section__desc">
-        Version{' '}
-        <span id="aboutVersion" aria-live="polite">
-          {version}
-        </span>{' '}
-        · Source{' '}
-        <code id="aboutSource" translate="no" aria-live="polite">
-          {aboutSource}
-        </code>
-      </p>
-      <div className="settings-actions">
-        <Button variant="secondary" id="checkUpdates" onClick={checkUpdates}>
-          Check for updates
-        </Button>
+
+      <div className="system-update-row">
+        <div className="system-update-row__content">
+          <span className="system-update-row__label">Update source</span>
+          <span className="system-update-row__summary">
+            <code translate="no">{source}</code>
+            <span aria-hidden="true">·</span>
+            <code translate="no">{branch}</code>
+          </span>
+        </div>
         <Button
           variant="secondary"
+          size="lg"
+          onClick={() => setEditingSource(value => !value)}
+          disabled={actionsPending}
+          aria-expanded={editingSource}
+          aria-controls="system-update-source-fields"
+          aria-label={editingSource ? 'Close update source editor' : 'Edit update source'}
+        >
+          {editingSource ? 'Done' : 'Edit'}
+        </Button>
+      </div>
+
+      {editingSource ? (
+        <div className="system-update-source-fields" id="system-update-source-fields">
+          <div className="form-field">
+            <Label htmlFor="settings-system-update-source">Update source</Label>
+            <Input
+              id="settings-system-update-source"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              data-adv-text="system.update_source"
+              {...register('system.update_source')}
+            />
+            <HelperText>
+              Git remote used by <code>update-system.mjs</code>.
+            </HelperText>
+          </div>
+          <div className="form-field">
+            <Label htmlFor="settings-system-update-branch">Update branch</Label>
+            <Input
+              id="settings-system-update-branch"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              data-adv-text="system.update_branch"
+              {...register('system.update_branch')}
+            />
+            <HelperText>
+              Branch <code>update-system.mjs</code> tracks.
+            </HelperText>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="system-update-row system-update-row--recovery">
+        <div className="system-update-row__content">
+          <span className="system-update-row__label">Recovery</span>
+          <span className="system-update-row__help">Restore the previous installed version.</span>
+        </div>
+        <Button
+          variant="secondary"
+          size="lg"
           id="rollback"
           title="Roll back to the previous installed version (asks to confirm)"
           onClick={rollback}
+          disabled={actionsPending}
         >
           Roll back
         </Button>

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { Button, HelperText, Input, Label } from '@/components/primitives';
 import { useToastStore } from '@/components/toast/toast-store';
 import {
@@ -54,15 +55,21 @@ interface SystemSectionProps {
 }
 
 function defaultNavigate(href: string) {
+  if (href === window.location.href) {
+    window.location.reload();
+    return;
+  }
   window.location.replace(href);
 }
 
 function getConfirmation(): ((options: ConfirmOptions) => Promise<boolean>) | undefined {
   return (
-    window as typeof window & {
-      deleteConfirmModal?: { confirm: (options: ConfirmOptions) => Promise<boolean> };
-    }
-  ).deleteConfirmModal?.confirm;
+    (
+      window as typeof window & {
+        deleteConfirmModal?: { confirm: (options: ConfirmOptions) => Promise<boolean> };
+      }
+    ).deleteConfirmModal?.confirm ?? useDeleteConfirmStore.getState().confirm
+  );
 }
 
 function changelogExcerpt(changelog: string) {
@@ -152,6 +159,11 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
 
   useEffect(() => {
     if (!job) return;
+    if (job.phase === 'failed') {
+      window.sessionStorage.removeItem(ACTIVE_JOB_KEY);
+      window.sessionStorage.removeItem(RETURN_HREF_KEY);
+      return;
+    }
     const notice = resultFromJob(job);
     if (!notice) return;
 
@@ -165,6 +177,7 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
   }, [job, navigate]);
 
   const checkUpdates = useCallback(async () => {
+    if (job?.phase === 'failed') setJobId(null);
     setIsChecking(true);
     setCheckError(null);
     try {
@@ -182,7 +195,7 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
     } finally {
       setIsChecking(false);
     }
-  }, [pushToast, updateCheck]);
+  }, [job?.phase, pushToast, updateCheck]);
 
   const applyUpdate = useCallback(async () => {
     if (checkResult?.status !== 'update-available') return;

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -14,6 +14,7 @@ import {
   useUpdateJob,
   useVersion,
 } from '@/hooks/use-system';
+import { FetchJsonError } from '@/lib/api/fetch-json';
 import type { UpdateJob, UpdateJobPhase } from '@/lib/schemas/update-job';
 import type { SettingsFormValues } from '../types';
 
@@ -171,6 +172,15 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
       );
     }
   }, [pushToast]);
+
+  useEffect(() => {
+    if (!(updateJob.error instanceof FetchJsonError) || updateJob.error.status !== 404) return;
+    window.sessionStorage.removeItem(ACTIVE_JOB_KEY);
+    window.sessionStorage.removeItem(RETURN_HREF_KEY);
+    setDiscoveryAttached(true);
+    setJobId(null);
+    setCheckError('Saved update progress is no longer available. Check again to refresh status.');
+  }, [updateJob.error]);
 
   useEffect(() => {
     if (!job) return;

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -7,6 +7,7 @@ import { Button, HelperText, Input, Label } from '@/components/primitives';
 import { useToastStore } from '@/components/toast/toast-store';
 import {
   type UpdateCheckResponse,
+  useActiveUpdateJob,
   useRollback,
   useUpdateApply,
   useUpdateCheck,
@@ -31,6 +32,7 @@ const PHASE_LABEL: Record<UpdateJobPhase, string> = {
   restarting: 'Restarting',
   verifying: 'Verifying restart',
   recovering: 'Recovering previous version',
+  'recovery-queued': 'Preparing recovery',
   succeeded: 'Update complete',
   'rolled-back': 'Recovered automatically',
   failed: 'Update failed',
@@ -125,12 +127,14 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
   const [isChecking, setIsChecking] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
   const [jobId, setJobId] = useState<string | null>(readActiveJobId);
+  const [discoveryAttached, setDiscoveryAttached] = useState(false);
   const [resultNotice, setResultNotice] = useState<ResultNotice | null>(null);
 
   const versionQuery = useVersion();
   const installedVersion = versionQuery.isPending ? '…' : (versionQuery.data?.version ?? '?');
   const updateCheck = useUpdateCheck();
   const updateApply = useUpdateApply();
+  const activeUpdateJob = useActiveUpdateJob(!jobId && !discoveryAttached);
   const updateJob = useUpdateJob(jobId);
   const rollbackMutation = useRollback();
   const job = updateJob.data;
@@ -142,6 +146,17 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
     updateCheck.isPending ||
     updateApply.isPending ||
     rollbackMutation.isPending;
+
+  useEffect(() => {
+    const discovered = activeUpdateJob.data?.job;
+    if (jobId || discoveryAttached || !discovered) return;
+    if (!window.sessionStorage.getItem(RETURN_HREF_KEY)) {
+      window.sessionStorage.setItem(RETURN_HREF_KEY, window.location.href);
+    }
+    window.sessionStorage.setItem(ACTIVE_JOB_KEY, discovered.id);
+    setDiscoveryAttached(true);
+    setJobId(discovered.id);
+  }, [activeUpdateJob.data?.job, discoveryAttached, jobId]);
 
   useEffect(() => {
     const notice = readResultNotice();

--- a/src/hooks/__tests__/use-system.test.tsx
+++ b/src/hooks/__tests__/use-system.test.tsx
@@ -3,8 +3,10 @@ import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import {
+  activeUpdateJobKey,
   type UpdateCheckResponse,
   updateJobKey,
+  useActiveUpdateJob,
   useUpdateApply,
   useUpdateJob,
 } from '@/hooks/use-system';
@@ -124,6 +126,44 @@ describe('useUpdateApply', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ toVersion: '0.4.0' }),
     });
+  });
+});
+
+describe('useActiveUpdateJob', () => {
+  it('does not discover when Settings already has a retained job id', () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useActiveUpdateJob(false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(activeUpdateJobKey()).toEqual(['system', 'active-update-job']);
+  });
+
+  it('polls until it discovers a recovery-queued job, then stops', async () => {
+    vi.useFakeTimers();
+    const recoveryQueued = makeJob({ phase: 'recovery-queued' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ job: null }))
+      .mockResolvedValueOnce(jsonResponse({ job: recoveryQueued }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useActiveUpdateJob(true), { wrapper });
+
+    await flushMicrotasks();
+    expect(result.current.data).toEqual({ job: null });
+
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    await flushMicrotasks();
+    expect(result.current.data).toEqual({ job: recoveryQueued });
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/update/status', undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/hooks/__tests__/use-system.test.tsx
+++ b/src/hooks/__tests__/use-system.test.tsx
@@ -1,0 +1,262 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import {
+  type UpdateCheckResponse,
+  updateJobKey,
+  useUpdateApply,
+  useUpdateJob,
+} from '@/hooks/use-system';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+
+const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+
+function makeJob(overrides: Partial<UpdateJob> = {}): UpdateJob {
+  return {
+    id: JOB_ID,
+    phase: 'queued',
+    launchState: 'claim-pending',
+    mode: { prod: false, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: '2026-07-31T20:00:00.000Z',
+    updatedAt: '2026-07-31T20:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 404 ? 'Not Found' : status === 500 ? 'Internal Server Error' : 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { gcTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, wrapper };
+}
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1);
+  });
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('UpdateCheckResponse', () => {
+  it('models every response shape emitted by the update check route', () => {
+    expectTypeOf<UpdateCheckResponse>().toEqualTypeOf<
+      | { status: 'update-available'; local: string; remote: string; changelog: string }
+      | { status: 'up-to-date'; local: string; remote: string }
+      | { status: 'dismissed' }
+      | { status: 'offline'; local: string }
+    >();
+
+    const responses: UpdateCheckResponse[] = [
+      { status: 'dismissed' },
+      { status: 'offline', local: '0.3.2' },
+      { status: 'up-to-date', local: '0.3.2', remote: '0.3.2' },
+      {
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: 'Faster restart',
+      },
+    ];
+
+    expect(responses.map(response => response.status)).toEqual([
+      'dismissed',
+      'offline',
+      'up-to-date',
+      'update-available',
+    ]);
+  });
+});
+
+describe('useUpdateApply', () => {
+  it('POSTs without a JSON body when no target version is supplied', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ jobId: JOB_ID }, 202));
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateApply(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync()).resolves.toEqual({ jobId: JOB_ID });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/update/apply', { method: 'POST' });
+  });
+
+  it('POSTs the optional target version as JSON when supplied', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ jobId: JOB_ID }, 202));
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateApply(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ toVersion: '0.4.0' });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/update/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ toVersion: '0.4.0' }),
+    });
+  });
+});
+
+describe('useUpdateJob', () => {
+  it.each([undefined, null, '', '   ', 'not-a-uuid'])('does not fetch for invalid id %j', jobId => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useUpdateJob(jobId), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateJobKey(jobId)).toEqual(['system', 'update-job', jobId ?? null]);
+  });
+
+  it('polls every second while active and stops after a terminal phase', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(makeJob({ phase: 'queued' })))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          makeJob({
+            phase: 'applying',
+            launchState: 'owned',
+            pid: 4242,
+            updatedAt: '2026-07-31T20:00:01.000Z',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          makeJob({
+            phase: 'succeeded',
+            launchState: undefined,
+            pid: undefined,
+            updatedAt: '2026-07-31T20:00:02.000Z',
+          }),
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateJob(JOB_ID), { wrapper });
+
+    await flushMicrotasks();
+    expect(result.current.data?.phase).toBe('queued');
+
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    await flushMicrotasks();
+    expect(result.current.data?.phase).toBe('applying');
+
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    await flushMicrotasks();
+    expect(result.current.data?.phase).toBe('succeeded');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(['succeeded', 'rolled-back', 'failed'] as const)(
+    'does not poll after initial terminal phase %s',
+    async phase => {
+      vi.useFakeTimers();
+      const fetchMock = vi.fn(async () => jsonResponse(makeJob({ phase })));
+      vi.stubGlobal('fetch', fetchMock);
+      const { wrapper } = makeWrapper();
+      const { result } = renderHook(() => useUpdateJob(JOB_ID), { wrapper });
+
+      await flushMicrotasks();
+      expect(result.current.data?.phase).toBe(phase);
+
+      await act(async () => vi.advanceTimersByTimeAsync(5000));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('retains the last successful job while restart downtime retries are in flight', async () => {
+    vi.useFakeTimers();
+    const active = makeJob({
+      phase: 'restarting',
+      launchState: 'owned',
+      pid: 4242,
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(active))
+      .mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateJob(JOB_ID), { wrapper });
+
+    await flushMicrotasks();
+    expect(result.current.data).toEqual(active);
+
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    await flushMicrotasks();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual(active);
+
+    await act(async () => vi.advanceTimersByTimeAsync(7000));
+    await flushMicrotasks();
+    expect(result.current.data).toEqual(active);
+  });
+
+  it.each([
+    ['network failures', () => Promise.reject(new TypeError('Failed to fetch'))],
+    ['server failures', () => Promise.resolve(jsonResponse({ error: 'restarting' }, 500))],
+  ])('retries %s with a bounded policy', async (_label, response) => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(response);
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateJob(JOB_ID), { wrapper });
+
+    await act(async () => vi.advanceTimersByTimeAsync(7000));
+    await flushMicrotasks();
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('does not retry a 404 response', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => jsonResponse({ error: 'Update job not found' }, 404));
+    vi.stubGlobal('fetch', fetchMock);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUpdateJob(JOB_ID), { wrapper });
+
+    await flushMicrotasks();
+
+    expect(result.current.isError).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/use-system.test.tsx
+++ b/src/hooks/__tests__/use-system.test.tsx
@@ -156,7 +156,7 @@ describe('useActiveUpdateJob', () => {
     await flushMicrotasks();
     expect(result.current.data).toEqual({ job: null });
 
-    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    await act(async () => vi.advanceTimersByTimeAsync(15_000));
     await flushMicrotasks();
     expect(result.current.data).toEqual({ job: recoveryQueued });
     expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/update/status', undefined);
@@ -211,6 +211,9 @@ describe('useUpdateJob', () => {
 
     await flushMicrotasks();
     expect(result.current.data?.phase).toBe('queued');
+    expect(fetchMock).toHaveBeenLastCalledWith(`/api/update/status/${JOB_ID}`, {
+      method: 'POST',
+    });
 
     await act(async () => vi.advanceTimersByTimeAsync(1000));
     await flushMicrotasks();

--- a/src/hooks/use-system.ts
+++ b/src/hooks/use-system.ts
@@ -1,24 +1,38 @@
 'use client';
 
 // hooks/use-system.ts — TanStack Query wrappers around the system/update
-// endpoints (GET /api/version, GET /api/update/check,
-// POST /api/update/rollback). Backs the Settings → About section, which
-// previously hand-rolled these with useEffect + raw fetch (a legacy
-// carryover flagged in the production-readiness audit).
+// endpoints (GET /api/version, GET /api/update/check, POST /api/update/apply,
+// GET /api/update/status/:id, POST /api/update/rollback). Backs the
+// Settings → About section, which previously hand-rolled these with
+// useEffect + raw fetch (a legacy carryover flagged in the
+// production-readiness audit).
 //
 // The version never changes within a session, so the query is cached
 // effectively forever. Check/rollback are user-triggered, so they're
 // mutations — the section component owns the toast messaging.
 
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { fetchJson } from '@/lib/api/fetch-json';
+import { FetchJsonError, fetchJson } from '@/lib/api/fetch-json';
+import type { UpdateJob } from '@/lib/schemas/update-job';
+
+export type { UpdateJob } from '@/lib/schemas/update-job';
 
 export interface VersionResponse {
   version?: string;
 }
 
-export interface UpdateCheckResponse {
-  status?: string;
+export type UpdateCheckResponse =
+  | { status: 'update-available'; local: string; remote: string; changelog: string }
+  | { status: 'up-to-date'; local: string; remote: string }
+  | { status: 'dismissed' }
+  | { status: 'offline'; local: string };
+
+export interface UpdateApplyRequest {
+  toVersion?: string;
+}
+
+export interface UpdateApplyResponse {
+  jobId: string;
 }
 
 export interface RollbackResponse {
@@ -27,6 +41,27 @@ export interface RollbackResponse {
 }
 
 export const VERSION_QUERY_KEY = ['system', 'version'] as const;
+const UPDATE_JOB_POLL_MS = 1000;
+const UPDATE_JOB_MAX_RETRIES = 3;
+const UPDATE_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const TERMINAL_UPDATE_JOB_PHASES = new Set<UpdateJob['phase']>([
+  'succeeded',
+  'rolled-back',
+  'failed',
+]);
+
+export function updateJobKey(jobId: string | null | undefined) {
+  return ['system', 'update-job', jobId ?? null] as const;
+}
+
+function isValidUpdateJobId(jobId: string | null | undefined): jobId is string {
+  return typeof jobId === 'string' && UPDATE_JOB_ID.test(jobId);
+}
+
+function retryUpdateJob(failureCount: number, error: Error): boolean {
+  if (failureCount >= UPDATE_JOB_MAX_RETRIES) return false;
+  return error instanceof TypeError || (error instanceof FetchJsonError && error.status >= 500);
+}
 
 export function useVersion() {
   return useQuery<VersionResponse>({
@@ -40,6 +75,36 @@ export function useVersion() {
 export function useUpdateCheck() {
   return useMutation<UpdateCheckResponse>({
     mutationFn: () => fetchJson<UpdateCheckResponse>('/api/update/check'),
+  });
+}
+
+export function useUpdateApply() {
+  return useMutation<UpdateApplyResponse, Error, UpdateApplyRequest | void>({
+    mutationFn: request =>
+      fetchJson<UpdateApplyResponse>('/api/update/apply', {
+        method: 'POST',
+        ...(request?.toVersion === undefined
+          ? {}
+          : {
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ toVersion: request.toVersion }),
+            }),
+      }),
+  });
+}
+
+export function useUpdateJob(jobId: string | null | undefined) {
+  return useQuery<UpdateJob>({
+    queryKey: updateJobKey(jobId),
+    queryFn: () => fetchJson<UpdateJob>(`/api/update/status/${jobId}`),
+    enabled: isValidUpdateJobId(jobId),
+    refetchInterval: query =>
+      query.state.data && TERMINAL_UPDATE_JOB_PHASES.has(query.state.data.phase)
+        ? false
+        : UPDATE_JOB_POLL_MS,
+    refetchIntervalInBackground: true,
+    retry: retryUpdateJob,
+    retryDelay: attemptIndex => Math.min(UPDATE_JOB_POLL_MS * 2 ** attemptIndex, 4000),
   });
 }
 

--- a/src/hooks/use-system.ts
+++ b/src/hooks/use-system.ts
@@ -2,7 +2,7 @@
 
 // hooks/use-system.ts — TanStack Query wrappers around the system/update
 // endpoints (GET /api/version, GET /api/update/check, POST /api/update/apply,
-// GET /api/update/status/:id, POST /api/update/rollback). Backs the
+// POST /api/update/status/:id, POST /api/update/rollback). Backs the
 // Settings → About section, which previously hand-rolled these with
 // useEffect + raw fetch (a legacy carryover flagged in the
 // production-readiness audit).
@@ -47,6 +47,7 @@ export interface RollbackResponse {
 export const VERSION_QUERY_KEY = ['system', 'version'] as const;
 export const ACTIVE_UPDATE_JOB_QUERY_KEY = ['system', 'active-update-job'] as const;
 const UPDATE_JOB_POLL_MS = 1000;
+const ACTIVE_UPDATE_JOB_POLL_MS = 15_000;
 const UPDATE_JOB_MAX_RETRIES = 3;
 const UPDATE_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TERMINAL_UPDATE_JOB_PHASES = new Set<UpdateJob['phase']>([
@@ -107,8 +108,8 @@ export function useActiveUpdateJob(enabled = true) {
     queryKey: activeUpdateJobKey(),
     queryFn: () => fetchJson<ActiveUpdateJobResponse>('/api/update/status'),
     enabled,
-    refetchInterval: query => (query.state.data?.job ? false : UPDATE_JOB_POLL_MS),
-    refetchIntervalInBackground: true,
+    refetchInterval: query => (query.state.data?.job ? false : ACTIVE_UPDATE_JOB_POLL_MS),
+    refetchIntervalInBackground: false,
     retry: retryUpdateJob,
     retryDelay: attemptIndex => Math.min(UPDATE_JOB_POLL_MS * 2 ** attemptIndex, 4000),
   });
@@ -117,7 +118,10 @@ export function useActiveUpdateJob(enabled = true) {
 export function useUpdateJob(jobId: string | null | undefined) {
   return useQuery<UpdateJob>({
     queryKey: updateJobKey(jobId),
-    queryFn: () => fetchJson<UpdateJob>(`/api/update/status/${jobId}`),
+    queryFn: () =>
+      fetchJson<UpdateJob>(`/api/update/status/${jobId}`, {
+        method: 'POST',
+      }),
     enabled: isValidUpdateJobId(jobId),
     refetchInterval: query =>
       query.state.data && TERMINAL_UPDATE_JOB_PHASES.has(query.state.data.phase)

--- a/src/hooks/use-system.ts
+++ b/src/hooks/use-system.ts
@@ -35,12 +35,17 @@ export interface UpdateApplyResponse {
   jobId: string;
 }
 
+export interface ActiveUpdateJobResponse {
+  job: UpdateJob | null;
+}
+
 export interface RollbackResponse {
   ok?: boolean;
   error?: string;
 }
 
 export const VERSION_QUERY_KEY = ['system', 'version'] as const;
+export const ACTIVE_UPDATE_JOB_QUERY_KEY = ['system', 'active-update-job'] as const;
 const UPDATE_JOB_POLL_MS = 1000;
 const UPDATE_JOB_MAX_RETRIES = 3;
 const UPDATE_JOB_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -52,6 +57,10 @@ const TERMINAL_UPDATE_JOB_PHASES = new Set<UpdateJob['phase']>([
 
 export function updateJobKey(jobId: string | null | undefined) {
   return ['system', 'update-job', jobId ?? null] as const;
+}
+
+export function activeUpdateJobKey() {
+  return ACTIVE_UPDATE_JOB_QUERY_KEY;
 }
 
 function isValidUpdateJobId(jobId: string | null | undefined): jobId is string {
@@ -90,6 +99,18 @@ export function useUpdateApply() {
               body: JSON.stringify({ toVersion: request.toVersion }),
             }),
       }),
+  });
+}
+
+export function useActiveUpdateJob(enabled = true) {
+  return useQuery<ActiveUpdateJobResponse>({
+    queryKey: activeUpdateJobKey(),
+    queryFn: () => fetchJson<ActiveUpdateJobResponse>('/api/update/status'),
+    enabled,
+    refetchInterval: query => (query.state.data?.job ? false : UPDATE_JOB_POLL_MS),
+    refetchIntervalInBackground: true,
+    retry: retryUpdateJob,
+    retryDelay: attemptIndex => Math.min(UPDATE_JOB_POLL_MS * 2 ** attemptIndex, 4000),
   });
 }
 

--- a/src/lib/api/fetch-json.ts
+++ b/src/lib/api/fetch-json.ts
@@ -1,11 +1,20 @@
 /**
  * fetchJson — JSON fetch with structured error extraction.
  *
- * Throws Error(msg) where msg is `body.error` if the response is JSON
- * with that field, otherwise the raw body text, otherwise the status
- * line. The four legacy /api routes use `{ "error": "..." }` envelopes,
- * so this preserves their messages instead of surfacing a bare 500.
+ * Throws FetchJsonError(status, msg) where msg is `body.error` if the
+ * response is JSON with that field, otherwise the raw body text, otherwise
+ * the status line. Callers can use the status without parsing the message.
  */
+export class FetchJsonError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'FetchJsonError';
+    this.status = status;
+  }
+}
+
 export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
   if (!response.ok) {
@@ -16,7 +25,7 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
     } catch {
       // body wasn't JSON — fall back to raw text
     }
-    throw new Error(msg || `${response.status} ${response.statusText}`);
+    throw new FetchJsonError(response.status, msg || `${response.status} ${response.statusText}`);
   }
   return response.json() as Promise<T>;
 }

--- a/src/lib/repo-path-policy.mjs
+++ b/src/lib/repo-path-policy.mjs
@@ -33,6 +33,8 @@ export const SYSTEM_PATHS = Object.freeze([
   'src/lib/repo-path-policy.mjs',
   'src/lib/check-user-data-boundary.mjs',
   'scripts/sync-release-version.mjs',
+  'scripts/update-worker.mjs',
+  'scripts/web.mjs',
   'update-system.mjs',
   'test-all.mjs',
 ]);

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -16,7 +16,7 @@ export const UPDATE_JOB_PHASES = [
 export const UpdateJobPhase = z.enum(UPDATE_JOB_PHASES);
 export type UpdateJobPhase = z.infer<typeof UpdateJobPhase>;
 
-export const UpdateJobLaunchState = z.enum(['ownership-unknown', 'owned']);
+export const UpdateJobLaunchState = z.enum(['claim-pending', 'owned']);
 export type UpdateJobLaunchState = z.infer<typeof UpdateJobLaunchState>;
 
 export const UpdateJob = z
@@ -37,5 +37,14 @@ export const UpdateJob = z
     pid: z.number().int().positive().optional(),
     launchState: UpdateJobLaunchState.optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((job, context) => {
+    if (job.launchState === 'owned' && job.pid === undefined) {
+      context.addIssue({
+        code: 'custom',
+        path: ['pid'],
+        message: 'owned update jobs require a worker pid',
+      });
+    }
+  });
 export type UpdateJob = z.infer<typeof UpdateJob>;

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -19,6 +19,15 @@ export type UpdateJobPhase = z.infer<typeof UpdateJobPhase>;
 export const UpdateJobLaunchState = z.enum(['claim-pending', 'owned']);
 export type UpdateJobLaunchState = z.infer<typeof UpdateJobLaunchState>;
 
+const ACTIVE_WORKER_PHASES = new Set<UpdateJobPhase>([
+  'applying',
+  'stopping',
+  'rebuilding',
+  'restarting',
+  'verifying',
+  'recovering',
+]);
+
 export const UpdateJob = z
   .object({
     id: z.string().uuid(),
@@ -39,6 +48,16 @@ export const UpdateJob = z
   })
   .strict()
   .superRefine((job, context) => {
+    if (
+      ACTIVE_WORKER_PHASES.has(job.phase) &&
+      (job.launchState !== 'owned' || job.pid === undefined)
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['launchState'],
+        message: 'active update jobs require owned worker metadata',
+      });
+    }
     if (job.launchState === 'owned' && job.pid === undefined) {
       context.addIssue({
         code: 'custom',

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -8,6 +8,7 @@ export const UPDATE_JOB_PHASES = [
   'restarting',
   'verifying',
   'recovering',
+  'recovery-queued',
   'succeeded',
   'rolled-back',
   'failed',
@@ -28,6 +29,17 @@ const ACTIVE_WORKER_PHASES = new Set<UpdateJobPhase>([
   'recovering',
 ]);
 
+export const UpdateJobCheckpoint = z.enum([
+  'apply-started',
+  'applied',
+  'server-stopped',
+  'server-restarted',
+  'rollback-complete',
+  'dependencies-restored',
+  'recovery-build-complete',
+  'recovery-server-started',
+]);
+
 export const UpdateJob = z
   .object({
     id: z.string().uuid(),
@@ -45,6 +57,7 @@ export const UpdateJob = z
     error: z.string().optional(),
     pid: z.number().int().positive().optional(),
     launchState: UpdateJobLaunchState.optional(),
+    checkpoint: UpdateJobCheckpoint.optional(),
   })
   .strict()
   .superRefine((job, context) => {

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const UPDATE_JOB_PHASES = [
+  'queued',
+  'applying',
+  'stopping',
+  'rebuilding',
+  'restarting',
+  'verifying',
+  'recovering',
+  'succeeded',
+  'rolled-back',
+  'failed',
+] as const;
+
+export const UpdateJobPhase = z.enum(UPDATE_JOB_PHASES);
+export type UpdateJobPhase = z.infer<typeof UpdateJobPhase>;
+
+export const UpdateJob = z
+  .object({
+    id: z.string().uuid(),
+    phase: UpdateJobPhase,
+    mode: z
+      .object({
+        prod: z.boolean(),
+        tailscale: z.boolean(),
+      })
+      .strict(),
+    fromVersion: z.string(),
+    toVersion: z.string().optional(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    error: z.string().optional(),
+  })
+  .strict();
+export type UpdateJob = z.infer<typeof UpdateJob>;

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -31,6 +31,7 @@ export const UpdateJob = z
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
     error: z.string().optional(),
+    pid: z.number().int().positive().optional(),
   })
   .strict();
 export type UpdateJob = z.infer<typeof UpdateJob>;

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -16,6 +16,9 @@ export const UPDATE_JOB_PHASES = [
 export const UpdateJobPhase = z.enum(UPDATE_JOB_PHASES);
 export type UpdateJobPhase = z.infer<typeof UpdateJobPhase>;
 
+export const UpdateJobLaunchState = z.enum(['ownership-unknown', 'owned']);
+export type UpdateJobLaunchState = z.infer<typeof UpdateJobLaunchState>;
+
 export const UpdateJob = z
   .object({
     id: z.string().uuid(),
@@ -32,6 +35,7 @@ export const UpdateJob = z
     updatedAt: z.string().datetime(),
     error: z.string().optional(),
     pid: z.number().int().positive().optional(),
+    launchState: UpdateJobLaunchState.optional(),
   })
   .strict();
 export type UpdateJob = z.infer<typeof UpdateJob>;

--- a/src/lib/schemas/update-job.ts
+++ b/src/lib/schemas/update-job.ts
@@ -20,6 +20,8 @@ export type UpdateJobPhase = z.infer<typeof UpdateJobPhase>;
 export const UpdateJobLaunchState = z.enum(['claim-pending', 'owned']);
 export type UpdateJobLaunchState = z.infer<typeof UpdateJobLaunchState>;
 
+export const UpdateJobId = z.uuid();
+
 const ACTIVE_WORKER_PHASES = new Set<UpdateJobPhase>([
   'applying',
   'stopping',
@@ -42,7 +44,7 @@ export const UpdateJobCheckpoint = z.enum([
 
 export const UpdateJob = z
   .object({
-    id: z.string().uuid(),
+    id: UpdateJobId,
     phase: UpdateJobPhase,
     mode: z
       .object({
@@ -52,8 +54,8 @@ export const UpdateJob = z
       .strict(),
     fromVersion: z.string(),
     toVersion: z.string().optional(),
-    createdAt: z.string().datetime(),
-    updatedAt: z.string().datetime(),
+    createdAt: z.iso.datetime(),
+    updatedAt: z.iso.datetime(),
     error: z.string().optional(),
     pid: z.number().int().positive().optional(),
     launchState: UpdateJobLaunchState.optional(),

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -479,6 +479,60 @@ describe('update-job durable contract', () => {
     });
   });
 
+  it('marks an expired pre-claim queued job failed when status reconciles it', () => {
+    const interrupted = { ...job('queued'), launchState: 'claim-pending' as const };
+    writeUpdateJob(root, interrupted);
+    const worker = fakeDeps();
+
+    const reconciled = reconcileUpdateJob(root, JOB_ID, worker.deps);
+
+    expect(reconciled).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker did not claim ownership',
+      updatedAt: NOW.toISOString(),
+    });
+    expect(worker.spawn).not.toHaveBeenCalled();
+  });
+
+  it('retries an expired recovery claim instead of leaving it queued forever', () => {
+    const interrupted = {
+      ...job('recovery-queued'),
+      launchState: 'claim-pending' as const,
+      checkpoint: 'applied' as const,
+      error: 'Update worker stopped before completion',
+    };
+    writeUpdateJob(root, interrupted);
+    const worker = fakeDeps();
+
+    const reconciled = reconcileUpdateJob(root, JOB_ID, worker.deps);
+
+    expect(reconciled).toMatchObject({
+      phase: 'recovery-queued',
+      launchState: 'claim-pending',
+      checkpoint: 'applied',
+      updatedAt: NOW.toISOString(),
+    });
+    expect(worker.spawn).toHaveBeenCalledWith(
+      process.execPath,
+      [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', JOB_ID, '--recover'],
+      expect.objectContaining({ cwd: root, detached: true }),
+    );
+  });
+
+  it('does not steal a fresh claim-pending job during status polling', () => {
+    const active = {
+      ...job('queued'),
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      launchState: 'claim-pending' as const,
+    };
+    writeUpdateJob(root, active);
+    const worker = fakeDeps(SECOND_JOB_ID, [new Date(NOW.getTime() + 1_000)]);
+
+    expect(reconcileUpdateJob(root, JOB_ID, worker.deps)).toEqual(active);
+    expect(worker.spawn).not.toHaveBeenCalled();
+  });
+
   it('keeps an expired nonterminal job busy while its persisted worker pid is alive', () => {
     const active = { ...job('rebuilding'), launchState: 'owned' as const, pid: 98989 };
     writeUpdateJob(root, active);

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -195,6 +195,50 @@ describe('update-job durable contract', () => {
     expect(unref).toHaveBeenCalledTimes(1);
   });
 
+  it('does not regress worker progress when spawn advances the persisted phase before returning', () => {
+    const workerHarness = fakeDeps(SECOND_JOB_ID);
+    const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((...args) => {
+      const queued = loadUpdateJob(root, SECOND_JOB_ID);
+      expect(queued).not.toBeNull();
+      writeUpdateJob(root, {
+        ...(queued as NonNullable<typeof queued>),
+        phase: 'applying',
+        updatedAt: LATER.toISOString(),
+      });
+      return workerHarness.spawn(...args);
+    });
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...workerHarness.deps, spawn },
+    );
+
+    expect(result).toMatchObject({
+      status: 'started',
+      job: {
+        id: SECOND_JOB_ID,
+        phase: 'applying',
+        updatedAt: LATER.toISOString(),
+        pid: 4242,
+      },
+    });
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toMatchObject({
+      phase: 'applying',
+      updatedAt: LATER.toISOString(),
+      pid: 4242,
+    });
+    expect(
+      JSON.parse(readFileSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`), 'utf-8')),
+    ).toMatchObject({
+      phase: 'applying',
+      updatedAt: LATER.toISOString(),
+    });
+  });
+
   it.each([
     'queued',
     'applying',

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -1,0 +1,193 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateJob, UpdateJobPhase } from '../../schemas/update-job';
+import {
+  loadUpdateJob,
+  startUpdateJob,
+  type UpdateOrchestratorDeps,
+  writeUpdateJob,
+} from '../update-orchestrator';
+
+const JOB_ID = '11111111-1111-4111-8111-111111111111';
+const SECOND_JOB_ID = '22222222-2222-4222-8222-222222222222';
+const NOW = new Date('2026-07-31T12:00:00.000Z');
+const EARLIER = '2026-07-30T12:00:00.000Z';
+
+const ALL_PHASES = [
+  'queued',
+  'applying',
+  'stopping',
+  'rebuilding',
+  'restarting',
+  'verifying',
+  'recovering',
+  'succeeded',
+  'rolled-back',
+  'failed',
+] as const;
+
+function job(phase: (typeof ALL_PHASES)[number] = 'queued', id = JOB_ID) {
+  return {
+    id,
+    phase,
+    mode: { prod: true, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: EARLIER,
+    updatedAt: EARLIER,
+  };
+}
+
+function fakeDeps(id = SECOND_JOB_ID) {
+  const unref = vi.fn();
+  const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>(() => ({ unref }));
+  return {
+    deps: {
+      clock: () => NOW,
+      uuid: () => id,
+      spawn,
+    },
+    spawn,
+    unref,
+  };
+}
+
+describe('update-job durable contract', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'update-orchestrator-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('accepts every supported phase and parses the complete job shape', () => {
+    expect(UpdateJobPhase.options).toEqual(ALL_PHASES);
+
+    for (const phase of ALL_PHASES) {
+      expect(
+        UpdateJob.parse({ ...job(phase), error: phase === 'failed' ? 'build failed' : undefined }),
+      ).toMatchObject({
+        id: JOB_ID,
+        phase,
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+        toVersion: '0.4.0',
+        createdAt: EARLIER,
+        updatedAt: EARLIER,
+      });
+    }
+  });
+
+  it('rejects invalid JSON when loading a persisted job', () => {
+    const path = join(root, 'data/update/jobs', `${JOB_ID}.json`);
+    mkdirSync(join(root, 'data/update/jobs'), { recursive: true });
+    writeFileSync(path, '{not-json', { encoding: 'utf-8', flag: 'w' });
+
+    expect(() => loadUpdateJob(root, JOB_ID)).toThrow();
+  });
+
+  it('atomically persists jobs under data/update/jobs', () => {
+    writeUpdateJob(root, job('queued'));
+    writeUpdateJob(root, {
+      ...job('applying'),
+      updatedAt: '2026-07-31T12:01:00.000Z',
+    });
+
+    const path = join(root, 'data/update/jobs', `${JOB_ID}.json`);
+    expect(loadUpdateJob(root, JOB_ID)).toMatchObject({
+      id: JOB_ID,
+      phase: 'applying',
+      updatedAt: '2026-07-31T12:01:00.000Z',
+    });
+    expect(JSON.parse(readFileSync(`${path}.bak`, 'utf-8'))).toMatchObject({
+      id: JOB_ID,
+      phase: 'queued',
+    });
+    expect(readdirSync(join(root, 'data/update/jobs')).some(file => file.endsWith('.tmp'))).toBe(
+      false,
+    );
+  });
+
+  it('starts a new detached worker when existing jobs are terminal', () => {
+    writeUpdateJob(root, job('succeeded'));
+    const { deps, spawn, unref } = fakeDeps();
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: true },
+        fromVersion: '0.3.2',
+        toVersion: '0.4.0',
+      },
+      deps,
+    );
+
+    expect(result).toEqual({
+      status: 'started',
+      job: {
+        id: SECOND_JOB_ID,
+        phase: 'queued',
+        mode: { prod: true, tailscale: true },
+        fromVersion: '0.3.2',
+        toVersion: '0.4.0',
+        createdAt: NOW.toISOString(),
+        updatedAt: NOW.toISOString(),
+      },
+    });
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toEqual(result.job);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      process.execPath,
+      [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', SECOND_JOB_ID],
+      expect.objectContaining({
+        cwd: root,
+        detached: true,
+        stdio: ['ignore', expect.any(Number), expect.any(Number)],
+      }),
+    );
+    const spawnOptions = spawn.mock.calls[0]?.[2];
+    expect(spawnOptions?.stdio[1]).toBe(spawnOptions?.stdio[2]);
+    expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.log`))).toBe(true);
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'queued',
+    'applying',
+    'stopping',
+    'rebuilding',
+    'restarting',
+    'verifying',
+    'recovering',
+  ])('returns busy instead of spawning when a %s job exists', phase => {
+    const active = job(phase as (typeof ALL_PHASES)[number]);
+    writeUpdateJob(root, active);
+    const { deps, spawn } = fakeDeps();
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: false, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      deps,
+    );
+
+    expect(result).toEqual({ status: 'busy', job: active });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`))).toBe(false);
+  });
+});

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -54,16 +54,16 @@ function job(phase: (typeof ALL_PHASES)[number] = 'queued', id = JOB_ID) {
 
 function fakeDeps(id = SECOND_JOB_ID, clockValues: Date[] = [NOW]) {
   const unref = vi.fn();
-  let errorListener: ((error: Error) => void) | undefined;
+  const listeners = new Map<string, (...args: unknown[]) => void>();
   let worker: {
     pid: number;
-    once: (event: 'error', listener: (error: Error) => void) => typeof worker;
+    once: (event: string, listener: (...args: unknown[]) => void) => typeof worker;
     unref: typeof unref;
   };
   worker = {
     pid: 4242,
-    once: vi.fn((event: 'error', listener: (error: Error) => void) => {
-      if (event === 'error') errorListener = listener;
+    once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      listeners.set(event, listener);
       return worker;
     }),
     unref,
@@ -77,8 +77,19 @@ function fakeDeps(id = SECOND_JOB_ID, clockValues: Date[] = [NOW]) {
       spawn,
     },
     emitError(error: Error) {
-      if (!errorListener) throw new Error('worker error listener was not registered');
-      errorListener(error);
+      const listener = listeners.get('error');
+      if (!listener) throw new Error('worker error listener was not registered');
+      listener(error);
+    },
+    emitExit(code: number | null, signal: NodeJS.Signals | null = null) {
+      const listener = listeners.get('exit');
+      if (!listener) throw new Error('worker exit listener was not registered');
+      listener(code, signal);
+    },
+    emitClose(code: number | null, signal: NodeJS.Signals | null = null) {
+      const listener = listeners.get('close');
+      if (!listener) throw new Error('worker close listener was not registered');
+      listener(code, signal);
     },
     spawn,
     unref,
@@ -123,13 +134,14 @@ describe('update-job durable contract', () => {
   });
 
   it('parses durable launch ownership state', () => {
-    expect(UpdateJob.parse({ ...job('queued'), launchState: 'ownership-unknown' })).toMatchObject({
-      launchState: 'ownership-unknown',
+    expect(UpdateJob.parse({ ...job('queued'), launchState: 'claim-pending' })).toMatchObject({
+      launchState: 'claim-pending',
     });
     expect(UpdateJob.parse({ ...job('applying'), launchState: 'owned', pid: 4242 })).toMatchObject({
       launchState: 'owned',
       pid: 4242,
     });
+    expect(() => UpdateJob.parse({ ...job('applying'), launchState: 'owned' })).toThrow();
   });
 
   it('rejects invalid JSON when loading a persisted job', () => {
@@ -153,10 +165,7 @@ describe('update-job durable contract', () => {
       phase: 'applying',
       updatedAt: '2026-07-31T12:01:00.000Z',
     });
-    expect(JSON.parse(readFileSync(`${path}.bak`, 'utf-8'))).toMatchObject({
-      id: JOB_ID,
-      phase: 'queued',
-    });
+    expect(existsSync(`${path}.bak`)).toBe(false);
     expect(readdirSync(join(root, 'data/update/jobs')).some(file => file.endsWith('.tmp'))).toBe(
       false,
     );
@@ -186,8 +195,7 @@ describe('update-job durable contract', () => {
         toVersion: '0.4.0',
         createdAt: NOW.toISOString(),
         updatedAt: NOW.toISOString(),
-        pid: 4242,
-        launchState: 'owned',
+        launchState: 'claim-pending',
       },
     });
     expect(loadUpdateJob(root, SECOND_JOB_ID)).toEqual(result.job);
@@ -215,6 +223,8 @@ describe('update-job durable contract', () => {
       writeUpdateJob(root, {
         ...(queued as NonNullable<typeof queued>),
         phase: 'applying',
+        launchState: 'owned',
+        pid: 4242,
         updatedAt: LATER.toISOString(),
       });
       return workerHarness.spawn(...args);
@@ -406,6 +416,29 @@ describe('update-job durable contract', () => {
     });
   });
 
+  it('reaps a claim-pending job left behind by a crash before spawn', () => {
+    const interrupted = { ...job('queued'), launchState: 'claim-pending' as const };
+    writeUpdateJob(root, interrupted);
+    const replacement = fakeDeps();
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      replacement.deps,
+    );
+
+    expect(result.status).toBe('started');
+    expect(replacement.spawn).toHaveBeenCalledTimes(1);
+    expect(loadUpdateJob(root, interrupted.id)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker did not claim ownership',
+      updatedAt: NOW.toISOString(),
+    });
+  });
+
   it('keeps an expired nonterminal job busy while its persisted worker pid is alive', () => {
     const active = { ...job('rebuilding'), pid: 98989 };
     writeUpdateJob(root, active);
@@ -569,7 +602,64 @@ describe('update-job durable contract', () => {
     ).toBe('started');
   });
 
-  it('keeps launch ownership nonterminal when spawn returns no pid and blocks later retry', () => {
+  it('persists an abnormal child exit as failed and permits retry', () => {
+    const first = fakeDeps(SECOND_JOB_ID, [NOW, LATER]);
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: true },
+        fromVersion: '0.3.2',
+      },
+      first.deps,
+    );
+    expect(started.status).toBe('started');
+
+    first.emitExit(2);
+
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker exited before completion',
+      updatedAt: LATER.toISOString(),
+    });
+    const retry = fakeDeps(THIRD_JOB_ID);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: true },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('started');
+  });
+
+  it('does not overwrite a terminal job when an abnormal child close arrives late', () => {
+    const first = fakeDeps(SECOND_JOB_ID, [NOW, LATER]);
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      first.deps,
+    );
+    if (started.status !== 'started') throw new Error('expected update launch');
+    writeUpdateJob(root, {
+      ...started.job,
+      phase: 'succeeded',
+      updatedAt: LATER.toISOString(),
+    });
+
+    first.emitClose(null, 'SIGTERM');
+
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toMatchObject({
+      phase: 'succeeded',
+      updatedAt: LATER.toISOString(),
+    });
+  });
+
+  it('reaps a worker that never claims a pid and permits retry after the claim lease', () => {
     const first = fakeDeps(SECOND_JOB_ID);
     const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((...args) => {
       const worker = first.spawn(...args);
@@ -587,7 +677,7 @@ describe('update-job durable contract', () => {
 
     expect(started).toMatchObject({
       status: 'started',
-      job: { phase: 'queued', launchState: 'ownership-unknown' },
+      job: { phase: 'queued', launchState: 'claim-pending' },
     });
     const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
     expect(
@@ -599,11 +689,11 @@ describe('update-job durable contract', () => {
         },
         retry.deps,
       ).status,
-    ).toBe('busy');
-    expect(retry.spawn).not.toHaveBeenCalled();
+    ).toBe('started');
+    expect(retry.spawn).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps launch ownership nonterminal when spawn returns an invalid pid', () => {
+  it('ignores an invalid parent-observed pid and recovers through the claim lease', () => {
     const first = fakeDeps(SECOND_JOB_ID);
     const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((...args) => ({
       ...first.spawn(...args),
@@ -621,7 +711,7 @@ describe('update-job durable contract', () => {
 
     expect(started).toMatchObject({
       status: 'started',
-      job: { phase: 'queued', launchState: 'ownership-unknown' },
+      job: { phase: 'queued', launchState: 'claim-pending' },
     });
     const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
     expect(
@@ -633,15 +723,12 @@ describe('update-job durable contract', () => {
         },
         retry.deps,
       ).status,
-    ).toBe('busy');
-    expect(retry.spawn).not.toHaveBeenCalled();
+    ).toBe('started');
+    expect(retry.spawn).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps launch ownership nonterminal when pid persistence fails', () => {
+  it('leaves pid claiming to the worker instead of persisting the parent-observed pid', () => {
     const first = fakeDeps(SECOND_JOB_ID);
-    const persistPid = vi.fn(() => {
-      throw new Error('pid storage unavailable');
-    });
 
     const started = startUpdateJob(
       root,
@@ -649,26 +736,15 @@ describe('update-job durable contract', () => {
         mode: { prod: true, tailscale: false },
         fromVersion: '0.3.2',
       },
-      { ...first.deps, persistPid },
+      first.deps,
     );
 
-    expect(persistPid).toHaveBeenCalledTimes(1);
     expect(started).toMatchObject({
       status: 'started',
-      job: { phase: 'queued', launchState: 'ownership-unknown' },
+      job: { phase: 'queued', launchState: 'claim-pending' },
     });
-    const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
-    expect(
-      startUpdateJob(
-        root,
-        {
-          mode: { prod: true, tailscale: false },
-          fromVersion: '0.3.2',
-        },
-        retry.deps,
-      ).status,
-    ).toBe('busy');
-    expect(retry.spawn).not.toHaveBeenCalled();
+    expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.pid`))).toBe(false);
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).not.toHaveProperty('pid');
   });
 
   it('keeps launch ownership nonterminal when the post-spawn reload fails', () => {
@@ -689,7 +765,7 @@ describe('update-job durable contract', () => {
     expect(reloadJob).toHaveBeenCalledTimes(1);
     expect(started).toMatchObject({
       status: 'started',
-      job: { phase: 'queued', launchState: 'owned', pid: 4242 },
+      job: { phase: 'queued', launchState: 'claim-pending' },
     });
     const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
     const retryResult = startUpdateJob(
@@ -698,9 +774,9 @@ describe('update-job durable contract', () => {
         mode: { prod: true, tailscale: false },
         fromVersion: '0.3.2',
       },
-      { ...retry.deps, pidAlive: () => true },
+      retry.deps,
     );
-    expect(retryResult.status).toBe('busy');
-    expect(retry.spawn).not.toHaveBeenCalled();
+    expect(retryResult.status).toBe('started');
+    expect(retry.spawn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -293,6 +293,27 @@ describe('update-job durable contract', () => {
     });
   });
 
+  it('keeps an expired nonterminal job busy while its persisted worker pid is alive', () => {
+    const active = { ...job('rebuilding'), pid: 98989 };
+    writeUpdateJob(root, active);
+    const replacement = fakeDeps();
+    const pidAlive = vi.fn(() => true);
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...replacement.deps, pidAlive },
+    );
+
+    expect(result).toEqual({ status: 'busy', job: active });
+    expect(pidAlive).toHaveBeenCalledWith(98989);
+    expect(replacement.spawn).not.toHaveBeenCalled();
+    expect(loadUpdateJob(root, active.id)).toEqual(active);
+  });
+
   it('reaps a fresh nonterminal job whose persisted worker pid is no longer alive', () => {
     const interrupted = {
       ...job('applying'),

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateJob, UpdateJobPhase } from '../../schemas/update-job';
 import {
   loadUpdateJob,
+  reconcileUpdateJob,
   startUpdateJob,
   type UpdateOrchestratorDeps,
   writeUpdateJob,
@@ -35,6 +36,7 @@ const ALL_PHASES = [
   'restarting',
   'verifying',
   'recovering',
+  'recovery-queued',
   'succeeded',
   'rolled-back',
   'failed',
@@ -128,6 +130,10 @@ describe('update-job durable contract', () => {
     {
       label: 'queued after claim',
       candidate: { ...job('queued'), launchState: 'owned', pid: 4242 },
+    },
+    {
+      label: 'recovery queued before claim',
+      candidate: { ...job('recovery-queued'), launchState: 'claim-pending' },
     },
     ...ACTIVE_WORKER_PHASES.map(phase => ({
       label: `${phase} after claim`,
@@ -400,12 +406,13 @@ describe('update-job durable contract', () => {
     'restarting',
     'verifying',
     'recovering',
+    'recovery-queued',
   ])('returns busy instead of spawning when a %s job exists', phase => {
     const active = {
       ...job(phase as (typeof ALL_PHASES)[number]),
       createdAt: NOW.toISOString(),
       updatedAt: NOW.toISOString(),
-      ...(phase === 'queued'
+      ...(phase === 'queued' || phase === 'recovery-queued'
         ? { launchState: 'claim-pending' as const }
         : { launchState: 'owned' as const, pid: 4242 }),
     };
@@ -493,7 +500,7 @@ describe('update-job durable contract', () => {
     expect(loadUpdateJob(root, active.id)).toEqual(active);
   });
 
-  it('reaps a fresh nonterminal job whose persisted worker pid is no longer alive', () => {
+  it('queues recovery instead of replacing a job whose worker died after mutation began', () => {
     const interrupted = {
       ...job('applying'),
       createdAt: NOW.toISOString(),
@@ -514,13 +521,45 @@ describe('update-job durable contract', () => {
       { ...replacement.deps, pidAlive },
     );
 
-    expect(result.status).toBe('started');
+    expect(result.status).toBe('busy');
     expect(pidAlive).toHaveBeenCalledWith(98989);
     expect(loadUpdateJob(root, interrupted.id)).toMatchObject({
-      phase: 'failed',
+      phase: 'recovery-queued',
+      launchState: 'claim-pending',
       error: 'Update worker stopped before completion',
       updatedAt: NOW.toISOString(),
     });
+    expect(replacement.spawn).toHaveBeenCalledWith(
+      process.execPath,
+      [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', JOB_ID, '--recover'],
+      expect.objectContaining({ cwd: root, detached: true }),
+    );
+    expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`))).toBe(false);
+  });
+
+  it('does not steal a recovery sidecar from another live worker', () => {
+    const interrupted = {
+      ...job('stopping'),
+      launchState: 'owned' as const,
+      pid: 98989,
+      checkpoint: 'applied' as const,
+    };
+    writeUpdateJob(root, interrupted);
+    writeFileSync(join(root, 'data/update/jobs', `${JOB_ID}.pid`), '77777\n');
+    const replacement = fakeDeps();
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...replacement.deps, pidAlive: pid => pid === 77777 },
+    );
+
+    expect(result).toEqual({ status: 'busy', job: interrupted });
+    expect(replacement.spawn).not.toHaveBeenCalled();
+    expect(readFileSync(join(root, 'data/update/jobs', `${JOB_ID}.pid`), 'utf-8')).toBe('77777\n');
   });
 
   it('persists a safe failure when the job log cannot be opened, then permits retry', () => {

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -40,6 +40,15 @@ const ALL_PHASES = [
   'failed',
 ] as const;
 
+const ACTIVE_WORKER_PHASES = [
+  'applying',
+  'stopping',
+  'rebuilding',
+  'restarting',
+  'verifying',
+  'recovering',
+] as const;
+
 function job(phase: (typeof ALL_PHASES)[number] = 'queued', id = JOB_ID) {
   return {
     id,
@@ -107,41 +116,60 @@ describe('update-job durable contract', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('accepts every supported phase and parses the complete job shape', () => {
+  it('exposes every supported phase', () => {
     expect(UpdateJobPhase.options).toEqual(ALL_PHASES);
-
-    for (const phase of ALL_PHASES) {
-      expect(
-        UpdateJob.parse({ ...job(phase), error: phase === 'failed' ? 'build failed' : undefined }),
-      ).toMatchObject({
-        id: JOB_ID,
-        phase,
-        mode: { prod: true, tailscale: false },
-        fromVersion: '0.3.2',
-        toVersion: '0.4.0',
-        createdAt: EARLIER,
-        updatedAt: EARLIER,
-      });
-    }
   });
 
-  it('parses an optional persisted worker pid', () => {
-    expect(UpdateJob.parse({ ...job('applying'), pid: 4242 })).toMatchObject({
-      id: JOB_ID,
-      phase: 'applying',
-      pid: 4242,
-    });
+  it.each([
+    {
+      label: 'queued before claim',
+      candidate: { ...job('queued'), launchState: 'claim-pending' },
+    },
+    {
+      label: 'queued after claim',
+      candidate: { ...job('queued'), launchState: 'owned', pid: 4242 },
+    },
+    ...ACTIVE_WORKER_PHASES.map(phase => ({
+      label: `${phase} after claim`,
+      candidate: { ...job(phase), launchState: 'owned', pid: 4242 },
+    })),
+    { label: 'failed before spawn', candidate: { ...job('failed'), error: 'spawn failed' } },
+    {
+      label: 'failed before claim',
+      candidate: { ...job('failed'), launchState: 'claim-pending', error: 'claim expired' },
+    },
+    {
+      label: 'succeeded after claim',
+      candidate: { ...job('succeeded'), launchState: 'owned', pid: 4242 },
+    },
+    { label: 'rolled back without ownership metadata', candidate: job('rolled-back') },
+  ])('accepts valid ownership state: $label', ({ candidate }) => {
+    expect(UpdateJob.parse(candidate)).toMatchObject(candidate);
   });
 
-  it('parses durable launch ownership state', () => {
-    expect(UpdateJob.parse({ ...job('queued'), launchState: 'claim-pending' })).toMatchObject({
-      launchState: 'claim-pending',
-    });
-    expect(UpdateJob.parse({ ...job('applying'), launchState: 'owned', pid: 4242 })).toMatchObject({
-      launchState: 'owned',
-      pid: 4242,
-    });
-    expect(() => UpdateJob.parse({ ...job('applying'), launchState: 'owned' })).toThrow();
+  it.each([
+    ...ACTIVE_WORKER_PHASES.flatMap(phase => [
+      { label: `${phase} without ownership`, candidate: job(phase) },
+      {
+        label: `${phase} before claim`,
+        candidate: { ...job(phase), launchState: 'claim-pending', pid: 4242 },
+      },
+      { label: `${phase} without pid`, candidate: { ...job(phase), launchState: 'owned' } },
+      {
+        label: `${phase} with invalid pid`,
+        candidate: { ...job(phase), launchState: 'owned', pid: 0 },
+      },
+    ]),
+    {
+      label: 'queued ownership without pid',
+      candidate: { ...job('queued'), launchState: 'owned' },
+    },
+    {
+      label: 'terminal ownership without pid',
+      candidate: { ...job('failed'), launchState: 'owned' },
+    },
+  ])('rejects invalid ownership state: $label', ({ candidate }) => {
+    expect(() => UpdateJob.parse(candidate)).toThrow();
   });
 
   it('rejects invalid JSON when loading a persisted job', () => {
@@ -156,6 +184,8 @@ describe('update-job durable contract', () => {
     writeUpdateJob(root, job('queued'));
     writeUpdateJob(root, {
       ...job('applying'),
+      launchState: 'owned',
+      pid: 4242,
       updatedAt: '2026-07-31T12:01:00.000Z',
     });
 
@@ -375,6 +405,9 @@ describe('update-job durable contract', () => {
       ...job(phase as (typeof ALL_PHASES)[number]),
       createdAt: NOW.toISOString(),
       updatedAt: NOW.toISOString(),
+      ...(phase === 'queued'
+        ? { launchState: 'claim-pending' as const }
+        : { launchState: 'owned' as const, pid: 4242 }),
     };
     writeUpdateJob(root, active);
     const { deps, spawn } = fakeDeps();
@@ -385,7 +418,7 @@ describe('update-job durable contract', () => {
         mode: { prod: false, tailscale: false },
         fromVersion: '0.3.2',
       },
-      deps,
+      { ...deps, pidAlive: () => true },
     );
 
     expect(result).toEqual({ status: 'busy', job: active });
@@ -393,8 +426,8 @@ describe('update-job durable contract', () => {
     expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`))).toBe(false);
   });
 
-  it('reaps an expired nonterminal lease before starting a replacement job', () => {
-    const interrupted = job('rebuilding');
+  it('reaps an expired legacy queued lease before starting a replacement job', () => {
+    const interrupted = job('queued');
     writeUpdateJob(root, interrupted);
     const { deps, spawn } = fakeDeps();
 
@@ -440,7 +473,7 @@ describe('update-job durable contract', () => {
   });
 
   it('keeps an expired nonterminal job busy while its persisted worker pid is alive', () => {
-    const active = { ...job('rebuilding'), pid: 98989 };
+    const active = { ...job('rebuilding'), launchState: 'owned' as const, pid: 98989 };
     writeUpdateJob(root, active);
     const replacement = fakeDeps();
     const pidAlive = vi.fn(() => true);
@@ -465,6 +498,7 @@ describe('update-job durable contract', () => {
       ...job('applying'),
       createdAt: NOW.toISOString(),
       updatedAt: NOW.toISOString(),
+      launchState: 'owned' as const,
       pid: 98989,
     };
     writeUpdateJob(root, interrupted);

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -24,6 +24,7 @@ const SECOND_JOB_ID = '22222222-2222-4222-8222-222222222222';
 const THIRD_JOB_ID = '33333333-3333-4333-8333-333333333333';
 const NOW = new Date('2026-07-31T12:00:00.000Z');
 const LATER = new Date('2026-07-31T12:01:00.000Z');
+const FUTURE = new Date('2026-08-01T12:00:00.000Z');
 const EARLIER = '2026-07-30T12:00:00.000Z';
 
 const ALL_PHASES = [
@@ -121,6 +122,16 @@ describe('update-job durable contract', () => {
     });
   });
 
+  it('parses durable launch ownership state', () => {
+    expect(UpdateJob.parse({ ...job('queued'), launchState: 'ownership-unknown' })).toMatchObject({
+      launchState: 'ownership-unknown',
+    });
+    expect(UpdateJob.parse({ ...job('applying'), launchState: 'owned', pid: 4242 })).toMatchObject({
+      launchState: 'owned',
+      pid: 4242,
+    });
+  });
+
   it('rejects invalid JSON when loading a persisted job', () => {
     const path = join(root, 'data/update/jobs', `${JOB_ID}.json`);
     mkdirSync(join(root, 'data/update/jobs'), { recursive: true });
@@ -176,6 +187,7 @@ describe('update-job durable contract', () => {
         createdAt: NOW.toISOString(),
         updatedAt: NOW.toISOString(),
         pid: 4242,
+        launchState: 'owned',
       },
     });
     expect(loadUpdateJob(root, SECOND_JOB_ID)).toEqual(result.job);
@@ -224,12 +236,14 @@ describe('update-job durable contract', () => {
         phase: 'applying',
         updatedAt: LATER.toISOString(),
         pid: 4242,
+        launchState: 'owned',
       },
     });
     expect(loadUpdateJob(root, SECOND_JOB_ID)).toMatchObject({
       phase: 'applying',
       updatedAt: LATER.toISOString(),
       pid: 4242,
+      launchState: 'owned',
     });
     expect(
       JSON.parse(readFileSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`), 'utf-8')),
@@ -237,6 +251,105 @@ describe('update-job durable contract', () => {
       phase: 'applying',
       updatedAt: LATER.toISOString(),
     });
+  });
+
+  it('allows only one spawn when another process interleaves before the first scan', () => {
+    const first = fakeDeps(SECOND_JOB_ID);
+    const contender = fakeDeps(THIRD_JOB_ID);
+    let contenderResult: ReturnType<typeof startUpdateJob> | undefined;
+    const mkdirLock = vi.fn((path: string) => {
+      mkdirSync(path);
+      contenderResult = startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        contender.deps,
+      );
+    });
+
+    const firstResult = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, mkdirLock },
+    );
+
+    expect(firstResult.status).toBe('started');
+    expect(contenderResult).toEqual({ status: 'busy', job: null });
+    expect(first.spawn).toHaveBeenCalledTimes(1);
+    expect(contender.spawn).not.toHaveBeenCalled();
+  });
+
+  it('recovers a start lock whose owner pid is dead', () => {
+    const lockDirectory = join(root, 'data/update/start.lock');
+    mkdirSync(lockDirectory, { recursive: true });
+    writeFileSync(
+      join(lockDirectory, 'owner.json'),
+      JSON.stringify({ token: JOB_ID, pid: 98989, acquiredAt: NOW.toISOString() }),
+      'utf-8',
+    );
+    const replacement = fakeDeps(SECOND_JOB_ID);
+    const pidAlive = vi.fn(() => false);
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: false, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...replacement.deps, pidAlive },
+    );
+
+    expect(result.status).toBe('started');
+    expect(replacement.spawn).toHaveBeenCalledTimes(1);
+    expect(existsSync(lockDirectory)).toBe(false);
+  });
+
+  it('permits only one spawn when another process recovers the stale lock first', () => {
+    const lockDirectory = join(root, 'data/update/start.lock');
+    mkdirSync(lockDirectory, { recursive: true });
+    writeFileSync(
+      join(lockDirectory, 'owner.json'),
+      JSON.stringify({ token: JOB_ID, pid: 98989, acquiredAt: NOW.toISOString() }),
+      'utf-8',
+    );
+    const first = fakeDeps(SECOND_JOB_ID);
+    const contender = fakeDeps(THIRD_JOB_ID);
+    const pidAlive = vi.fn((pid: number) => pid === 4242);
+    let contenderResult: ReturnType<typeof startUpdateJob> | undefined;
+    const mkdirLock = vi.fn((path: string) => {
+      try {
+        mkdirSync(path);
+      } catch (error) {
+        contenderResult = startUpdateJob(
+          root,
+          {
+            mode: { prod: true, tailscale: false },
+            fromVersion: '0.3.2',
+          },
+          { ...contender.deps, pidAlive },
+        );
+        throw error;
+      }
+    });
+
+    const firstResult = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, mkdirLock, pidAlive },
+    );
+
+    expect(contenderResult?.status).toBe('started');
+    expect(firstResult.status).toBe('busy');
+    expect(contender.spawn).toHaveBeenCalledTimes(1);
+    expect(first.spawn).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -407,6 +520,7 @@ describe('update-job durable contract', () => {
         updatedAt: LATER.toISOString(),
       },
     });
+    if (failed.status !== 'failed') throw new Error('expected failed update launch');
     expect(failed.job.error).not.toContain('secret');
     expect(() => fstatSync(logFileDescriptor as number)).toThrow();
 
@@ -453,5 +567,140 @@ describe('update-job durable contract', () => {
         retry.deps,
       ).status,
     ).toBe('started');
+  });
+
+  it('keeps launch ownership nonterminal when spawn returns no pid and blocks later retry', () => {
+    const first = fakeDeps(SECOND_JOB_ID);
+    const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((...args) => {
+      const worker = first.spawn(...args);
+      return { once: worker.once.bind(worker), unref: worker.unref.bind(worker) };
+    });
+
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, spawn },
+    );
+
+    expect(started).toMatchObject({
+      status: 'started',
+      job: { phase: 'queued', launchState: 'ownership-unknown' },
+    });
+    const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('busy');
+    expect(retry.spawn).not.toHaveBeenCalled();
+  });
+
+  it('keeps launch ownership nonterminal when spawn returns an invalid pid', () => {
+    const first = fakeDeps(SECOND_JOB_ID);
+    const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((...args) => ({
+      ...first.spawn(...args),
+      pid: 0,
+    }));
+
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, spawn },
+    );
+
+    expect(started).toMatchObject({
+      status: 'started',
+      job: { phase: 'queued', launchState: 'ownership-unknown' },
+    });
+    const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('busy');
+    expect(retry.spawn).not.toHaveBeenCalled();
+  });
+
+  it('keeps launch ownership nonterminal when pid persistence fails', () => {
+    const first = fakeDeps(SECOND_JOB_ID);
+    const persistPid = vi.fn(() => {
+      throw new Error('pid storage unavailable');
+    });
+
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, persistPid },
+    );
+
+    expect(persistPid).toHaveBeenCalledTimes(1);
+    expect(started).toMatchObject({
+      status: 'started',
+      job: { phase: 'queued', launchState: 'ownership-unknown' },
+    });
+    const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('busy');
+    expect(retry.spawn).not.toHaveBeenCalled();
+  });
+
+  it('keeps launch ownership nonterminal when the post-spawn reload fails', () => {
+    const first = fakeDeps(SECOND_JOB_ID);
+    const reloadJob = vi.fn(() => {
+      throw new Error('reload unavailable');
+    });
+
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...first.deps, reloadJob },
+    );
+
+    expect(reloadJob).toHaveBeenCalledTimes(1);
+    expect(started).toMatchObject({
+      status: 'started',
+      job: { phase: 'queued', launchState: 'owned', pid: 4242 },
+    });
+    const retry = fakeDeps(THIRD_JOB_ID, [FUTURE]);
+    const retryResult = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...retry.deps, pidAlive: () => true },
+    );
+    expect(retryResult.status).toBe('busy');
+    expect(retry.spawn).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  fstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -20,7 +21,9 @@ import {
 
 const JOB_ID = '11111111-1111-4111-8111-111111111111';
 const SECOND_JOB_ID = '22222222-2222-4222-8222-222222222222';
+const THIRD_JOB_ID = '33333333-3333-4333-8333-333333333333';
 const NOW = new Date('2026-07-31T12:00:00.000Z');
+const LATER = new Date('2026-07-31T12:01:00.000Z');
 const EARLIER = '2026-07-30T12:00:00.000Z';
 
 const ALL_PHASES = [
@@ -48,14 +51,33 @@ function job(phase: (typeof ALL_PHASES)[number] = 'queued', id = JOB_ID) {
   };
 }
 
-function fakeDeps(id = SECOND_JOB_ID) {
+function fakeDeps(id = SECOND_JOB_ID, clockValues: Date[] = [NOW]) {
   const unref = vi.fn();
-  const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>(() => ({ unref }));
+  let errorListener: ((error: Error) => void) | undefined;
+  let worker: {
+    pid: number;
+    once: (event: 'error', listener: (error: Error) => void) => typeof worker;
+    unref: typeof unref;
+  };
+  worker = {
+    pid: 4242,
+    once: vi.fn((event: 'error', listener: (error: Error) => void) => {
+      if (event === 'error') errorListener = listener;
+      return worker;
+    }),
+    unref,
+  };
+  const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>(() => worker);
+  let clockIndex = 0;
   return {
     deps: {
-      clock: () => NOW,
+      clock: () => clockValues[Math.min(clockIndex++, clockValues.length - 1)] ?? NOW,
       uuid: () => id,
       spawn,
+    },
+    emitError(error: Error) {
+      if (!errorListener) throw new Error('worker error listener was not registered');
+      errorListener(error);
     },
     spawn,
     unref,
@@ -89,6 +111,14 @@ describe('update-job durable contract', () => {
         updatedAt: EARLIER,
       });
     }
+  });
+
+  it('parses an optional persisted worker pid', () => {
+    expect(UpdateJob.parse({ ...job('applying'), pid: 4242 })).toMatchObject({
+      id: JOB_ID,
+      phase: 'applying',
+      pid: 4242,
+    });
   });
 
   it('rejects invalid JSON when loading a persisted job', () => {
@@ -145,6 +175,7 @@ describe('update-job durable contract', () => {
         toVersion: '0.4.0',
         createdAt: NOW.toISOString(),
         updatedAt: NOW.toISOString(),
+        pid: 4242,
       },
     });
     expect(loadUpdateJob(root, SECOND_JOB_ID)).toEqual(result.job);
@@ -173,7 +204,11 @@ describe('update-job durable contract', () => {
     'verifying',
     'recovering',
   ])('returns busy instead of spawning when a %s job exists', phase => {
-    const active = job(phase as (typeof ALL_PHASES)[number]);
+    const active = {
+      ...job(phase as (typeof ALL_PHASES)[number]),
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+    };
     writeUpdateJob(root, active);
     const { deps, spawn } = fakeDeps();
 
@@ -189,5 +224,169 @@ describe('update-job durable contract', () => {
     expect(result).toEqual({ status: 'busy', job: active });
     expect(spawn).not.toHaveBeenCalled();
     expect(existsSync(join(root, 'data/update/jobs', `${SECOND_JOB_ID}.json`))).toBe(false);
+  });
+
+  it('reaps an expired nonterminal lease before starting a replacement job', () => {
+    const interrupted = job('rebuilding');
+    writeUpdateJob(root, interrupted);
+    const { deps, spawn } = fakeDeps();
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      deps,
+    );
+
+    expect(result.status).toBe('started');
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(loadUpdateJob(root, interrupted.id)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker lease expired',
+      updatedAt: NOW.toISOString(),
+    });
+  });
+
+  it('reaps a fresh nonterminal job whose persisted worker pid is no longer alive', () => {
+    const interrupted = {
+      ...job('applying'),
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      pid: 98989,
+    };
+    writeUpdateJob(root, interrupted);
+    const replacement = fakeDeps();
+    const pidAlive = vi.fn(() => false);
+
+    const result = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { ...replacement.deps, pidAlive },
+    );
+
+    expect(result.status).toBe('started');
+    expect(pidAlive).toHaveBeenCalledWith(98989);
+    expect(loadUpdateJob(root, interrupted.id)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker stopped before completion',
+      updatedAt: NOW.toISOString(),
+    });
+  });
+
+  it('persists a safe failure when the job log cannot be opened, then permits retry', () => {
+    const logPath = join(root, 'data/update/jobs', `${SECOND_JOB_ID}.log`);
+    mkdirSync(logPath, { recursive: true });
+    const first = fakeDeps(SECOND_JOB_ID, [NOW, LATER]);
+
+    const failed = startUpdateJob(
+      root,
+      {
+        mode: { prod: false, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      first.deps,
+    );
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      job: {
+        id: SECOND_JOB_ID,
+        phase: 'failed',
+        error: 'Update worker failed to start',
+        updatedAt: LATER.toISOString(),
+      },
+    });
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toEqual(failed.job);
+
+    rmSync(logPath, { recursive: true });
+    const retry = fakeDeps(THIRD_JOB_ID);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: false, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('started');
+  });
+
+  it('closes the log and persists a safe failure when spawn throws, then permits retry', () => {
+    let logFileDescriptor: number | undefined;
+    const spawn = vi.fn<UpdateOrchestratorDeps['spawn']>((_command, _args, options) => {
+      logFileDescriptor = options.stdio[1];
+      throw new Error('secret operating-system detail');
+    });
+    const clock = vi.fn().mockReturnValueOnce(NOW).mockReturnValue(LATER);
+
+    const failed = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: false },
+        fromVersion: '0.3.2',
+      },
+      { clock, uuid: () => SECOND_JOB_ID, spawn },
+    );
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      job: {
+        phase: 'failed',
+        error: 'Update worker failed to start',
+        updatedAt: LATER.toISOString(),
+      },
+    });
+    expect(failed.job.error).not.toContain('secret');
+    expect(() => fstatSync(logFileDescriptor as number)).toThrow();
+
+    const retry = fakeDeps(THIRD_JOB_ID);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: false },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('started');
+  });
+
+  it('persists an asynchronous child error as failed and permits retry', () => {
+    const first = fakeDeps(SECOND_JOB_ID, [NOW, LATER]);
+    const started = startUpdateJob(
+      root,
+      {
+        mode: { prod: true, tailscale: true },
+        fromVersion: '0.3.2',
+      },
+      first.deps,
+    );
+    expect(started.status).toBe('started');
+
+    first.emitError(new Error('secret child-process detail'));
+
+    expect(loadUpdateJob(root, SECOND_JOB_ID)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker failed to start',
+      updatedAt: LATER.toISOString(),
+    });
+    const retry = fakeDeps(THIRD_JOB_ID);
+    expect(
+      startUpdateJob(
+        root,
+        {
+          mode: { prod: true, tailscale: true },
+          fromVersion: '0.3.2',
+        },
+        retry.deps,
+      ).status,
+    ).toBe('started');
   });
 });

--- a/src/lib/server/__tests__/update-orchestrator.test.ts
+++ b/src/lib/server/__tests__/update-orchestrator.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateJob, UpdateJobPhase } from '../../schemas/update-job';
 import {
+  loadLatestActiveUpdateJob,
   loadUpdateJob,
   reconcileUpdateJob,
   startUpdateJob,
@@ -184,6 +185,36 @@ describe('update-job durable contract', () => {
     writeFileSync(path, '{not-json', { encoding: 'utf-8', flag: 'w' });
 
     expect(() => loadUpdateJob(root, JOB_ID)).toThrow();
+  });
+
+  it('skips damaged records while discovering the latest active job', () => {
+    const directory = join(root, 'data/update/jobs');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, `${JOB_ID}.json`), '{not-json', 'utf-8');
+    const active = {
+      ...job('queued', SECOND_JOB_ID),
+      launchState: 'claim-pending' as const,
+      updatedAt: NOW.toISOString(),
+    };
+    writeUpdateJob(root, active);
+
+    expect(loadLatestActiveUpdateJob(root)).toEqual(active);
+  });
+
+  it('skips damaged records when starting a new update', () => {
+    const directory = join(root, 'data/update/jobs');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(join(directory, `${JOB_ID}.json`), '{not-json', 'utf-8');
+    const worker = fakeDeps(SECOND_JOB_ID);
+
+    expect(
+      startUpdateJob(
+        root,
+        { mode: { prod: false, tailscale: false }, fromVersion: '0.3.2' },
+        worker.deps,
+      ).status,
+    ).toBe('started');
+    expect(worker.spawn).toHaveBeenCalledTimes(1);
   });
 
   it('atomically persists jobs under data/update/jobs', () => {
@@ -517,6 +548,26 @@ describe('update-job durable contract', () => {
       [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', JOB_ID, '--recover'],
       expect.objectContaining({ cwd: root, detached: true }),
     );
+  });
+
+  it('fails an unclaimed recovery worker that exits abnormally', () => {
+    const interrupted = {
+      ...job('recovery-queued'),
+      launchState: 'claim-pending' as const,
+      checkpoint: 'applied' as const,
+      error: 'Update worker stopped before completion',
+    };
+    writeUpdateJob(root, interrupted);
+    const worker = fakeDeps(SECOND_JOB_ID, [NOW, LATER]);
+
+    reconcileUpdateJob(root, JOB_ID, worker.deps);
+    worker.emitExit(2);
+
+    expect(loadUpdateJob(root, JOB_ID)).toMatchObject({
+      phase: 'failed',
+      error: 'Update worker exited before completion',
+      updatedAt: LATER.toISOString(),
+    });
   });
 
   it('does not steal a fresh claim-pending job during status polling', () => {

--- a/src/lib/server/update-api.ts
+++ b/src/lib/server/update-api.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+import { z } from 'zod';
+import { getWebLaunchMode } from '../../../scripts/web.mjs';
+
+const UpdateApplyBody = z
+  .object({
+    toVersion: z.string().trim().min(1).max(100).optional(),
+  })
+  .strict();
+
+export type UpdateApplyBody = z.infer<typeof UpdateApplyBody>;
+
+export async function parseUpdateApplyBody(request: Request): Promise<UpdateApplyBody | null> {
+  const text = await request.text();
+  if (text.trim() === '') return {};
+  try {
+    const parsed = UpdateApplyBody.safeParse(JSON.parse(text));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+interface UpdateLaunchMode {
+  prod: boolean;
+  tailscale: boolean;
+}
+
+const UpdateLaunchMode = z.object({ prod: z.boolean(), tailscale: z.boolean() }).strict();
+
+function fallbackLaunchMode(request: Request): UpdateLaunchMode {
+  let origin: URL;
+  try {
+    origin = new URL(request.headers.get('origin') ?? request.url);
+  } catch {
+    origin = new URL(request.url);
+  }
+  const hostname = origin.hostname.toLowerCase();
+  const localhost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+  return {
+    prod: process.env.NODE_ENV === 'production',
+    tailscale: !localhost && origin.protocol === 'https:' && hostname.endsWith('.ts.net'),
+  };
+}
+
+/** Prefer the managed launcher's persisted mode; use only conservative request
+ * and runtime signals if that metadata cannot be read or validated. */
+export function resolveUpdateLaunchMode(request: Request): UpdateLaunchMode {
+  const fallback = fallbackLaunchMode(request);
+  try {
+    const persisted = UpdateLaunchMode.safeParse(getWebLaunchMode());
+    if (persisted.success) {
+      // getWebLaunchMode deliberately represents absent/stale metadata as the
+      // safest local-dev mode. Strong runtime/request evidence may only turn
+      // those false flags on; it can never erase a persisted true flag.
+      return {
+        prod: persisted.data.prod || fallback.prod,
+        tailscale: persisted.data.tailscale || fallback.tailscale,
+      };
+    }
+  } catch {
+    // A missing/stale launcher record must not prevent a safe restart attempt.
+  }
+  return fallback;
+}

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -5,8 +5,13 @@ import { closeSync, existsSync, openSync, readdirSync, readFileSync } from 'node
 import { join } from 'node:path';
 import { type UpdateJob, UpdateJob as UpdateJobSchema } from '../schemas/update-job';
 import { atomicWrite } from './atomic-write';
+import { isPidAlive } from './jobs/stale';
 
 const TERMINAL_PHASES = new Set<UpdateJob['phase']>(['succeeded', 'rolled-back', 'failed']);
+const UPDATE_JOB_LEASE_MS = 15 * 60 * 1000;
+const LEASE_EXPIRED_ERROR = 'Update worker lease expired';
+const WORKER_STOPPED_ERROR = 'Update worker stopped before completion';
+const START_FAILED_ERROR = 'Update worker failed to start';
 
 export interface UpdateRequestContext {
   mode: UpdateJob['mode'];
@@ -15,6 +20,8 @@ export interface UpdateRequestContext {
 }
 
 interface SpawnedUpdateWorker {
+  pid?: number;
+  once(event: 'error', listener: (error: Error) => void): SpawnedUpdateWorker;
   unref(): void;
 }
 
@@ -27,6 +34,7 @@ interface UpdateWorkerSpawnOptions {
 export interface UpdateOrchestratorDeps {
   clock: () => Date;
   uuid: () => string;
+  pidAlive?: (pid: number) => boolean;
   spawn: (
     command: string,
     args: string[],
@@ -36,11 +44,13 @@ export interface UpdateOrchestratorDeps {
 
 export type StartUpdateJobResult =
   | { status: 'started'; job: UpdateJob }
-  | { status: 'busy'; job: UpdateJob };
+  | { status: 'busy'; job: UpdateJob }
+  | { status: 'failed'; job: UpdateJob };
 
 const defaultDeps: UpdateOrchestratorDeps = {
   clock: () => new Date(),
   uuid: randomUUID,
+  pidAlive: isPidAlive,
   spawn: (command, args, options) => nodeSpawn(command, args, options),
 };
 
@@ -63,14 +73,49 @@ export function writeUpdateJob(root: string, job: UpdateJob): void {
   atomicWrite(updateJobPath(root, parsed.id), `${JSON.stringify(parsed, null, 2)}\n`);
 }
 
-function findActiveUpdateJob(root: string): UpdateJob | null {
+function failUpdateJob(root: string, job: UpdateJob, updatedAt: Date, error: string): UpdateJob {
+  const failed = UpdateJobSchema.parse({
+    ...job,
+    phase: 'failed',
+    error,
+    updatedAt: updatedAt.toISOString(),
+  });
+  writeUpdateJob(root, failed);
+  return failed;
+}
+
+function failPersistedUpdateJob(
+  root: string,
+  id: string,
+  deps: UpdateOrchestratorDeps,
+  error: string,
+): UpdateJob | null {
+  const current = loadUpdateJob(root, id);
+  if (!current || TERMINAL_PHASES.has(current.phase)) return current;
+  return failUpdateJob(root, current, deps.clock(), error);
+}
+
+function findActiveUpdateJob(
+  root: string,
+  now: Date,
+  pidAlive: (pid: number) => boolean,
+): UpdateJob | null {
   const directory = updateJobsDir(root);
   if (!existsSync(directory)) return null;
 
   for (const file of readdirSync(directory)) {
     if (!file.endsWith('.json')) continue;
     const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
-    if (job && !TERMINAL_PHASES.has(job.phase)) return job;
+    if (!job || TERMINAL_PHASES.has(job.phase)) continue;
+    if (job.pid !== undefined && !pidAlive(job.pid)) {
+      failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
+      continue;
+    }
+    if (now.getTime() - Date.parse(job.updatedAt) >= UPDATE_JOB_LEASE_MS) {
+      failUpdateJob(root, job, now, LEASE_EXPIRED_ERROR);
+      continue;
+    }
+    return job;
   }
 
   return null;
@@ -81,10 +126,11 @@ export function startUpdateJob(
   requestContext: UpdateRequestContext,
   deps: UpdateOrchestratorDeps = defaultDeps,
 ): StartUpdateJobResult {
-  const activeJob = findActiveUpdateJob(root);
+  const now = deps.clock();
+  const activeJob = findActiveUpdateJob(root, now, deps.pidAlive ?? isPidAlive);
   if (activeJob) return { status: 'busy', job: activeJob };
 
-  const timestamp = deps.clock().toISOString();
+  const timestamp = now.toISOString();
   const job = UpdateJobSchema.parse({
     id: deps.uuid(),
     phase: 'queued',
@@ -96,8 +142,9 @@ export function startUpdateJob(
   });
   writeUpdateJob(root, job);
 
-  const logFileDescriptor = openSync(join(updateJobsDir(root), `${job.id}.log`), 'a');
+  let logFileDescriptor: number | undefined;
   try {
+    logFileDescriptor = openSync(join(updateJobsDir(root), `${job.id}.log`), 'a');
     const worker = deps.spawn(
       process.execPath,
       [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', job.id],
@@ -107,10 +154,26 @@ export function startUpdateJob(
         stdio: ['ignore', logFileDescriptor, logFileDescriptor],
       },
     );
+    worker.once('error', () => {
+      try {
+        failPersistedUpdateJob(root, job.id, deps, START_FAILED_ERROR);
+      } catch {
+        // Event handlers cannot return persistence failures to the caller.
+      }
+    });
     worker.unref();
+    const startedJob = UpdateJobSchema.parse({
+      ...job,
+      ...(worker.pid === undefined ? {} : { pid: worker.pid }),
+    });
+    writeUpdateJob(root, startedJob);
+    return { status: 'started', job: startedJob };
+  } catch {
+    return {
+      status: 'failed',
+      job: failUpdateJob(root, job, deps.clock(), START_FAILED_ERROR),
+    };
   } finally {
-    closeSync(logFileDescriptor);
+    if (logFileDescriptor !== undefined) closeSync(logFileDescriptor);
   }
-
-  return { status: 'started', job };
 }

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -117,9 +117,12 @@ function findActiveUpdateJob(
     if (!file.endsWith('.json')) continue;
     const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
     if (!job || TERMINAL_PHASES.has(job.phase)) continue;
-    if (job.pid !== undefined && !pidAlive(job.pid)) {
-      failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
-      continue;
+    if (job.pid !== undefined) {
+      if (!pidAlive(job.pid)) {
+        failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
+        continue;
+      }
+      return job;
     }
     if (now.getTime() - Date.parse(job.updatedAt) >= UPDATE_JOB_LEASE_MS) {
       failUpdateJob(root, job, now, LEASE_EXPIRED_ERROR);

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -1,7 +1,16 @@
 import 'server-only';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { closeSync, existsSync, openSync, readdirSync, readFileSync } from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { type UpdateJob, UpdateJob as UpdateJobSchema } from '../schemas/update-job';
 import { atomicWrite } from './atomic-write';
@@ -9,6 +18,7 @@ import { isPidAlive } from './jobs/stale';
 
 const TERMINAL_PHASES = new Set<UpdateJob['phase']>(['succeeded', 'rolled-back', 'failed']);
 const UPDATE_JOB_LEASE_MS = 15 * 60 * 1000;
+const START_LOCK_LEASE_MS = 60 * 1000;
 const LEASE_EXPIRED_ERROR = 'Update worker lease expired';
 const WORKER_STOPPED_ERROR = 'Update worker stopped before completion';
 const START_FAILED_ERROR = 'Update worker failed to start';
@@ -35,6 +45,9 @@ export interface UpdateOrchestratorDeps {
   clock: () => Date;
   uuid: () => string;
   pidAlive?: (pid: number) => boolean;
+  mkdirLock?: (path: string) => void;
+  persistPid?: (path: string, content: string) => void;
+  reloadJob?: (root: string, id: string) => UpdateJob | null;
   spawn: (
     command: string,
     args: string[],
@@ -44,7 +57,7 @@ export interface UpdateOrchestratorDeps {
 
 export type StartUpdateJobResult =
   | { status: 'started'; job: UpdateJob }
-  | { status: 'busy'; job: UpdateJob }
+  | { status: 'busy'; job: UpdateJob | null }
   | { status: 'failed'; job: UpdateJob };
 
 const defaultDeps: UpdateOrchestratorDeps = {
@@ -66,16 +79,131 @@ function updateJobPidPath(root: string, id: string): string {
   return join(updateJobsDir(root), `${id}.pid`);
 }
 
+function updateStartLockDir(root: string): string {
+  return join(root, 'data/update/start.lock');
+}
+
+interface StartLockOwner {
+  token: string;
+  pid: number;
+  acquiredAt: string;
+}
+
+function readStartLockOwner(root: string): StartLockOwner | null {
+  try {
+    const raw = JSON.parse(readFileSync(join(updateStartLockDir(root), 'owner.json'), 'utf-8'));
+    if (
+      typeof raw?.token !== 'string' ||
+      typeof raw?.pid !== 'number' ||
+      !Number.isInteger(raw.pid) ||
+      raw.pid <= 0 ||
+      typeof raw?.acquiredAt !== 'string' ||
+      Number.isNaN(Date.parse(raw.acquiredAt))
+    ) {
+      return null;
+    }
+    return raw as StartLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function acquireStartLock(
+  root: string,
+  token: string,
+  now: Date,
+  deps: UpdateOrchestratorDeps,
+): (() => void) | null {
+  const directory = updateStartLockDir(root);
+  const recoveryDirectory = `${directory}.recovery`;
+  const mkdirLock = deps.mkdirLock ?? (path => mkdirSync(path));
+  mkdirSync(join(root, 'data/update'), { recursive: true });
+
+  const tryCreateLock = (): boolean => {
+    try {
+      mkdirLock(directory);
+      return true;
+    } catch (error) {
+      if (isAlreadyExistsError(error)) return false;
+      throw error;
+    }
+  };
+
+  let recoveryHeld = false;
+  let lockCreated = tryCreateLock();
+  if (!lockCreated) {
+    try {
+      try {
+        mkdirSync(recoveryDirectory);
+        recoveryHeld = true;
+      } catch (error) {
+        if (!isAlreadyExistsError(error)) throw error;
+        const recoveryAge = now.getTime() - statSync(recoveryDirectory).mtimeMs;
+        if (recoveryAge < START_LOCK_LEASE_MS) return null;
+        rmSync(recoveryDirectory, { recursive: true, force: true });
+        try {
+          mkdirSync(recoveryDirectory);
+          recoveryHeld = true;
+        } catch (retryError) {
+          if (isAlreadyExistsError(retryError)) return null;
+          throw retryError;
+        }
+      }
+
+      if (existsSync(directory)) {
+        const owner = readStartLockOwner(root);
+        const pidAlive = deps.pidAlive ?? isPidAlive;
+        if (owner && pidAlive(owner.pid)) return null;
+        const lockTimestamp = owner ? Date.parse(owner.acquiredAt) : statSync(directory).mtimeMs;
+        if (!owner && now.getTime() - lockTimestamp < START_LOCK_LEASE_MS) return null;
+        rmSync(directory, { recursive: true, force: true });
+      }
+      lockCreated = tryCreateLock();
+      if (!lockCreated) return null;
+    } finally {
+      if (recoveryHeld) rmSync(recoveryDirectory, { recursive: true, force: true });
+    }
+  }
+
+  if (!lockCreated) return null;
+  try {
+    const owner: StartLockOwner = {
+      token,
+      pid: process.pid,
+      acquiredAt: now.toISOString(),
+    };
+    atomicWrite(join(directory, 'owner.json'), `${JSON.stringify(owner, null, 2)}\n`);
+  } catch (error) {
+    rmSync(directory, { recursive: true, force: true });
+    throw error;
+  }
+
+  return () => {
+    if (readStartLockOwner(root)?.token === token) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  };
+}
+
 export function loadUpdateJob(root: string, id: string): UpdateJob | null {
   const path = updateJobPath(root, id);
   if (!existsSync(path)) return null;
   const job = UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
   const pidPath = updateJobPidPath(root, id);
   if (!existsSync(pidPath)) return job;
-  return UpdateJobSchema.parse({
-    ...job,
-    pid: Number(readFileSync(pidPath, 'utf-8').trim()),
-  });
+  try {
+    return UpdateJobSchema.parse({
+      ...job,
+      pid: Number(readFileSync(pidPath, 'utf-8').trim()),
+      launchState: 'owned',
+    });
+  } catch {
+    return job;
+  }
 }
 
 export function writeUpdateJob(root: string, job: UpdateJob): void {
@@ -117,6 +245,8 @@ function findActiveUpdateJob(
     if (!file.endsWith('.json')) continue;
     const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
     if (!job || TERMINAL_PHASES.has(job.phase)) continue;
+    if (job.launchState === 'ownership-unknown') return job;
+    if (job.launchState === 'owned' && job.pid === undefined) return job;
     if (job.pid !== undefined) {
       if (!pidAlive(job.pid)) {
         failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
@@ -140,13 +270,32 @@ export function startUpdateJob(
   deps: UpdateOrchestratorDeps = defaultDeps,
 ): StartUpdateJobResult {
   const now = deps.clock();
+  const id = deps.uuid();
+  const releaseStartLock = acquireStartLock(root, id, now, deps);
+  if (!releaseStartLock) return { status: 'busy', job: null };
+
+  try {
+    return startUpdateJobUnderLock(root, requestContext, deps, now, id);
+  } finally {
+    releaseStartLock();
+  }
+}
+
+function startUpdateJobUnderLock(
+  root: string,
+  requestContext: UpdateRequestContext,
+  deps: UpdateOrchestratorDeps,
+  now: Date,
+  id: string,
+): StartUpdateJobResult {
   const activeJob = findActiveUpdateJob(root, now, deps.pidAlive ?? isPidAlive);
   if (activeJob) return { status: 'busy', job: activeJob };
 
   const timestamp = now.toISOString();
   const job = UpdateJobSchema.parse({
-    id: deps.uuid(),
+    id,
     phase: 'queued',
+    launchState: 'ownership-unknown',
     mode: requestContext.mode,
     fromVersion: requestContext.fromVersion,
     ...(requestContext.toVersion === undefined ? {} : { toVersion: requestContext.toVersion }),
@@ -156,6 +305,8 @@ export function startUpdateJob(
   writeUpdateJob(root, job);
 
   let logFileDescriptor: number | undefined;
+  let spawnSucceeded = false;
+  let launchedJob = job;
   try {
     logFileDescriptor = openSync(join(updateJobsDir(root), `${job.id}.log`), 'a');
     const worker = deps.spawn(
@@ -167,6 +318,7 @@ export function startUpdateJob(
         stdio: ['ignore', logFileDescriptor, logFileDescriptor],
       },
     );
+    spawnSucceeded = true;
     worker.once('error', () => {
       try {
         failPersistedUpdateJob(root, job.id, deps, START_FAILED_ERROR);
@@ -177,12 +329,15 @@ export function startUpdateJob(
     worker.unref();
     if (worker.pid !== undefined) {
       const pid = UpdateJobSchema.shape.pid.unwrap().parse(worker.pid);
-      atomicWrite(updateJobPidPath(root, job.id), `${pid}\n`);
+      const persistPid = deps.persistPid ?? atomicWrite;
+      persistPid(updateJobPidPath(root, job.id), `${pid}\n`);
+      launchedJob = UpdateJobSchema.parse({ ...job, pid, launchState: 'owned' });
     }
-    const startedJob = loadUpdateJob(root, job.id);
-    if (!startedJob) throw new Error('Update job disappeared during launch');
-    return { status: 'started', job: startedJob };
+    const reloadJob = deps.reloadJob ?? loadUpdateJob;
+    launchedJob = reloadJob(root, job.id) ?? launchedJob;
+    return { status: 'started', job: launchedJob };
   } catch {
+    if (spawnSucceeded) return { status: 'started', job: launchedJob };
     const failed = failPersistedUpdateJob(root, job.id, deps, START_FAILED_ERROR);
     if (failed && TERMINAL_PHASES.has(failed.phase) && failed.phase !== 'failed') {
       return { status: 'started', job: failed };

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { spawn as nodeSpawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import {
   closeSync,
   existsSync,
@@ -8,20 +8,24 @@ import {
   openSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { type UpdateJob, UpdateJob as UpdateJobSchema } from '../schemas/update-job';
-import { atomicWrite } from './atomic-write';
 import { isPidAlive } from './jobs/stale';
 
 const TERMINAL_PHASES = new Set<UpdateJob['phase']>(['succeeded', 'rolled-back', 'failed']);
 const UPDATE_JOB_LEASE_MS = 15 * 60 * 1000;
+const CLAIM_PENDING_LEASE_MS = 60 * 1000;
 const START_LOCK_LEASE_MS = 60 * 1000;
 const LEASE_EXPIRED_ERROR = 'Update worker lease expired';
+const CLAIM_EXPIRED_ERROR = 'Update worker did not claim ownership';
 const WORKER_STOPPED_ERROR = 'Update worker stopped before completion';
 const START_FAILED_ERROR = 'Update worker failed to start';
+const WORKER_EXITED_ERROR = 'Update worker exited before completion';
 
 export interface UpdateRequestContext {
   mode: UpdateJob['mode'];
@@ -31,7 +35,10 @@ export interface UpdateRequestContext {
 
 interface SpawnedUpdateWorker {
   pid?: number;
-  once(event: 'error', listener: (error: Error) => void): SpawnedUpdateWorker;
+  once(
+    event: 'error' | 'exit' | 'close',
+    listener: (...args: unknown[]) => void,
+  ): SpawnedUpdateWorker;
   unref(): void;
 }
 
@@ -46,7 +53,6 @@ export interface UpdateOrchestratorDeps {
   uuid: () => string;
   pidAlive?: (pid: number) => boolean;
   mkdirLock?: (path: string) => void;
-  persistPid?: (path: string, content: string) => void;
   reloadJob?: (root: string, id: string) => UpdateJob | null;
   spawn: (
     command: string,
@@ -64,7 +70,20 @@ const defaultDeps: UpdateOrchestratorDeps = {
   clock: () => new Date(),
   uuid: randomUUID,
   pidAlive: isPidAlive,
-  spawn: (command, args, options) => nodeSpawn(command, args, options),
+  spawn: (command, args, options) => {
+    const child = nodeSpawn(command, args, options);
+    const worker: SpawnedUpdateWorker = {
+      pid: child.pid,
+      once(event, listener) {
+        child.once(event, (...args: unknown[]) => listener(...args));
+        return worker;
+      },
+      unref() {
+        child.unref();
+      },
+    };
+    return worker;
+  },
 };
 
 function updateJobsDir(root: string): string {
@@ -73,10 +92,6 @@ function updateJobsDir(root: string): string {
 
 function updateJobPath(root: string, id: string): string {
   return join(updateJobsDir(root), `${id}.json`);
-}
-
-function updateJobPidPath(root: string, id: string): string {
-  return join(updateJobsDir(root), `${id}.pid`);
 }
 
 function updateStartLockDir(root: string): string {
@@ -110,6 +125,18 @@ function readStartLockOwner(root: string): StartLockOwner | null {
 
 function isAlreadyExistsError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === 'EEXIST';
+}
+
+function atomicReplace(filePath: string, content: string): void {
+  const temporaryPath = `${filePath}.${randomBytes(4).toString('hex')}.tmp`;
+  mkdirSync(dirname(filePath), { recursive: true });
+  try {
+    writeFileSync(temporaryPath, content, 'utf-8');
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    rmSync(temporaryPath, { force: true });
+    throw error;
+  }
 }
 
 function acquireStartLock(
@@ -176,7 +203,7 @@ function acquireStartLock(
       pid: process.pid,
       acquiredAt: now.toISOString(),
     };
-    atomicWrite(join(directory, 'owner.json'), `${JSON.stringify(owner, null, 2)}\n`);
+    atomicReplace(join(directory, 'owner.json'), `${JSON.stringify(owner, null, 2)}\n`);
   } catch (error) {
     rmSync(directory, { recursive: true, force: true });
     throw error;
@@ -192,23 +219,12 @@ function acquireStartLock(
 export function loadUpdateJob(root: string, id: string): UpdateJob | null {
   const path = updateJobPath(root, id);
   if (!existsSync(path)) return null;
-  const job = UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
-  const pidPath = updateJobPidPath(root, id);
-  if (!existsSync(pidPath)) return job;
-  try {
-    return UpdateJobSchema.parse({
-      ...job,
-      pid: Number(readFileSync(pidPath, 'utf-8').trim()),
-      launchState: 'owned',
-    });
-  } catch {
-    return job;
-  }
+  return UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
 }
 
 export function writeUpdateJob(root: string, job: UpdateJob): void {
   const parsed = UpdateJobSchema.parse(job);
-  atomicWrite(updateJobPath(root, parsed.id), `${JSON.stringify(parsed, null, 2)}\n`);
+  atomicReplace(updateJobPath(root, parsed.id), `${JSON.stringify(parsed, null, 2)}\n`);
 }
 
 function failUpdateJob(root: string, job: UpdateJob, updatedAt: Date, error: string): UpdateJob {
@@ -245,8 +261,13 @@ function findActiveUpdateJob(
     if (!file.endsWith('.json')) continue;
     const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
     if (!job || TERMINAL_PHASES.has(job.phase)) continue;
-    if (job.launchState === 'ownership-unknown') return job;
-    if (job.launchState === 'owned' && job.pid === undefined) return job;
+    if (job.launchState === 'claim-pending') {
+      if (now.getTime() - Date.parse(job.updatedAt) >= CLAIM_PENDING_LEASE_MS) {
+        failUpdateJob(root, job, now, CLAIM_EXPIRED_ERROR);
+        continue;
+      }
+      return job;
+    }
     if (job.pid !== undefined) {
       if (!pidAlive(job.pid)) {
         failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
@@ -295,7 +316,7 @@ function startUpdateJobUnderLock(
   const job = UpdateJobSchema.parse({
     id,
     phase: 'queued',
-    launchState: 'ownership-unknown',
+    launchState: 'claim-pending',
     mode: requestContext.mode,
     fromVersion: requestContext.fromVersion,
     ...(requestContext.toVersion === undefined ? {} : { toVersion: requestContext.toVersion }),
@@ -326,13 +347,18 @@ function startUpdateJobUnderLock(
         // Event handlers cannot return persistence failures to the caller.
       }
     });
+    const handleAbnormalCompletion = (...args: unknown[]) => {
+      const [code, signal] = args;
+      if (code === 0 && (signal === null || signal === undefined)) return;
+      try {
+        failPersistedUpdateJob(root, job.id, deps, WORKER_EXITED_ERROR);
+      } catch {
+        // Event handlers cannot return persistence failures to the caller.
+      }
+    };
+    worker.once('exit', handleAbnormalCompletion);
+    worker.once('close', handleAbnormalCompletion);
     worker.unref();
-    if (worker.pid !== undefined) {
-      const pid = UpdateJobSchema.shape.pid.unwrap().parse(worker.pid);
-      const persistPid = deps.persistPid ?? atomicWrite;
-      persistPid(updateJobPidPath(root, job.id), `${pid}\n`);
-      launchedJob = UpdateJobSchema.parse({ ...job, pid, launchState: 'owned' });
-    }
     const reloadJob = deps.reloadJob ?? loadUpdateJob;
     launchedJob = reloadJob(root, job.id) ?? launchedJob;
     return { status: 'started', job: launchedJob };

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -94,6 +94,10 @@ function updateJobPath(root: string, id: string): string {
   return join(updateJobsDir(root), `${id}.json`);
 }
 
+function updateJobPidPath(root: string, id: string): string {
+  return join(updateJobsDir(root), `${id}.pid`);
+}
+
 function updateStartLockDir(root: string): string {
   return join(root, 'data/update/start.lock');
 }
@@ -222,6 +226,26 @@ export function loadUpdateJob(root: string, id: string): UpdateJob | null {
   return UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
 }
 
+export function loadLatestActiveUpdateJob(root: string): UpdateJob | null {
+  const directory = updateJobsDir(root);
+  if (!existsSync(directory)) return null;
+
+  let latest: UpdateJob | null = null;
+  for (const file of readdirSync(directory)) {
+    if (!file.endsWith('.json')) continue;
+    const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
+    if (!job || TERMINAL_PHASES.has(job.phase)) continue;
+    if (
+      !latest ||
+      Date.parse(job.updatedAt) > Date.parse(latest.updatedAt) ||
+      (Date.parse(job.updatedAt) === Date.parse(latest.updatedAt) && job.id > latest.id)
+    ) {
+      latest = job;
+    }
+  }
+  return latest;
+}
+
 export function writeUpdateJob(root: string, job: UpdateJob): void {
   const parsed = UpdateJobSchema.parse(job);
   atomicReplace(updateJobPath(root, parsed.id), `${JSON.stringify(parsed, null, 2)}\n`);
@@ -270,8 +294,7 @@ function findActiveUpdateJob(
     }
     if (job.pid !== undefined) {
       if (!pidAlive(job.pid)) {
-        failUpdateJob(root, job, now, WORKER_STOPPED_ERROR);
-        continue;
+        return job;
       }
       return job;
     }
@@ -310,7 +333,16 @@ function startUpdateJobUnderLock(
   id: string,
 ): StartUpdateJobResult {
   const activeJob = findActiveUpdateJob(root, now, deps.pidAlive ?? isPidAlive);
-  if (activeJob) return { status: 'busy', job: activeJob };
+  if (activeJob) {
+    if (
+      activeJob.launchState === 'owned' &&
+      activeJob.pid !== undefined &&
+      !(deps.pidAlive ?? isPidAlive)(activeJob.pid)
+    ) {
+      return { status: 'busy', job: startRecoveryWorkerUnderLock(root, activeJob, deps, now) };
+    }
+    return { status: 'busy', job: activeJob };
+  }
 
   const timestamp = now.toISOString();
   const job = UpdateJobSchema.parse({
@@ -351,7 +383,10 @@ function startUpdateJobUnderLock(
       const [code, signal] = args;
       if (code === 0 && (signal === null || signal === undefined)) return;
       try {
-        failPersistedUpdateJob(root, job.id, deps, WORKER_EXITED_ERROR);
+        const current = loadUpdateJob(root, job.id);
+        if (current?.launchState !== 'owned') {
+          failPersistedUpdateJob(root, job.id, deps, WORKER_EXITED_ERROR);
+        }
       } catch {
         // Event handlers cannot return persistence failures to the caller.
       }
@@ -374,5 +409,95 @@ function startUpdateJobUnderLock(
     };
   } finally {
     if (logFileDescriptor !== undefined) closeSync(logFileDescriptor);
+  }
+}
+
+function startRecoveryWorkerUnderLock(
+  root: string,
+  interrupted: UpdateJob,
+  deps: UpdateOrchestratorDeps,
+  now: Date,
+): UpdateJob {
+  const sidecar = updateJobPidPath(root, interrupted.id);
+  if (existsSync(sidecar)) {
+    const claimedPid = Number(readFileSync(sidecar, 'utf-8').trim());
+    if (
+      Number.isInteger(claimedPid) &&
+      claimedPid > 0 &&
+      claimedPid !== interrupted.pid &&
+      (deps.pidAlive ?? isPidAlive)(claimedPid)
+    ) {
+      return interrupted;
+    }
+    rmSync(sidecar, { force: true });
+  }
+
+  const recoveryJob = UpdateJobSchema.parse({
+    ...interrupted,
+    phase: 'recovery-queued',
+    launchState: 'claim-pending',
+    pid: undefined,
+    error: WORKER_STOPPED_ERROR,
+    updatedAt: now.toISOString(),
+  });
+  writeUpdateJob(root, recoveryJob);
+
+  let logFileDescriptor: number | undefined;
+  try {
+    logFileDescriptor = openSync(join(updateJobsDir(root), `${interrupted.id}.log`), 'a');
+    const worker = deps.spawn(
+      process.execPath,
+      [
+        join(root, 'scripts/update-worker.mjs'),
+        '--root',
+        root,
+        '--job-id',
+        interrupted.id,
+        '--recover',
+      ],
+      {
+        cwd: root,
+        detached: true,
+        stdio: ['ignore', logFileDescriptor, logFileDescriptor],
+      },
+    );
+    worker.once('error', () => {
+      try {
+        failPersistedUpdateJob(root, interrupted.id, deps, START_FAILED_ERROR);
+      } catch {
+        // Event handlers cannot return persistence failures to the caller.
+      }
+    });
+    worker.unref();
+    return (deps.reloadJob ?? loadUpdateJob)(root, interrupted.id) ?? recoveryJob;
+  } catch {
+    return failPersistedUpdateJob(root, interrupted.id, deps, START_FAILED_ERROR) ?? recoveryJob;
+  } finally {
+    if (logFileDescriptor !== undefined) closeSync(logFileDescriptor);
+  }
+}
+
+export function reconcileUpdateJob(
+  root: string,
+  id: string,
+  deps: UpdateOrchestratorDeps = defaultDeps,
+): UpdateJob | null {
+  const now = deps.clock();
+  const releaseStartLock = acquireStartLock(root, `recover-${id}`, now, deps);
+  if (!releaseStartLock) return loadUpdateJob(root, id);
+  try {
+    const job = loadUpdateJob(root, id);
+    if (
+      !job ||
+      TERMINAL_PHASES.has(job.phase) ||
+      job.launchState !== 'owned' ||
+      job.pid === undefined ||
+      (deps.pidAlive ?? isPidAlive)(job.pid)
+    ) {
+      return job;
+    }
+    return startRecoveryWorkerUnderLock(root, job, deps, now);
+  } finally {
+    releaseStartLock();
   }
 }

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -487,6 +487,13 @@ export function reconcileUpdateJob(
   if (!releaseStartLock) return loadUpdateJob(root, id);
   try {
     const job = loadUpdateJob(root, id);
+    if (job?.launchState === 'claim-pending' && !TERMINAL_PHASES.has(job.phase)) {
+      if (now.getTime() - Date.parse(job.updatedAt) < CLAIM_PENDING_LEASE_MS) return job;
+      if (job.phase === 'recovery-queued') {
+        return startRecoveryWorkerUnderLock(root, job, deps, now);
+      }
+      return failUpdateJob(root, job, now, CLAIM_EXPIRED_ERROR);
+    }
     if (
       !job ||
       TERMINAL_PHASES.has(job.phase) ||

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -226,15 +226,25 @@ export function loadUpdateJob(root: string, id: string): UpdateJob | null {
   return UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
 }
 
-export function loadLatestActiveUpdateJob(root: string): UpdateJob | null {
+function loadScannableUpdateJobs(root: string): UpdateJob[] {
   const directory = updateJobsDir(root);
-  if (!existsSync(directory)) return null;
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory).flatMap(file => {
+    if (!file.endsWith('.json')) return [];
+    try {
+      const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
+      return job ? [job] : [];
+    } catch {
+      // One damaged job record must not block discovery or future updates.
+      return [];
+    }
+  });
+}
 
+export function loadLatestActiveUpdateJob(root: string): UpdateJob | null {
   let latest: UpdateJob | null = null;
-  for (const file of readdirSync(directory)) {
-    if (!file.endsWith('.json')) continue;
-    const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
-    if (!job || TERMINAL_PHASES.has(job.phase)) continue;
+  for (const job of loadScannableUpdateJobs(root)) {
+    if (TERMINAL_PHASES.has(job.phase)) continue;
     if (
       !latest ||
       Date.parse(job.updatedAt) > Date.parse(latest.updatedAt) ||
@@ -273,18 +283,15 @@ function failPersistedUpdateJob(
   return failUpdateJob(root, current, deps.clock(), error);
 }
 
-function findActiveUpdateJob(
-  root: string,
-  now: Date,
-  pidAlive: (pid: number) => boolean,
-): UpdateJob | null {
-  const directory = updateJobsDir(root);
-  if (!existsSync(directory)) return null;
+function findActiveUpdateJob(root: string, now: Date): UpdateJob | null {
+  const jobs = loadScannableUpdateJobs(root)
+    .filter(job => !TERMINAL_PHASES.has(job.phase))
+    .sort(
+      (left, right) =>
+        Date.parse(right.updatedAt) - Date.parse(left.updatedAt) || right.id.localeCompare(left.id),
+    );
 
-  for (const file of readdirSync(directory)) {
-    if (!file.endsWith('.json')) continue;
-    const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
-    if (!job || TERMINAL_PHASES.has(job.phase)) continue;
+  for (const job of jobs) {
     if (job.launchState === 'claim-pending') {
       if (now.getTime() - Date.parse(job.updatedAt) >= CLAIM_PENDING_LEASE_MS) {
         failUpdateJob(root, job, now, CLAIM_EXPIRED_ERROR);
@@ -292,12 +299,7 @@ function findActiveUpdateJob(
       }
       return job;
     }
-    if (job.pid !== undefined) {
-      if (!pidAlive(job.pid)) {
-        return job;
-      }
-      return job;
-    }
+    if (job.pid !== undefined) return job;
     if (now.getTime() - Date.parse(job.updatedAt) >= UPDATE_JOB_LEASE_MS) {
       failUpdateJob(root, job, now, LEASE_EXPIRED_ERROR);
       continue;
@@ -332,7 +334,7 @@ function startUpdateJobUnderLock(
   now: Date,
   id: string,
 ): StartUpdateJobResult {
-  const activeJob = findActiveUpdateJob(root, now, deps.pidAlive ?? isPidAlive);
+  const activeJob = findActiveUpdateJob(root, now);
   if (activeJob) {
     if (
       activeJob.launchState === 'owned' &&
@@ -468,6 +470,20 @@ function startRecoveryWorkerUnderLock(
         // Event handlers cannot return persistence failures to the caller.
       }
     });
+    const handleAbnormalCompletion = (...args: unknown[]) => {
+      const [code, signal] = args;
+      if (code === 0 && (signal === null || signal === undefined)) return;
+      try {
+        const current = loadUpdateJob(root, interrupted.id);
+        if (current?.launchState !== 'owned') {
+          failPersistedUpdateJob(root, interrupted.id, deps, WORKER_EXITED_ERROR);
+        }
+      } catch {
+        // Event handlers cannot return persistence failures to the caller.
+      }
+    };
+    worker.once('exit', handleAbnormalCompletion);
+    worker.once('close', handleAbnormalCompletion);
     worker.unref();
     return (deps.reloadJob ?? loadUpdateJob)(root, interrupted.id) ?? recoveryJob;
   } catch {

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -1,0 +1,116 @@
+import 'server-only';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { closeSync, existsSync, openSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { type UpdateJob, UpdateJob as UpdateJobSchema } from '../schemas/update-job';
+import { atomicWrite } from './atomic-write';
+
+const TERMINAL_PHASES = new Set<UpdateJob['phase']>(['succeeded', 'rolled-back', 'failed']);
+
+export interface UpdateRequestContext {
+  mode: UpdateJob['mode'];
+  fromVersion: string;
+  toVersion?: string;
+}
+
+interface SpawnedUpdateWorker {
+  unref(): void;
+}
+
+interface UpdateWorkerSpawnOptions {
+  cwd: string;
+  detached: true;
+  stdio: ['ignore', number, number];
+}
+
+export interface UpdateOrchestratorDeps {
+  clock: () => Date;
+  uuid: () => string;
+  spawn: (
+    command: string,
+    args: string[],
+    options: UpdateWorkerSpawnOptions,
+  ) => SpawnedUpdateWorker;
+}
+
+export type StartUpdateJobResult =
+  | { status: 'started'; job: UpdateJob }
+  | { status: 'busy'; job: UpdateJob };
+
+const defaultDeps: UpdateOrchestratorDeps = {
+  clock: () => new Date(),
+  uuid: randomUUID,
+  spawn: (command, args, options) => nodeSpawn(command, args, options),
+};
+
+function updateJobsDir(root: string): string {
+  return join(root, 'data/update/jobs');
+}
+
+function updateJobPath(root: string, id: string): string {
+  return join(updateJobsDir(root), `${id}.json`);
+}
+
+export function loadUpdateJob(root: string, id: string): UpdateJob | null {
+  const path = updateJobPath(root, id);
+  if (!existsSync(path)) return null;
+  return UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+}
+
+export function writeUpdateJob(root: string, job: UpdateJob): void {
+  const parsed = UpdateJobSchema.parse(job);
+  atomicWrite(updateJobPath(root, parsed.id), `${JSON.stringify(parsed, null, 2)}\n`);
+}
+
+function findActiveUpdateJob(root: string): UpdateJob | null {
+  const directory = updateJobsDir(root);
+  if (!existsSync(directory)) return null;
+
+  for (const file of readdirSync(directory)) {
+    if (!file.endsWith('.json')) continue;
+    const job = loadUpdateJob(root, file.slice(0, -'.json'.length));
+    if (job && !TERMINAL_PHASES.has(job.phase)) return job;
+  }
+
+  return null;
+}
+
+export function startUpdateJob(
+  root: string,
+  requestContext: UpdateRequestContext,
+  deps: UpdateOrchestratorDeps = defaultDeps,
+): StartUpdateJobResult {
+  const activeJob = findActiveUpdateJob(root);
+  if (activeJob) return { status: 'busy', job: activeJob };
+
+  const timestamp = deps.clock().toISOString();
+  const job = UpdateJobSchema.parse({
+    id: deps.uuid(),
+    phase: 'queued',
+    mode: requestContext.mode,
+    fromVersion: requestContext.fromVersion,
+    ...(requestContext.toVersion === undefined ? {} : { toVersion: requestContext.toVersion }),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+  writeUpdateJob(root, job);
+
+  const logFileDescriptor = openSync(join(updateJobsDir(root), `${job.id}.log`), 'a');
+  try {
+    const worker = deps.spawn(
+      process.execPath,
+      [join(root, 'scripts/update-worker.mjs'), '--root', root, '--job-id', job.id],
+      {
+        cwd: root,
+        detached: true,
+        stdio: ['ignore', logFileDescriptor, logFileDescriptor],
+      },
+    );
+    worker.unref();
+  } finally {
+    closeSync(logFileDescriptor);
+  }
+
+  return { status: 'started', job };
+}

--- a/src/lib/server/update-orchestrator.ts
+++ b/src/lib/server/update-orchestrator.ts
@@ -62,10 +62,20 @@ function updateJobPath(root: string, id: string): string {
   return join(updateJobsDir(root), `${id}.json`);
 }
 
+function updateJobPidPath(root: string, id: string): string {
+  return join(updateJobsDir(root), `${id}.pid`);
+}
+
 export function loadUpdateJob(root: string, id: string): UpdateJob | null {
   const path = updateJobPath(root, id);
   if (!existsSync(path)) return null;
-  return UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  const job = UpdateJobSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  const pidPath = updateJobPidPath(root, id);
+  if (!existsSync(pidPath)) return job;
+  return UpdateJobSchema.parse({
+    ...job,
+    pid: Number(readFileSync(pidPath, 'utf-8').trim()),
+  });
 }
 
 export function writeUpdateJob(root: string, job: UpdateJob): void {
@@ -162,16 +172,21 @@ export function startUpdateJob(
       }
     });
     worker.unref();
-    const startedJob = UpdateJobSchema.parse({
-      ...job,
-      ...(worker.pid === undefined ? {} : { pid: worker.pid }),
-    });
-    writeUpdateJob(root, startedJob);
+    if (worker.pid !== undefined) {
+      const pid = UpdateJobSchema.shape.pid.unwrap().parse(worker.pid);
+      atomicWrite(updateJobPidPath(root, job.id), `${pid}\n`);
+    }
+    const startedJob = loadUpdateJob(root, job.id);
+    if (!startedJob) throw new Error('Update job disappeared during launch');
     return { status: 'started', job: startedJob };
   } catch {
+    const failed = failPersistedUpdateJob(root, job.id, deps, START_FAILED_ERROR);
+    if (failed && TERMINAL_PHASES.has(failed.phase) && failed.phase !== 'failed') {
+      return { status: 'started', job: failed };
+    }
     return {
       status: 'failed',
-      job: failUpdateJob(root, job, deps.clock(), START_FAILED_ERROR),
+      job: failed ?? failUpdateJob(root, job, deps.clock(), START_FAILED_ERROR),
     };
   } finally {
     if (logFileDescriptor !== undefined) closeSync(logFileDescriptor);

--- a/test/e2e-fixtures.test.ts
+++ b/test/e2e-fixtures.test.ts
@@ -16,4 +16,12 @@ describe('report fixture Markdown filtering', () => {
     const markdown = '# Report\n\n## First\nText\n## Second';
     expect(withoutFencedCode(markdown)).toBe(markdown);
   });
+
+  it('keeps four-space-indented backticks as code and preserves later headings', () => {
+    const markdown = '    ```\n    ## indented code\n    ```\n## First\n## Second';
+    const filtered = withoutFencedCode(markdown);
+
+    expect(filtered).toBe(markdown);
+    expect(filtered.match(/^##\s+/gm)).toHaveLength(2);
+  });
 });

--- a/test/e2e-fixtures.test.ts
+++ b/test/e2e-fixtures.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { withoutFencedCode } from './e2e/markdown-fixtures';
+
+describe('report fixture Markdown filtering', () => {
+  it('excludes headings inside tilde fences', () => {
+    expect(withoutFencedCode('~~~markdown\n## hidden\n~~~\n## visible')).toBe('## visible');
+  });
+
+  it('does not close a longer backtick fence with a shorter inner fence', () => {
+    expect(
+      withoutFencedCode('````markdown\n## hidden\n```\n## still hidden\n````\n## visible'),
+    ).toBe('## visible');
+  });
+
+  it('preserves unfenced Markdown unchanged', () => {
+    const markdown = '# Report\n\n## First\nText\n## Second';
+    expect(withoutFencedCode(markdown)).toBe(markdown);
+  });
+});

--- a/test/e2e/_fixtures.ts
+++ b/test/e2e/_fixtures.ts
@@ -11,7 +11,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
 
-const ROOT = process.cwd();
+const ROOT = process.env.SUR9E_ROOT ?? process.cwd();
 const REPORTS_DIR = join(ROOT, 'artifacts', 'reports');
 const TRACKER_FILE = join(ROOT, 'data', 'applications.md');
 
@@ -25,9 +25,24 @@ function trackedReportFixtures(): string[] {
     // even though it exists on disk. Pick the first report still linked by an
     // application row; otherwise skip the data-dependent specs cleanly.
     return md.filter(file => tracker.includes(`(artifacts/reports/${file})`));
-  } catch {
-    return [];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
   }
+}
+
+function withoutFencedCode(markdown: string): string {
+  let insideFence = false;
+  return markdown
+    .split('\n')
+    .filter(line => {
+      if (/^\s*```/.test(line)) {
+        insideFence = !insideFence;
+        return false;
+      }
+      return !insideFence;
+    })
+    .join('\n');
 }
 
 const TRACKED_REPORTS = trackedReportFixtures();
@@ -40,9 +55,10 @@ export const HEADING_REPORT_FIXTURE: string | null =
   TRACKED_REPORTS.find(file => {
     try {
       const markdown = readFileSync(join(REPORTS_DIR, file), 'utf-8');
-      return (markdown.match(/^##\s+/gm) ?? []).length >= 2;
-    } catch {
-      return false;
+      return (withoutFencedCode(markdown).match(/^##\s+/gm) ?? []).length >= 2;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw error;
     }
   }) ?? null;
 

--- a/test/e2e/_fixtures.ts
+++ b/test/e2e/_fixtures.ts
@@ -10,6 +10,7 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
+import { withoutFencedCode } from './markdown-fixtures';
 
 const ROOT = process.env.SUR9E_ROOT ?? process.cwd();
 const REPORTS_DIR = join(ROOT, 'artifacts', 'reports');
@@ -29,20 +30,6 @@ function trackedReportFixtures(): string[] {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw error;
   }
-}
-
-function withoutFencedCode(markdown: string): string {
-  let insideFence = false;
-  return markdown
-    .split('\n')
-    .filter(line => {
-      if (/^\s*```/.test(line)) {
-        insideFence = !insideFence;
-        return false;
-      }
-      return !insideFence;
-    })
-    .join('\n');
 }
 
 const TRACKED_REPORTS = trackedReportFixtures();

--- a/test/e2e/markdown-fixtures.ts
+++ b/test/e2e/markdown-fixtures.ts
@@ -4,14 +4,14 @@ export function withoutFencedCode(markdown: string): string {
     .split('\n')
     .filter(line => {
       if (fence) {
-        const closingFence = line.match(/^\s*(`+|~+)\s*$/)?.[1];
+        const closingFence = line.match(/^ {0,3}(`+|~+)\s*$/)?.[1];
         if (closingFence?.[0] === fence.character && closingFence.length >= fence.length) {
           fence = null;
         }
         return false;
       }
 
-      const openingFence = line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+      const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})/)?.[1];
       if (openingFence) {
         fence = {
           character: openingFence[0] as '`' | '~',

--- a/test/e2e/markdown-fixtures.ts
+++ b/test/e2e/markdown-fixtures.ts
@@ -1,0 +1,25 @@
+export function withoutFencedCode(markdown: string): string {
+  let fence: { character: '`' | '~'; length: number } | null = null;
+  return markdown
+    .split('\n')
+    .filter(line => {
+      if (fence) {
+        const closingFence = line.match(/^\s*(`+|~+)\s*$/)?.[1];
+        if (closingFence?.[0] === fence.character && closingFence.length >= fence.length) {
+          fence = null;
+        }
+        return false;
+      }
+
+      const openingFence = line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+      if (openingFence) {
+        fence = {
+          character: openingFence[0] as '`' | '~',
+          length: openingFence.length,
+        };
+        return false;
+      }
+      return true;
+    })
+    .join('\n');
+}

--- a/test/e2e/settings-update.spec.ts
+++ b/test/e2e/settings-update.spec.ts
@@ -69,6 +69,8 @@ test('runs the one-click update flow through restart downtime and restores the e
   let applyCalls = 0;
   let rollbackCalls = 0;
   let statusCalls = 0;
+  let statusPhase = 'queued';
+  let failStatus = false;
   const unexpectedRequests: string[] = [];
 
   await page.route('**/api/version', route =>
@@ -99,24 +101,14 @@ test('runs the one-click update flow through restart downtime and restores the e
         body: JSON.stringify({ jobId: JOB_ID }),
       });
     }
-    if (pathname === `/api/update/status/${JOB_ID}` && request.method() === 'GET') {
+    if (pathname === `/api/update/status/${JOB_ID}` && request.method() === 'POST') {
       statusCalls += 1;
-      if (statusCalls >= 4 && statusCalls <= 7) {
-        return route.abort('connectionfailed');
-      }
-      const phases = new Map([
-        [1, 'queued'],
-        [2, 'rebuilding'],
-        [3, 'restarting'],
-        [8, 'verifying'],
-        [9, 'succeeded'],
-      ]);
-      const phase = phases.get(statusCalls) ?? 'succeeded';
-      if (phase === 'succeeded') installedVersion = '0.4.0';
+      if (failStatus) return route.abort('connectionfailed');
+      if (statusPhase === 'succeeded') installedVersion = '0.4.0';
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(job(phase)),
+        body: JSON.stringify(job(statusPhase)),
       });
     }
     if (pathname === '/api/update/rollback' && request.method() === 'POST') {
@@ -169,10 +161,16 @@ test('runs the one-click update flow through restart downtime and restores the e
   await page.keyboard.press('Enter');
 
   await expect(section.getByRole('status')).toContainText('Starting update');
+  statusPhase = 'rebuilding';
   await expect(section.getByRole('status')).toContainText('Rebuilding', { timeout: 8_000 });
+  statusPhase = 'restarting';
   await expect(section.getByRole('status')).toContainText('Restarting', { timeout: 8_000 });
+  failStatus = true;
   await expect(section.getByRole('status')).toContainText('Reconnecting', { timeout: 15_000 });
+  failStatus = false;
+  statusPhase = 'verifying';
   await expect(section.getByRole('status')).toContainText('Verifying restart', { timeout: 8_000 });
+  statusPhase = 'succeeded';
 
   await returnNavigation;
   await page.waitForLoadState('networkidle');
@@ -189,7 +187,7 @@ test('runs the one-click update flow through restart downtime and restores the e
   expect(checkCalls).toBe(1);
   expect(applyCalls).toBe(1);
   expect(rollbackCalls).toBe(0);
-  expect(statusCalls).toBeGreaterThanOrEqual(9);
+  expect(statusCalls).toBeGreaterThanOrEqual(6);
   expect(unexpectedRequests).toEqual([]);
 
   await page.reload();
@@ -253,6 +251,11 @@ for (const viewport of [
     await expect(edit).toHaveAttribute('aria-expanded', 'true');
     await expect(section.getByRole('textbox', { name: 'Update source' })).toBeVisible();
     await expect(section.getByRole('textbox', { name: 'Update branch' })).toBeVisible();
+
+    await page.screenshot({
+      path: `test-results/settings-update-panel-${viewport.name}-${viewport.width}x${viewport.height}.png`,
+      fullPage: true,
+    });
 
     const widths = await page.evaluate(() => ({
       viewport: window.innerWidth,

--- a/test/e2e/settings-update.spec.ts
+++ b/test/e2e/settings-update.spec.ts
@@ -1,0 +1,265 @@
+import { expect, type Page, test } from '@playwright/test';
+
+const JOB_ID = '26cf6d7a-2763-4b9d-b539-930fa8414bd5';
+const SETTINGS_HREF = '/settings?view=system#system';
+
+const availableCheck = {
+  status: 'update-available',
+  local: '0.3.2',
+  remote: '0.4.0',
+  changelog: 'Faster restart. Improved update recovery without touching your personal data.',
+} as const;
+
+function job(phase: string) {
+  const active = [
+    'applying',
+    'stopping',
+    'rebuilding',
+    'restarting',
+    'verifying',
+    'recovering',
+  ].includes(phase);
+  return {
+    id: JOB_ID,
+    phase,
+    mode: { prod: false, tailscale: false },
+    fromVersion: '0.3.2',
+    toVersion: '0.4.0',
+    createdAt: '2026-07-31T20:00:00.000Z',
+    updatedAt: '2026-07-31T20:00:00.000Z',
+    ...(active ? { launchState: 'owned', pid: 4242 } : { launchState: 'claim-pending' }),
+  };
+}
+
+async function stubReadOnlySystemEndpoints(page: Page) {
+  await page.route('**/api/version', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{"version":"0.3.2"}' }),
+  );
+  await page.route('**/api/update/**', route => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === '/api/update/check' && route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(availableCheck),
+      });
+    }
+    if (pathname === '/api/update/rollback' && route.request().method() === 'POST') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"ok":true}',
+      });
+    }
+    return route.fulfill({
+      status: 418,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: `Unexpected stubbed update request: ${pathname}` }),
+    });
+  });
+}
+
+test('runs the one-click update flow through restart downtime and restores the exact URL', async ({
+  page,
+}) => {
+  test.setTimeout(40_000);
+
+  let installedVersion = '0.3.2';
+  let checkCalls = 0;
+  let applyCalls = 0;
+  let rollbackCalls = 0;
+  let statusCalls = 0;
+  const unexpectedRequests: string[] = [];
+
+  await page.route('**/api/version', route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ version: installedVersion }),
+    }),
+  );
+  await page.route('**/api/update/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+
+    if (pathname === '/api/update/check' && request.method() === 'GET') {
+      checkCalls += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(availableCheck),
+      });
+    }
+    if (pathname === '/api/update/apply' && request.method() === 'POST') {
+      applyCalls += 1;
+      expect(request.postDataJSON()).toEqual({ toVersion: '0.4.0' });
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ jobId: JOB_ID }),
+      });
+    }
+    if (pathname === `/api/update/status/${JOB_ID}` && request.method() === 'GET') {
+      statusCalls += 1;
+      if (statusCalls >= 4 && statusCalls <= 7) {
+        return route.abort('connectionfailed');
+      }
+      const phases = new Map([
+        [1, 'queued'],
+        [2, 'rebuilding'],
+        [3, 'restarting'],
+        [8, 'verifying'],
+        [9, 'succeeded'],
+      ]);
+      const phase = phases.get(statusCalls) ?? 'succeeded';
+      if (phase === 'succeeded') installedVersion = '0.4.0';
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(job(phase)),
+      });
+    }
+    if (pathname === '/api/update/rollback' && request.method() === 'POST') {
+      rollbackCalls += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"ok":true}',
+      });
+    }
+
+    unexpectedRequests.push(`${request.method()} ${pathname}`);
+    return route.fulfill({
+      status: 418,
+      contentType: 'application/json',
+      body: '{"error":"unexpected update endpoint"}',
+    });
+  });
+
+  await page.goto(SETTINGS_HREF);
+  await page.waitForLoadState('networkidle');
+  const section = page.locator('section#system');
+  await expect(section.getByText('Not checked yet')).toBeVisible();
+  await expect(section.getByRole('button', { name: 'Update now' })).toHaveCount(0);
+
+  await section.getByRole('button', { name: 'Check for updates' }).click();
+  await expect(section.getByText('v0.4.0 available')).toBeVisible();
+  await expect(section.getByText(availableCheck.changelog)).toBeVisible();
+  await expect(section.getByRole('button', { name: 'Update now' })).toBeVisible();
+
+  await section.getByRole('button', { name: 'Update now' }).click();
+  const dialog = page.getByRole('dialog', {
+    name: 'Update Sur9e from v0.3.2 to v0.4.0?',
+  });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText(
+    'Sur9e will briefly go offline while it updates and restarts in this tab.',
+  );
+  await expect(dialog).toContainText('v0.3.2 → v0.4.0');
+  await expect(dialog).toContainText('Your CV, profile, tracker, and reports are untouched.');
+  const cancel = dialog.getByRole('button', { name: 'Cancel' });
+  const confirm = dialog.getByRole('button', { name: 'Update now' });
+  await expect(cancel).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(confirm).toBeFocused();
+  const returnNavigation = page.waitForEvent('framenavigated', {
+    predicate: frame => frame === page.mainFrame(),
+    timeout: 30_000,
+  });
+  await page.keyboard.press('Enter');
+
+  await expect(section.getByRole('status')).toContainText('Starting update');
+  await expect(section.getByRole('status')).toContainText('Rebuilding', { timeout: 8_000 });
+  await expect(section.getByRole('status')).toContainText('Restarting', { timeout: 8_000 });
+  await expect(section.getByRole('status')).toContainText('Reconnecting', { timeout: 15_000 });
+  await expect(section.getByRole('status')).toContainText('Verifying restart', { timeout: 8_000 });
+
+  await returnNavigation;
+  await page.waitForLoadState('networkidle');
+  await expect(page).toHaveURL(url => {
+    const actual = new URL(url);
+    return `${actual.pathname}${actual.search}${actual.hash}` === SETTINGS_HREF;
+  });
+  await expect(page.locator('section#system').getByRole('status')).toContainText(
+    'Update complete',
+    {
+      timeout: 10_000,
+    },
+  );
+  expect(checkCalls).toBe(1);
+  expect(applyCalls).toBe(1);
+  expect(rollbackCalls).toBe(0);
+  expect(statusCalls).toBeGreaterThanOrEqual(9);
+  expect(unexpectedRequests).toEqual([]);
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('section#system').getByText('Not checked yet')).toBeVisible();
+  await expect(page.locator('section#system').getByText('Update complete')).toHaveCount(0);
+  await expect(page.locator('#aboutVersion')).toHaveText('v0.4.0');
+});
+
+test('consumes an automatic rollback notice for one load', async ({ page }) => {
+  await stubReadOnlySystemEndpoints(page);
+  await page.goto(SETTINGS_HREF);
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(() => {
+    window.sessionStorage.setItem(
+      'sur9e.update.result',
+      JSON.stringify({ kind: 'rolled-back', version: '0.3.2', error: 'Build failed' }),
+    );
+  });
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('section#system').getByRole('status')).toContainText(
+    'Recovered automatically',
+  );
+  await expect(
+    page.getByRole('status').filter({ hasText: 'automatically recovered v0.3.2' }),
+  ).toBeVisible();
+
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('section#system').getByText('Not checked yet')).toBeVisible();
+  await expect(page.getByText(/automatically recovered v0\.3\.2/i)).toHaveCount(0);
+});
+
+for (const viewport of [
+  { name: 'desktop', width: 1280, height: 800 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'mobile', width: 375, height: 667 },
+]) {
+  test(`${viewport.name} keeps update controls visible, keyboard-accessible, and overflow-free`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await stubReadOnlySystemEndpoints(page);
+    await page.goto(SETTINGS_HREF);
+    await page.waitForLoadState('networkidle');
+
+    const section = page.locator('section#system');
+    await section.scrollIntoViewIfNeeded();
+    const check = section.getByRole('button', { name: 'Check for updates' });
+    const edit = section.locator('button[aria-controls="system-update-source-fields"]');
+    const rollback = section.getByRole('button', { name: 'Roll back' });
+    await expect(check).toBeVisible();
+    await expect(edit).toBeVisible();
+    await expect(rollback).toBeVisible();
+
+    await edit.focus();
+    await expect(edit).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(edit).toHaveAttribute('aria-expanded', 'true');
+    await expect(section.getByRole('textbox', { name: 'Update source' })).toBeVisible();
+    await expect(section.getByRole('textbox', { name: 'Update branch' })).toBeVisible();
+
+    const widths = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+      body: document.body.scrollWidth,
+    }));
+    expect(widths.document).toBeLessThanOrEqual(widths.viewport);
+    expect(widths.body).toBeLessThanOrEqual(widths.viewport);
+  });
+}

--- a/test/e2e/settings-update.spec.ts
+++ b/test/e2e/settings-update.spec.ts
@@ -18,6 +18,7 @@ function job(phase: string) {
     'restarting',
     'verifying',
     'recovering',
+    'recovery-queued',
   ].includes(phase);
   return {
     id: JOB_ID,
@@ -37,6 +38,13 @@ async function stubReadOnlySystemEndpoints(page: Page) {
   );
   await page.route('**/api/update/**', route => {
     const pathname = new URL(route.request().url()).pathname;
+    if (pathname === '/api/update/status' && route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"job":null}',
+      });
+    }
     if (pathname === '/api/update/check' && route.request().method() === 'GET') {
       return route.fulfill({
         status: 200,
@@ -83,6 +91,14 @@ test('runs the one-click update flow through restart downtime and restores the e
   await page.route('**/api/update/**', async route => {
     const request = route.request();
     const pathname = new URL(request.url()).pathname;
+
+    if (pathname === '/api/update/status' && request.method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"job":null}',
+      });
+    }
 
     if (pathname === '/api/update/check' && request.method() === 'GET') {
       checkCalls += 1;

--- a/test/menu-dots-icon-contract.test.ts
+++ b/test/menu-dots-icon-contract.test.ts
@@ -39,6 +39,6 @@ describe('menu dots icon contract', () => {
     const block = css.match(/\.icon-btn\s+svg\.menu-dots-icon\s*\{([^}]*)\}/)?.[1] ?? '';
     expect(block).toMatch(/width:\s*16px/);
     expect(block).toMatch(/height:\s*16px/);
-    expect(block).toMatch(/stroke-width:\s*2(?:px)?\s*;/);
+    expect(block).toMatch(/stroke-width:\s*2/);
   });
 });

--- a/test/menu-dots-icon-contract.test.ts
+++ b/test/menu-dots-icon-contract.test.ts
@@ -39,6 +39,6 @@ describe('menu dots icon contract', () => {
     const block = css.match(/\.icon-btn\s+svg\.menu-dots-icon\s*\{([^}]*)\}/)?.[1] ?? '';
     expect(block).toMatch(/width:\s*16px/);
     expect(block).toMatch(/height:\s*16px/);
-    expect(block).toMatch(/stroke-width:\s*2/);
+    expect(block).toMatch(/stroke-width:\s*2(?:px)?\s*;/);
   });
 });

--- a/test/repo-path-policy.test.mjs
+++ b/test/repo-path-policy.test.mjs
@@ -267,6 +267,8 @@ describe('repository path policy', () => {
         'src/lib/repo-path-policy.mjs',
         'src/lib/check-user-data-boundary.mjs',
         'scripts/sync-release-version.mjs',
+        'scripts/update-worker.mjs',
+        'scripts/web.mjs',
         'update-system.mjs',
         'test-all.mjs',
       ]),

--- a/test/update-system-integration.test.mjs
+++ b/test/update-system-integration.test.mjs
@@ -112,6 +112,8 @@ function createUpdateFixture() {
 
   configureRepository(upstream);
   seedUpdaterFiles(upstream);
+  copyTargetFile(upstream, 'scripts/update-worker.mjs');
+  copyTargetFile(upstream, 'scripts/web.mjs');
   writeFixtureFile(upstream, 'VERSION', '0.3.0\n');
   writeFixtureFile(upstream, 'content/changed.md', 'upstream\n');
   writeFixtureFile(upstream, 'content/new.md', 'new upstream file\n');
@@ -206,6 +208,12 @@ describe('update-system apply and rollback', () => {
     expect(readFileSync(resolve(installed, '.claude/skills/sur9e/SKILL.md'), 'utf8')).toBe(
       'upstream skill\n',
     );
+    expect(readFileSync(resolve(installed, 'scripts/update-worker.mjs'))).toEqual(
+      readFileSync(resolve(ROOT, 'scripts/update-worker.mjs')),
+    );
+    expect(readFileSync(resolve(installed, 'scripts/web.mjs'))).toEqual(
+      readFileSync(resolve(ROOT, 'scripts/web.mjs')),
+    );
     expect(existsSync(resolve(installed, 'content/obsolete.md'))).toBe(false);
     expect(existsSync(resolve(installed, 'content/line\nbreak.md'))).toBe(false);
     expect(existsSync(resolve(installed, 'content/trailing-space.md '))).toBe(false);
@@ -229,6 +237,8 @@ describe('update-system apply and rollback', () => {
     expect(readFileSync(resolve(installed, '.claude/skills/sur9e/SKILL.md'), 'utf8')).toBe(
       'installed skill\n',
     );
+    expect(existsSync(resolve(installed, 'scripts/update-worker.mjs'))).toBe(false);
+    expect(existsSync(resolve(installed, 'scripts/web.mjs'))).toBe(false);
     expectPrivateFiles(installed, privateFiles);
     expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
   });

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -1,8 +1,19 @@
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { runUpdateRestartJob } from '../scripts/update-worker.mjs';
+import {
+  recoverInterruptedUpdateOnStartup,
+  runUpdateRestartJob,
+  waitForSur9eHealth,
+} from '../scripts/update-worker.mjs';
 
 const JOB_ID = '11111111-1111-4111-8111-111111111111';
 const NOW = new Date('2026-07-31T20:00:00.000Z');
@@ -45,6 +56,8 @@ function harness(root, overrides = {}) {
       runCommand,
       waitForHealth,
       claimPid: vi.fn(),
+      readLaunchIdentity: vi.fn(() => ({ launchId: 'launch-123' })),
+      readVersion: vi.fn(() => '0.4.0'),
       persistJob: (_root, job) => states.push(structuredClone(job)),
       ...overrides,
     },
@@ -71,9 +84,11 @@ describe('runUpdateRestartJob', () => {
       [process.execPath, [join(root, 'scripts/web.mjs'), 'stop']],
       [process.execPath, [join(root, 'scripts/web.mjs'), '--detach']],
     ]);
-    expect(waitForHealth).toHaveBeenCalledWith('http://127.0.0.1:3000', {
+    expect(waitForHealth).toHaveBeenCalledWith('http://127.0.0.1:3000/api/version', {
       timeoutMs: 120_000,
       intervalMs: 1_000,
+      expectedVersion: '0.4.0',
+      launchId: 'launch-123',
     });
   });
 
@@ -149,6 +164,7 @@ describe('runUpdateRestartJob', () => {
       clock: () => NOW,
       runCommand,
       waitForHealth,
+      readLaunchIdentity: () => ({ launchId: 'launch-123' }),
     });
 
     expect(result).toEqual({ status: 'failed' });
@@ -207,7 +223,7 @@ describe('runUpdateRestartJob', () => {
     ]);
     expect(runCommand.mock.calls.map(([command, args]) => [command, args])).toContainEqual([
       'npm',
-      ['install', '--silent'],
+      ['ci', '--no-audit', '--no-fund'],
     ]);
     const finalStart = runCommand.mock.calls
       .filter(([, args]) => args[0] === join(root, 'scripts/web.mjs') && args[1] !== 'stop')
@@ -219,9 +235,11 @@ describe('runUpdateRestartJob', () => {
       '--detach',
     ]);
     if (mode.prod) expect(finalStart[2].env.SUR9E_WEB_SKIP_BUILD).toBe('1');
-    expect(waitForHealth).toHaveBeenLastCalledWith('http://127.0.0.1:3000', {
+    expect(waitForHealth).toHaveBeenLastCalledWith('http://127.0.0.1:3000/api/version', {
       timeoutMs: 120_000,
       intervalMs: 1_000,
+      expectedVersion: '0.3.2',
+      launchId: 'launch-123',
     });
   });
 
@@ -292,7 +310,7 @@ describe('runUpdateRestartJob', () => {
     {
       recoveryStage: 'install',
       mode: { prod: false, tailscale: false },
-      failCommand: 'install --silent',
+      failCommand: 'ci --no-audit --no-fund',
     },
     {
       recoveryStage: 'rebuild',
@@ -315,7 +333,7 @@ describe('runUpdateRestartJob', () => {
       if (label === 'run build') buildCount += 1;
       const recoveryFailure =
         (failCommand === 'rollback' && args[1] === 'rollback') ||
-        (failCommand === 'install --silent' && label === 'install --silent') ||
+        (failCommand === 'ci --no-audit --no-fund' && label === 'ci --no-audit --no-fund') ||
         (failCommand === 'second build' && label === 'run build' && buildCount === 1) ||
         (failCommand === 'web start' &&
           args[0] === join(root, 'scripts/web.mjs') &&
@@ -344,6 +362,7 @@ describe('runUpdateRestartJob', () => {
       clock: () => NOW,
       runCommand,
       waitForHealth,
+      readLaunchIdentity: () => ({ launchId: 'launch-123' }),
     });
 
     expect(queuedJob(root)).toMatchObject({
@@ -356,5 +375,141 @@ describe('runUpdateRestartJob', () => {
     expect(
       readdirSync(join(root, 'data/update/jobs')).filter(file => file.endsWith('.tmp')),
     ).toEqual([]);
+  });
+
+  it.each([
+    { checkpoint: 'apply-started', expectsRollback: true },
+    { checkpoint: 'applied', expectsRollback: true },
+    { checkpoint: 'server-stopped', expectsRollback: true },
+    { checkpoint: 'server-restarted', expectsRollback: true },
+    { checkpoint: 'rollback-complete', expectsRollback: false },
+  ])(
+    'recovers an interrupted update from $checkpoint without applying again',
+    async ({ checkpoint, expectsRollback }) => {
+      const root = makeRoot();
+      const interrupted = queuedJob(root);
+      writeFileSync(
+        join(root, 'data/update/jobs', `${JOB_ID}.json`),
+        `${JSON.stringify({
+          ...interrupted,
+          phase: 'recovery-queued',
+          launchState: 'claim-pending',
+          checkpoint,
+          error: 'Update worker stopped before completion',
+        })}\n`,
+      );
+      const { runCommand, deps } = harness(root);
+
+      const result = await runUpdateRestartJob(root, JOB_ID, deps, { recoveryOnly: true });
+
+      expect(result).toEqual({ status: 'rolled-back' });
+      const calls = runCommand.mock.calls.map(([, args]) => args);
+      expect(calls).not.toContainEqual([join(root, 'update-system.mjs'), 'apply']);
+      expect(calls).toContainEqual(['ci', '--no-audit', '--no-fund']);
+      expect(calls).toContainEqual([join(root, 'scripts/web.mjs'), '--detach']);
+      const rollbackCalls = calls.filter(
+        args => args[0] === join(root, 'update-system.mjs') && args[1] === 'rollback',
+      );
+      expect(rollbackCalls).toHaveLength(expectsRollback ? 1 : 0);
+    },
+  );
+});
+
+describe('waitForSur9eHealth', () => {
+  it('accepts only the expected Sur9e version and launch identity', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('not json', { status: 200 }))
+      .mockResolvedValueOnce(
+        Response.json({ version: '0.4.0', launchId: 'foreign-launch' }, { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({ version: '0.4.0', launchId: 'launch-123' }, { status: 200 }),
+      );
+
+    await expect(
+      waitForSur9eHealth('http://127.0.0.1:3000/api/version', {
+        timeoutMs: 100,
+        intervalMs: 1,
+        expectedVersion: '0.4.0',
+        launchId: 'launch-123',
+        fetchImpl,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('times out when another service answers successfully', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(Response.json({ version: '9.9.9', launchId: 'other' }));
+
+    await expect(
+      waitForSur9eHealth('http://127.0.0.1:3000/api/version', {
+        timeoutMs: 5,
+        intervalMs: 1,
+        expectedVersion: '0.4.0',
+        launchId: 'launch-123',
+        fetchImpl,
+      }),
+    ).rejects.toThrow('Health verification timed out');
+  });
+});
+
+describe('recoverInterruptedUpdateOnStartup', () => {
+  it('adopts a dead owned worker and runs recovery only', async () => {
+    const root = makeRoot();
+    const interrupted = {
+      ...queuedJob(root),
+      phase: 'stopping',
+      launchState: 'owned',
+      pid: 98989,
+      checkpoint: 'applied',
+    };
+    writeFileSync(
+      join(root, 'data/update/jobs', `${JOB_ID}.json`),
+      `${JSON.stringify(interrupted)}\n`,
+    );
+    writeFileSync(join(root, 'data/update/jobs', `${JOB_ID}.pid`), '98989\n');
+    const runJob = vi.fn().mockResolvedValue({ status: 'rolled-back' });
+
+    await expect(
+      recoverInterruptedUpdateOnStartup(root, {
+        pidAlive: () => false,
+        runJob,
+      }),
+    ).resolves.toEqual({
+      status: 'recovered',
+      jobId: JOB_ID,
+      result: { status: 'rolled-back' },
+    });
+
+    expect(runJob).toHaveBeenCalledWith(root, JOB_ID, expect.any(Object), {
+      recoveryOnly: true,
+    });
+    expect(existsSync(join(root, 'data/update/jobs', `${JOB_ID}.pid`))).toBe(false);
+  });
+
+  it('does not adopt a live worker or a fresh claim-pending recovery', async () => {
+    const root = makeRoot();
+    const active = {
+      ...queuedJob(root),
+      phase: 'recovery-queued',
+      launchState: 'claim-pending',
+      error: 'Update worker stopped before completion',
+      updatedAt: NOW.toISOString(),
+    };
+    writeFileSync(join(root, 'data/update/jobs', `${JOB_ID}.json`), `${JSON.stringify(active)}\n`);
+    const runJob = vi.fn();
+
+    await expect(
+      recoverInterruptedUpdateOnStartup(root, {
+        clock: () => new Date(NOW.getTime() + 1_000),
+        pidAlive: () => false,
+        runJob,
+      }),
+    ).resolves.toEqual({ status: 'active', jobId: JOB_ID });
+    expect(runJob).not.toHaveBeenCalled();
   });
 });

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -1,0 +1,360 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { runUpdateRestartJob } from '../scripts/update-worker.mjs';
+
+const JOB_ID = '11111111-1111-4111-8111-111111111111';
+const NOW = new Date('2026-07-31T20:00:00.000Z');
+
+function makeRoot(mode = { prod: false, tailscale: false }) {
+  const root = mkdtempSync(join(tmpdir(), 'sur9e-update-worker-'));
+  const directory = join(root, 'data/update/jobs');
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, `${JOB_ID}.json`),
+    `${JSON.stringify({
+      id: JOB_ID,
+      phase: 'queued',
+      launchState: 'claim-pending',
+      mode,
+      fromVersion: '0.3.2',
+      toVersion: '0.4.0',
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+    })}\n`,
+  );
+  return root;
+}
+
+function queuedJob(root) {
+  return JSON.parse(readFileSync(join(root, 'data/update/jobs', `${JOB_ID}.json`), 'utf-8'));
+}
+
+function harness(root, overrides = {}) {
+  const states = [];
+  const runCommand = vi.fn().mockResolvedValue(undefined);
+  const waitForHealth = vi.fn().mockResolvedValue(undefined);
+  return {
+    states,
+    runCommand,
+    waitForHealth,
+    deps: {
+      pid: 4242,
+      clock: () => NOW,
+      runCommand,
+      waitForHealth,
+      claimPid: vi.fn(),
+      persistJob: (_root, job) => states.push(structuredClone(job)),
+      ...overrides,
+    },
+  };
+}
+
+describe('runUpdateRestartJob', () => {
+  it('runs the dev update through every phase and verifies local health', async () => {
+    const root = makeRoot();
+    const { states, runCommand, waitForHealth, deps } = harness(root);
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'succeeded' });
+    expect(states.map(job => job.phase)).toEqual([
+      'applying',
+      'stopping',
+      'restarting',
+      'verifying',
+      'succeeded',
+    ]);
+    expect(runCommand.mock.calls.map(([command, args]) => [command, args])).toEqual([
+      [process.execPath, [join(root, 'update-system.mjs'), 'apply']],
+      [process.execPath, [join(root, 'scripts/web.mjs'), 'stop']],
+      [process.execPath, [join(root, 'scripts/web.mjs'), '--detach']],
+    ]);
+    expect(waitForHealth).toHaveBeenCalledWith('http://127.0.0.1:3000', {
+      timeoutMs: 120_000,
+      intervalMs: 1_000,
+    });
+  });
+
+  it.each([
+    { label: 'dev', mode: { prod: false, tailscale: false }, args: ['--detach'], build: false },
+    {
+      label: 'dev + Tailscale',
+      mode: { prod: false, tailscale: true },
+      args: ['--dev', '--tailscale', '--detach'],
+      build: false,
+    },
+    {
+      label: 'prod',
+      mode: { prod: true, tailscale: false },
+      args: ['--prod', '--detach'],
+      build: true,
+    },
+    {
+      label: 'prod + Tailscale',
+      mode: { prod: true, tailscale: true },
+      args: ['--prod', '--tailscale', '--detach'],
+      build: true,
+    },
+  ])('preserves $label mode with argument arrays', async ({ mode, args, build }) => {
+    const root = makeRoot(mode);
+    const { runCommand, deps } = harness(root);
+
+    await runUpdateRestartJob(root, JOB_ID, deps);
+
+    const calls = runCommand.mock.calls;
+    const startCall = calls.find(
+      ([, commandArgs]) =>
+        commandArgs[0] === join(root, 'scripts/web.mjs') && commandArgs[1] !== 'stop',
+    );
+    expect(startCall[0]).toBe(process.execPath);
+    expect(startCall[1]).toEqual([join(root, 'scripts/web.mjs'), ...args]);
+    expect(startCall[2]).toMatchObject({ cwd: root });
+    if (mode.prod) expect(startCall[2].env.SUR9E_WEB_SKIP_BUILD).toBe('1');
+    else expect(startCall[2]).not.toHaveProperty('env');
+    expect(
+      calls.some(
+        ([command, commandArgs]) => command === 'npm' && commandArgs.join(' ') === 'run build',
+      ),
+    ).toBe(build);
+  });
+
+  it('aborts before loading or mutating the job when the PID claim fails', async () => {
+    const root = makeRoot();
+    const original = queuedJob(root);
+    const claimPid = vi.fn(() => {
+      throw new Error('already claimed');
+    });
+    const persistJob = vi.fn();
+    const { runCommand, waitForHealth, deps } = harness(root, { claimPid, persistJob });
+
+    await expect(runUpdateRestartJob(root, JOB_ID, deps)).resolves.toEqual({ status: 'failed' });
+
+    expect(claimPid).toHaveBeenCalledOnce();
+    expect(persistJob).not.toHaveBeenCalled();
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(waitForHealth).not.toHaveBeenCalled();
+    expect(queuedJob(root)).toEqual(original);
+  });
+
+  it('uses an exclusive PID sidecar claim without replacing another worker owner', async () => {
+    const root = makeRoot();
+    const sidecar = join(root, 'data/update/jobs', `${JOB_ID}.pid`);
+    writeFileSync(sidecar, '31337\n');
+    const { runCommand, waitForHealth } = harness(root);
+
+    const result = await runUpdateRestartJob(root, JOB_ID, {
+      pid: 4242,
+      clock: () => NOW,
+      runCommand,
+      waitForHealth,
+    });
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(readFileSync(sidecar, 'utf-8')).toBe('31337\n');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('marks apply failure failed without stopping or attempting rollback', async () => {
+    const root = makeRoot();
+    const { states, runCommand, deps } = harness(root);
+    runCommand.mockRejectedValueOnce(new Error('token=do-not-persist command details'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(states.map(job => job.phase)).toEqual(['applying', 'failed']);
+    expect(runCommand).toHaveBeenCalledTimes(1);
+    expect(runCommand.mock.calls[0][1]).toEqual([join(root, 'update-system.mjs'), 'apply']);
+    expect(states.at(-1).error).toBe('Update failed while applying the new version');
+  });
+
+  it.each([
+    { stage: 'stopping', mode: { prod: false, tailscale: false }, failCommand: 'stop' },
+    { stage: 'rebuilding', mode: { prod: true, tailscale: false }, failCommand: 'run build' },
+    { stage: 'restarting', mode: { prod: false, tailscale: true }, failCommand: 'web start' },
+    { stage: 'verifying', mode: { prod: false, tailscale: false }, failCommand: 'health' },
+  ])('rolls back safely when $stage fails', async ({ stage, mode, failCommand }) => {
+    const root = makeRoot(mode);
+    const { states, runCommand, waitForHealth, deps } = harness(root);
+    let failed = false;
+    runCommand.mockImplementation(async (_command, args) => {
+      const label =
+        args[1] === 'stop'
+          ? 'stop'
+          : args.join(' ') === 'run build'
+            ? 'run build'
+            : args[0] === join(root, 'scripts/web.mjs')
+              ? 'web start'
+              : '';
+      if (!failed && label === failCommand) {
+        failed = true;
+        throw new Error('secret output with command details');
+      }
+    });
+    if (failCommand === 'health') waitForHealth.mockRejectedValueOnce(new Error('secret health'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'rolled-back' });
+    expect(states.map(job => job.phase)).toContain('recovering');
+    expect(states.at(-1).phase).toBe('rolled-back');
+    expect(states.at(-1).error).toBe(`Update restart failed while ${stage}`);
+    expect(runCommand.mock.calls.map(([, args]) => args)).toContainEqual([
+      join(root, 'update-system.mjs'),
+      'rollback',
+    ]);
+    expect(runCommand.mock.calls.map(([command, args]) => [command, args])).toContainEqual([
+      'npm',
+      ['install', '--silent'],
+    ]);
+    const finalStart = runCommand.mock.calls
+      .filter(([, args]) => args[0] === join(root, 'scripts/web.mjs') && args[1] !== 'stop')
+      .at(-1);
+    expect(finalStart[1]).toEqual([
+      join(root, 'scripts/web.mjs'),
+      ...(mode.prod ? ['--prod'] : mode.tailscale ? ['--dev'] : []),
+      ...(mode.tailscale ? ['--tailscale'] : []),
+      '--detach',
+    ]);
+    if (mode.prod) expect(finalStart[2].env.SUR9E_WEB_SKIP_BUILD).toBe('1');
+    expect(waitForHealth).toHaveBeenLastCalledWith('http://127.0.0.1:3000', {
+      timeoutMs: 120_000,
+      intervalMs: 1_000,
+    });
+  });
+
+  it('stops an unhealthy new server before rolling back and restarting the old version', async () => {
+    const root = makeRoot({ prod: true, tailscale: true });
+    const { states, runCommand, waitForHealth, deps } = harness(root);
+    let serverRunning = false;
+    let stopCount = 0;
+    runCommand.mockImplementation(async (_command, args) => {
+      if (args[1] === 'stop') {
+        stopCount += 1;
+        serverRunning = false;
+      } else if (args[0] === join(root, 'scripts/web.mjs')) {
+        if (serverRunning) throw new Error('port occupied by unhealthy new server');
+        serverRunning = true;
+      }
+    });
+    waitForHealth.mockRejectedValueOnce(new Error('new server is unhealthy'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'rolled-back' });
+    expect(stopCount).toBe(2);
+    expect(serverRunning).toBe(true);
+    expect(states.at(-1)).toMatchObject({
+      phase: 'rolled-back',
+      error: 'Update restart failed while verifying',
+    });
+    const commandArgs = runCommand.mock.calls.map(([, args]) => args);
+    expect(commandArgs.indexOf(commandArgs.find(args => args[1] === 'rollback'))).toBeGreaterThan(
+      commandArgs.map(args => args[1]).lastIndexOf('stop'),
+    );
+  });
+
+  it('marks recovery failed when the unhealthy updated server cannot be stopped', async () => {
+    const root = makeRoot();
+    const { states, runCommand, waitForHealth, deps } = harness(root);
+    let stopCount = 0;
+    runCommand.mockImplementation(async (_command, args) => {
+      if (args[1] === 'stop' && ++stopCount === 2) {
+        throw new Error('private listener details');
+      }
+    });
+    waitForHealth.mockRejectedValueOnce(new Error('new server is unhealthy'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(states.map(job => job.phase)).toEqual([
+      'applying',
+      'stopping',
+      'restarting',
+      'verifying',
+      'recovering',
+      'failed',
+    ]);
+    expect(states.at(-1).error).toBe(
+      'Update restart failed while verifying; recovery failed while stopping the updated server',
+    );
+    expect(runCommand.mock.calls.map(([, args]) => args)).not.toContainEqual([
+      join(root, 'update-system.mjs'),
+      'rollback',
+    ]);
+  });
+
+  it.each([
+    { recoveryStage: 'rollback', mode: { prod: false, tailscale: false }, failCommand: 'rollback' },
+    {
+      recoveryStage: 'install',
+      mode: { prod: false, tailscale: false },
+      failCommand: 'install --silent',
+    },
+    {
+      recoveryStage: 'rebuild',
+      mode: { prod: true, tailscale: false },
+      failCommand: 'second build',
+    },
+    { recoveryStage: 'restart', mode: { prod: false, tailscale: true }, failCommand: 'web start' },
+    {
+      recoveryStage: 'verification',
+      mode: { prod: false, tailscale: false },
+      failCommand: 'health',
+    },
+  ])('marks the job failed when recovery $recoveryStage fails', async ({ mode, failCommand }) => {
+    const root = makeRoot(mode);
+    const { states, runCommand, waitForHealth, deps } = harness(root);
+    let buildCount = 0;
+    runCommand.mockImplementation(async (_command, args) => {
+      if (args[1] === 'stop') throw new Error('original private failure');
+      const label = args.join(' ');
+      if (label === 'run build') buildCount += 1;
+      const recoveryFailure =
+        (failCommand === 'rollback' && args[1] === 'rollback') ||
+        (failCommand === 'install --silent' && label === 'install --silent') ||
+        (failCommand === 'second build' && label === 'run build' && buildCount === 1) ||
+        (failCommand === 'web start' &&
+          args[0] === join(root, 'scripts/web.mjs') &&
+          args[1] !== 'stop');
+      if (recoveryFailure) throw new Error('recovery secret with command details');
+    });
+    if (failCommand === 'health') waitForHealth.mockRejectedValueOnce(new Error('health secret'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(states.map(job => job.phase)).toEqual(['applying', 'stopping', 'recovering', 'failed']);
+    expect(states.at(-1).error).toMatch(
+      /^Update restart failed while stopping; recovery failed while /,
+    );
+    expect(states.at(-1).error).not.toMatch(/secret|private|token=/);
+  });
+
+  it('atomically persists validated terminal state and the claimed PID with no temp residue', async () => {
+    const root = makeRoot();
+    const runCommand = vi.fn().mockResolvedValue(undefined);
+    const waitForHealth = vi.fn().mockResolvedValue(undefined);
+
+    await runUpdateRestartJob(root, JOB_ID, {
+      pid: 4242,
+      clock: () => NOW,
+      runCommand,
+      waitForHealth,
+    });
+
+    expect(queuedJob(root)).toMatchObject({
+      id: JOB_ID,
+      phase: 'succeeded',
+      launchState: 'owned',
+      pid: 4242,
+    });
+    expect(readFileSync(join(root, 'data/update/jobs', `${JOB_ID}.pid`), 'utf-8')).toBe('4242\n');
+    expect(
+      readdirSync(join(root, 'data/update/jobs')).filter(file => file.endsWith('.tmp')),
+    ).toEqual([]);
+  });
+});

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -18,6 +18,13 @@ import {
 
 const JOB_ID = '11111111-1111-4111-8111-111111111111';
 const NOW = new Date('2026-07-31T20:00:00.000Z');
+const RECOVERY_STAGE_TEXT = {
+  rollback: 'rolling back the checkout',
+  install: 'installing previous dependencies',
+  rebuild: 'rebuilding the previous version',
+  restart: 'restarting the previous version',
+  verification: 'verifying the previous version',
+};
 
 function makeRoot(mode = { prod: false, tailscale: false }) {
   const root = mkdtempSync(join(tmpdir(), 'sur9e-update-worker-'));
@@ -324,34 +331,39 @@ describe('runUpdateRestartJob', () => {
       mode: { prod: false, tailscale: false },
       failCommand: 'health',
     },
-  ])('marks the job failed when recovery $recoveryStage fails', async ({ mode, failCommand }) => {
-    const root = makeRoot(mode);
-    const { states, runCommand, waitForHealth, deps } = harness(root);
-    let buildCount = 0;
-    runCommand.mockImplementation(async (_command, args) => {
-      if (args[1] === 'stop') throw new Error('original private failure');
-      const label = args.join(' ');
-      if (label === 'run build') buildCount += 1;
-      const recoveryFailure =
-        (failCommand === 'rollback' && args[1] === 'rollback') ||
-        (failCommand === 'ci --no-audit --no-fund' && label === 'ci --no-audit --no-fund') ||
-        (failCommand === 'second build' && label === 'run build' && buildCount === 1) ||
-        (failCommand === 'web start' &&
-          args[0] === join(root, 'scripts/web.mjs') &&
-          args[1] !== 'stop');
-      if (recoveryFailure) throw new Error('recovery secret with command details');
-    });
-    if (failCommand === 'health') waitForHealth.mockRejectedValueOnce(new Error('health secret'));
+  ])(
+    'marks the job failed when recovery $recoveryStage fails',
+    async ({ recoveryStage, mode, failCommand }) => {
+      const root = makeRoot(mode);
+      const { states, runCommand, waitForHealth, deps } = harness(root);
+      let buildCount = 0;
+      let startCount = 0;
+      runCommand.mockImplementation(async (_command, args) => {
+        const label = args.join(' ');
+        if (label === 'run build') buildCount += 1;
+        if (args[0] === join(root, 'scripts/web.mjs') && args[1] !== 'stop') startCount += 1;
+        const recoveryFailure =
+          (failCommand === 'rollback' && args[1] === 'rollback') ||
+          (failCommand === 'ci --no-audit --no-fund' && label === 'ci --no-audit --no-fund') ||
+          (failCommand === 'second build' && label === 'run build' && buildCount === 2) ||
+          (failCommand === 'web start' && startCount === 2);
+        if (recoveryFailure) throw new Error('recovery secret with command details');
+      });
+      waitForHealth.mockRejectedValueOnce(new Error('original private health failure'));
+      if (failCommand === 'health') {
+        waitForHealth.mockRejectedValueOnce(new Error('recovery secret health failure'));
+      }
 
-    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+      const result = await runUpdateRestartJob(root, JOB_ID, deps);
 
-    expect(result).toEqual({ status: 'failed' });
-    expect(states.map(job => job.phase)).toEqual(['applying', 'stopping', 'recovering', 'failed']);
-    expect(states.at(-1).error).toMatch(
-      /^Update restart failed while stopping; recovery failed while /,
-    );
-    expect(states.at(-1).error).not.toMatch(/secret|private|token=/);
-  });
+      expect(result).toEqual({ status: 'failed' });
+      expect(states.at(-1).phase).toBe('failed');
+      expect(states.at(-1).error).toBe(
+        `Update restart failed while verifying; recovery failed while ${RECOVERY_STAGE_TEXT[recoveryStage]}`,
+      );
+      expect(states.at(-1).error).not.toMatch(/secret|private|token=/);
+    },
+  );
 
   it('atomically persists validated terminal state and the claimed PID with no temp residue', async () => {
     const root = makeRoot();

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import {
   existsSync,
   mkdirSync,
@@ -378,14 +379,17 @@ describe('runUpdateRestartJob', () => {
   });
 
   it.each([
-    { checkpoint: 'apply-started', expectsRollback: true },
-    { checkpoint: 'applied', expectsRollback: true },
-    { checkpoint: 'server-stopped', expectsRollback: true },
-    { checkpoint: 'server-restarted', expectsRollback: true },
-    { checkpoint: 'rollback-complete', expectsRollback: false },
+    { checkpoint: 'apply-started', installedVersion: '0.3.2', expectsRollback: true },
+    { checkpoint: 'applied', installedVersion: '0.4.0', expectsRollback: true },
+    { checkpoint: 'server-stopped', installedVersion: '0.4.0', expectsRollback: true },
+    { checkpoint: 'server-restarted', installedVersion: '0.4.0', expectsRollback: true },
+    { checkpoint: 'rollback-complete', installedVersion: '0.3.2', expectsRollback: false },
+    { checkpoint: 'dependencies-restored', installedVersion: '0.4.0', expectsRollback: false },
+    { checkpoint: 'recovery-build-complete', installedVersion: '0.4.0', expectsRollback: false },
+    { checkpoint: 'recovery-server-started', installedVersion: '0.4.0', expectsRollback: false },
   ])(
-    'recovers an interrupted update from $checkpoint without applying again',
-    async ({ checkpoint, expectsRollback }) => {
+    'recovers an interrupted update from $checkpoint at v$installedVersion without applying again',
+    async ({ checkpoint, installedVersion, expectsRollback }) => {
       const root = makeRoot();
       const interrupted = queuedJob(root);
       writeFileSync(
@@ -398,7 +402,9 @@ describe('runUpdateRestartJob', () => {
           error: 'Update worker stopped before completion',
         })}\n`,
       );
-      const { runCommand, deps } = harness(root);
+      const { runCommand, deps } = harness(root, {
+        readVersion: vi.fn(() => installedVersion),
+      });
 
       const result = await runUpdateRestartJob(root, JOB_ID, deps, { recoveryOnly: true });
 
@@ -511,5 +517,83 @@ describe('recoverInterruptedUpdateOnStartup', () => {
       }),
     ).resolves.toEqual({ status: 'active', jobId: JOB_ID });
     expect(runJob).not.toHaveBeenCalled();
+  });
+});
+
+describe('owned command timeout', () => {
+  it('waits for SIGKILL escalation before recovery when the group leader exits on SIGTERM', async () => {
+    vi.useFakeTimers();
+    const children = [
+      Object.assign(new EventEmitter(), { pid: 1101 }),
+      Object.assign(new EventEmitter(), { pid: 1102 }),
+      Object.assign(new EventEmitter(), { pid: 1103 }),
+    ];
+    const spawnProcess = vi.fn(() => children[spawnProcess.mock.calls.length - 1]);
+    vi.doMock('node:child_process', async importOriginal => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        default: { ...actual.default, spawn: spawnProcess },
+        spawn: spawnProcess,
+      };
+    });
+    vi.resetModules();
+    let timedOutGroupAlive = true;
+    const kill = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (pid === -1102 && signal === 0 && !timedOutGroupAlive) {
+        throw Object.assign(new Error('process group is gone'), { code: 'ESRCH' });
+      }
+      return true;
+    });
+
+    try {
+      const isolatedWorker = await import('../scripts/update-worker.mjs');
+      const root = makeRoot();
+      const states = [];
+      void isolatedWorker.runUpdateRestartJob(root, JOB_ID, {
+        pid: 4242,
+        clock: () => NOW,
+        claimPid: vi.fn(),
+        persistJob: (_root, job) => states.push(structuredClone(job)),
+        waitForHealth: vi.fn().mockResolvedValue(undefined),
+        readLaunchIdentity: vi.fn(() => ({ launchId: 'launch-123' })),
+      });
+
+      expect(spawnProcess).toHaveBeenCalledTimes(1);
+      children[0].emit('exit', 0, null);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(spawnProcess).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(2 * 60_000);
+      expect(kill).toHaveBeenCalledWith(-1102, 'SIGTERM');
+      children[1].emit('exit', null, 'SIGTERM');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(spawnProcess).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(kill).not.toHaveBeenCalledWith(-1102, 'SIGKILL');
+      expect(spawnProcess).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(kill).toHaveBeenCalledWith(-1102, 'SIGKILL');
+      expect(spawnProcess).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(spawnProcess).toHaveBeenCalledTimes(2);
+
+      timedOutGroupAlive = false;
+      await vi.advanceTimersByTimeAsync(50);
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(spawnProcess).toHaveBeenCalledTimes(3);
+      expect(states.map(job => job.phase)).toContain('recovering');
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      kill.mockRestore();
+      vi.doUnmock('node:child_process');
+      vi.resetModules();
+    }
   });
 });

--- a/test/web-launcher.test.mjs
+++ b/test/web-launcher.test.mjs
@@ -509,7 +509,7 @@ describe('managed launch mode', () => {
   });
 });
 
-describe('cmdStart — port guard', () => {
+describe('cmdStart — startup safeguards and ownership verification', () => {
   it('stops an unverified detached launcher and returns a safe failure', async () => {
     const child = fakeChild(9001);
     const spawnImpl = vi.fn().mockReturnValue(child);
@@ -524,6 +524,8 @@ describe('cmdStart — port guard', () => {
         error,
         log: vi.fn(),
         stateDir: tmpStateDir(),
+        root: CHECKOUT_ROOT,
+        hasInterruptedUpdate: () => false,
       },
     );
 
@@ -546,6 +548,8 @@ describe('cmdStart — port guard', () => {
         error,
         log: vi.fn(),
         stateDir: tmpStateDir(),
+        root: CHECKOUT_ROOT,
+        hasInterruptedUpdate: () => false,
       },
     );
 

--- a/test/web-launcher.test.mjs
+++ b/test/web-launcher.test.mjs
@@ -519,6 +519,64 @@ describe('cmdStart — port guard', () => {
     expect(error.mock.calls.flat().join('\n')).toMatch(/already in use by PID 1111/);
   });
 
+  it('recovers an interrupted update before starting another server', async () => {
+    const spawnImpl = vi.fn();
+    const recoverUpdate = vi.fn().mockResolvedValue({
+      status: 'recovered',
+      jobId: '11111111-1111-4111-8111-111111111111',
+      result: { status: 'rolled-back' },
+    });
+    const log = vi.fn();
+
+    const code = await cmdStart(
+      { command: 'start', prod: true, tailscale: false, detach: true },
+      {
+        exec: vi.fn().mockReturnValue({ status: 1, stdout: '' }),
+        spawnImpl,
+        error: vi.fn(),
+        log,
+        root: CHECKOUT_ROOT,
+        hasInterruptedUpdate: () => true,
+        recoverUpdate,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(recoverUpdate).toHaveBeenCalledWith(CHECKOUT_ROOT);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      'Recovered the previous Sur9e version after an interrupted update.',
+    );
+  });
+
+  it('refuses a normal start when interrupted-update recovery fails', async () => {
+    const spawnImpl = vi.fn();
+    const error = vi.fn();
+
+    const code = await cmdStart(
+      { command: 'start', prod: false, tailscale: false, detach: false },
+      {
+        exec: vi.fn().mockReturnValue({ status: 1, stdout: '' }),
+        spawnImpl,
+        error,
+        log: vi.fn(),
+        root: CHECKOUT_ROOT,
+        hasInterruptedUpdate: () => true,
+        recoverUpdate: vi.fn().mockResolvedValue({
+          status: 'recovered',
+          jobId: '11111111-1111-4111-8111-111111111111',
+          result: { status: 'failed' },
+        }),
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      'Interrupted update recovery failed — the server was not started.',
+    );
+  });
+
   it('exports the tailnet host to next dev so allowedDevOrigins can unblock proxied assets', () => {
     const sigintBefore = process.listeners('SIGINT');
     const sigtermBefore = process.listeners('SIGTERM');

--- a/test/web-launcher.test.mjs
+++ b/test/web-launcher.test.mjs
@@ -1,6 +1,6 @@
 // Unit tests for the web launcher's pure helpers. Everything is
 // dependency-injected — no real lsof, no real tailscale, no real data/.
-import { existsSync, mkdtempSync, writeFileSync as writeFs } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync as writeFs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join as joinPath } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -11,11 +11,43 @@ import {
   findTailscaleCli,
   getListener,
   getTailnetUrl,
+  getWebLaunchMode,
   parseWebArgs,
 } from '../scripts/web.mjs';
 
 function tmpStateDir() {
   return mkdtempSync(joinPath(tmpdir(), 'sur9e-web-test-'));
+}
+
+function readState(stateDir) {
+  return JSON.parse(readFileSync(joinPath(stateDir, 'web.json'), 'utf-8'));
+}
+
+function fakeChild(pid = 7001) {
+  const handlers = new Map();
+  return {
+    pid,
+    kill: vi.fn(),
+    on: vi.fn((event, handler) => handlers.set(event, handler)),
+    unref: vi.fn(),
+    emit(event, ...args) {
+      handlers.get(event)?.(...args);
+    },
+  };
+}
+
+function fakeProcess(pid = 7000) {
+  const handlers = new Map();
+  return {
+    pid,
+    env: {},
+    execPath: '/test/node',
+    exit: vi.fn(),
+    on: vi.fn((event, handler) => handlers.set(event, handler)),
+    emit(event, ...args) {
+      handlers.get(event)?.(...args);
+    },
+  };
 }
 
 describe('parseWebArgs', () => {
@@ -178,6 +210,153 @@ describe('enableServe', () => {
     const log = vi.fn();
     expect(enableServe({ exec, exists: () => true, log, error: vi.fn() })).toBe(true);
     expect(log.mock.calls.flat().join('\n')).toContain('https://mac.tail1234.ts.net');
+  });
+});
+
+describe('managed launch mode', () => {
+  const startedAt = '2026-07-31T18:30:00.000Z';
+
+  function startForeground({ prod = false, tailscale = false } = {}) {
+    const stateDir = tmpStateDir();
+    const child = fakeChild();
+    const processImpl = fakeProcess();
+    let lsofCalls = 0;
+    const exec = vi.fn((cmd, args) => {
+      if (cmd === 'lsof') {
+        lsofCalls += 1;
+        return lsofCalls === 1
+          ? { status: 1, stdout: '' }
+          : { status: 0, stdout: 'p7002\ncnode\n' };
+      }
+      if (cmd === 'which') return { status: 0, stdout: '/test/tailscale\n' };
+      if (args?.[0] === 'status') {
+        return {
+          status: 0,
+          stdout: JSON.stringify({ Self: { DNSName: 'test.tailnet.ts.net.' } }),
+        };
+      }
+      return { status: 0, stdout: '' };
+    });
+    const spawnImpl = vi.fn().mockReturnValue(child);
+    void cmdStart(
+      { command: 'start', prod, tailscale, detach: false },
+      {
+        exec,
+        spawnImpl,
+        exists: () => true,
+        log: vi.fn(),
+        error: vi.fn(),
+        stateDir,
+        env: { SUR9E_WEB_SKIP_BUILD: '1' },
+        processImpl,
+        now: () => startedAt,
+      },
+    );
+    return { child, exec, processImpl, spawnImpl, stateDir };
+  }
+
+  it.each([
+    ['dev', false, false],
+    ['prod', true, false],
+    ['prod + tailscale', true, true],
+  ])('persists foreground %s metadata for orchestrator readers', (_label, prod, tailscale) => {
+    const { processImpl, stateDir } = startForeground({ prod, tailscale });
+    expect(readFileSync(joinPath(stateDir, 'web.pid'), 'utf-8')).toBe(String(processImpl.pid));
+    expect(readState(stateDir)).toEqual({ pid: processImpl.pid, prod, tailscale, startedAt });
+
+    const exec = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: 'node /repo/scripts/web.mjs\n',
+    });
+    expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod, tailscale });
+  });
+
+  it('clears foreground state after signal-driven clean child exit', () => {
+    const { child, processImpl, stateDir } = startForeground();
+    processImpl.emit('SIGTERM');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    child.emit('exit', 0);
+    expect(existsSync(joinPath(stateDir, 'web.pid'))).toBe(false);
+    expect(existsSync(joinPath(stateDir, 'web.json'))).toBe(false);
+    expect(processImpl.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('does not clear state replaced by a different launcher before its child exits', () => {
+    const { child, processImpl, stateDir } = startForeground({ prod: true });
+    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(
+      joinPath(stateDir, 'web.json'),
+      JSON.stringify({ pid: 8123, prod: false, tailscale: true, startedAt: 'later' }),
+    );
+
+    child.emit('exit', 1);
+    expect(readFileSync(joinPath(stateDir, 'web.pid'), 'utf-8')).toBe('8123');
+    expect(readState(stateDir).pid).toBe(8123);
+    expect(processImpl.exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each([
+    ['stale', { status: 1, stdout: '' }],
+    ['foreign', { status: 0, stdout: '/usr/bin/unrelated-server\n' }],
+  ])('returns the safe dev-only fallback for %s persisted metadata', (_case, psResult) => {
+    const stateDir = tmpStateDir();
+    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(
+      joinPath(stateDir, 'web.json'),
+      JSON.stringify({ pid: 8123, prod: true, tailscale: true, startedAt }),
+    );
+    const exec = vi.fn().mockReturnValue(psResult);
+    expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod: false, tailscale: false });
+  });
+
+  it('returns the safe dev-only fallback for malformed persisted state', () => {
+    const stateDir = tmpStateDir();
+    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(joinPath(stateDir, 'web.json'), '{not json');
+    const exec = vi.fn();
+    expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod: false, tailscale: false });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('keeps detached launch behavior keyed to the detached child PID', async () => {
+    const stateDir = tmpStateDir();
+    const child = fakeChild(9001);
+    const processImpl = fakeProcess(9000);
+    const spawnImpl = vi.fn().mockReturnValue(child);
+    const exec = vi.fn().mockReturnValue({ status: 1, stdout: '' });
+
+    const code = await cmdStart(
+      { command: 'start', prod: false, tailscale: false, detach: true },
+      {
+        exec,
+        spawnImpl,
+        error: vi.fn(),
+        log: vi.fn(),
+        stateDir,
+        env: { TEST_MARKER: 'yes' },
+        processImpl,
+        now: () => startedAt,
+      },
+    );
+
+    expect(code).toBe(0);
+    expect(spawnImpl).toHaveBeenCalledWith(
+      '/test/node',
+      [expect.stringMatching(/scripts\/web\.mjs$/)],
+      expect.objectContaining({
+        detached: true,
+        env: { TEST_MARKER: 'yes', SUR9E_WEB_SKIP_BUILD: '1' },
+      }),
+    );
+    expect(readState(stateDir)).toEqual({
+      pid: child.pid,
+      prod: false,
+      tailscale: false,
+      startedAt,
+    });
+    expect(child.unref).toHaveBeenCalledOnce();
+    expect(processImpl.on).not.toHaveBeenCalled();
   });
 });
 

--- a/test/web-launcher.test.mjs
+++ b/test/web-launcher.test.mjs
@@ -247,11 +247,6 @@ describe('enableServe', () => {
 });
 
 describe('managed launch mode', () => {
-  const startedAt = '2026-07-31T18:30:00.000Z';
-  const checkoutRoot = '/repo/sur9e';
-  const launchId = '11111111-1111-4111-8111-111111111111';
-  const processStart = 'Fri Jul 31 18:29:59 2026';
-
   function startForeground({ prod = false, tailscale = false } = {}) {
     const stateDir = tmpStateDir();
     const child = fakeChild();
@@ -285,15 +280,15 @@ describe('managed launch mode', () => {
         stateDir,
         env: { SUR9E_WEB_SKIP_BUILD: '1' },
         processImpl,
-        now: () => startedAt,
-        root: checkoutRoot,
-        launchId: () => launchId,
+        now: () => STARTED_AT,
+        root: CHECKOUT_ROOT,
+        launchId: () => LAUNCH_ID,
         inspectProcess: pid => ({
           pid,
           ppid: 1,
-          command: `node ${checkoutRoot}/scripts/web.mjs`,
-          cwd: checkoutRoot,
-          start: processStart,
+          command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+          cwd: CHECKOUT_ROOT,
+          start: PROCESS_START,
         }),
       },
     );
@@ -311,21 +306,21 @@ describe('managed launch mode', () => {
       pid: processImpl.pid,
       prod,
       tailscale,
-      startedAt,
-      root: checkoutRoot,
-      processStart,
-      launchId,
+      startedAt: STARTED_AT,
+      root: CHECKOUT_ROOT,
+      processStart: PROCESS_START,
+      launchId: LAUNCH_ID,
     });
 
     expect(spawnImpl.mock.calls[0][2].env).toMatchObject({
-      SUR9E_WEB_LAUNCH_ID: launchId,
+      SUR9E_WEB_LAUNCH_ID: LAUNCH_ID,
     });
 
     expect(
       getWebLaunchMode({
         stateDir,
         inspectProcess: pid => verifiedIdentity(pid),
-        root: checkoutRoot,
+        root: CHECKOUT_ROOT,
       }),
     ).toEqual({ prod, tailscale });
   });
@@ -351,7 +346,7 @@ describe('managed launch mode', () => {
         prod: false,
         tailscale: true,
         startedAt: '2026-07-31T19:30:00.000Z',
-        root: checkoutRoot,
+        root: CHECKOUT_ROOT,
         processStart: 'Fri Jul 31 19:29:59 2026',
         launchId: '22222222-2222-4222-8222-222222222222',
       }),
@@ -364,17 +359,26 @@ describe('managed launch mode', () => {
   });
 
   it.each([
-    ['stale', { status: 1, stdout: '' }],
-    ['foreign', { status: 0, stdout: '/usr/bin/unrelated-server\n' }],
-  ])('returns the safe dev-only fallback for %s persisted metadata', (_case, psResult) => {
+    ['stale', null],
+    [
+      'foreign',
+      {
+        pid: 8123,
+        ppid: 1,
+        command: '/usr/bin/unrelated-server',
+        cwd: CHECKOUT_ROOT,
+        start: PROCESS_START,
+      },
+    ],
+  ])('returns the safe dev-only fallback for %s persisted metadata', (_case, identity) => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '8123');
-    writeFs(
-      joinPath(stateDir, 'web.json'),
-      JSON.stringify({ pid: 8123, prod: true, tailscale: true, startedAt }),
-    );
-    const exec = vi.fn().mockReturnValue(psResult);
-    expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod: false, tailscale: false });
+    writeVerifiedState(stateDir, { pid: 8123, prod: true, tailscale: true });
+    const inspectProcess = vi.fn().mockReturnValue(identity);
+    expect(getWebLaunchMode({ stateDir, inspectProcess, root: CHECKOUT_ROOT })).toEqual({
+      prod: false,
+      tailscale: false,
+    });
+    expect(inspectProcess).toHaveBeenCalledWith(8123);
   });
 
   it('rejects a launcher from another checkout even when the command and PID look valid', () => {
@@ -386,10 +390,10 @@ describe('managed launch mode', () => {
         pid: 8123,
         prod: true,
         tailscale: true,
-        startedAt,
+        startedAt: STARTED_AT,
         root: '/repo/sur9e',
-        processStart,
-        launchId,
+        processStart: PROCESS_START,
+        launchId: LAUNCH_ID,
       }),
     );
     const exec = vi.fn().mockReturnValue({
@@ -401,7 +405,7 @@ describe('managed launch mode', () => {
       ppid: 1,
       command: 'node /repo/other/scripts/web.mjs',
       cwd: '/repo/other',
-      start: processStart,
+      start: PROCESS_START,
     });
 
     expect(getWebLaunchMode({ stateDir, exec, inspectProcess, root: '/repo/sur9e' })).toEqual({
@@ -419,10 +423,10 @@ describe('managed launch mode', () => {
         pid: 8123,
         prod: true,
         tailscale: true,
-        startedAt,
+        startedAt: STARTED_AT,
         root: '/repo/sur9e',
-        processStart,
-        launchId,
+        processStart: PROCESS_START,
+        launchId: LAUNCH_ID,
       }),
     );
     const inspectProcess = vi.fn().mockReturnValue({
@@ -465,15 +469,15 @@ describe('managed launch mode', () => {
         stateDir,
         env: { TEST_MARKER: 'yes' },
         processImpl,
-        now: () => startedAt,
-        root: checkoutRoot,
-        launchId: () => launchId,
+        now: () => STARTED_AT,
+        root: CHECKOUT_ROOT,
+        launchId: () => LAUNCH_ID,
         inspectProcess: pid => ({
           pid,
           ppid: processImpl.pid,
-          command: `node ${checkoutRoot}/scripts/web.mjs`,
-          cwd: checkoutRoot,
-          start: processStart,
+          command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+          cwd: CHECKOUT_ROOT,
+          start: PROCESS_START,
         }),
       },
     );
@@ -487,7 +491,7 @@ describe('managed launch mode', () => {
         env: {
           TEST_MARKER: 'yes',
           SUR9E_WEB_SKIP_BUILD: '1',
-          SUR9E_WEB_LAUNCH_ID: launchId,
+          SUR9E_WEB_LAUNCH_ID: LAUNCH_ID,
         },
       }),
     );
@@ -495,10 +499,10 @@ describe('managed launch mode', () => {
       pid: child.pid,
       prod: false,
       tailscale: false,
-      startedAt,
-      root: checkoutRoot,
-      processStart,
-      launchId,
+      startedAt: STARTED_AT,
+      root: CHECKOUT_ROOT,
+      processStart: PROCESS_START,
+      launchId: LAUNCH_ID,
     });
     expect(child.unref).toHaveBeenCalledOnce();
     expect(processImpl.on).not.toHaveBeenCalled();
@@ -506,6 +510,50 @@ describe('managed launch mode', () => {
 });
 
 describe('cmdStart — port guard', () => {
+  it('stops an unverified detached launcher and returns a safe failure', async () => {
+    const child = fakeChild(9001);
+    const spawnImpl = vi.fn().mockReturnValue(child);
+    const error = vi.fn();
+
+    const code = await cmdStart(
+      { command: 'start', prod: false, tailscale: false, detach: true },
+      {
+        exec: vi.fn().mockReturnValue({ status: 1, stdout: '' }),
+        spawnImpl,
+        inspectProcess: () => null,
+        error,
+        log: vi.fn(),
+        stateDir: tmpStateDir(),
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(child.unref).toHaveBeenCalledOnce();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/verify.*ownership/i);
+  });
+
+  it('does not spawn a foreground server when launcher ownership cannot be verified', async () => {
+    const spawnImpl = vi.fn();
+    const error = vi.fn();
+
+    const code = await cmdStart(
+      { command: 'start', prod: false, tailscale: false, detach: false },
+      {
+        exec: vi.fn().mockReturnValue({ status: 1, stdout: '' }),
+        spawnImpl,
+        inspectProcess: () => null,
+        error,
+        log: vi.fn(),
+        stateDir: tmpStateDir(),
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(spawnImpl).not.toHaveBeenCalled();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/nothing started/i);
+  });
+
   it('refuses to start when :3000 is already in use and spawns nothing', async () => {
     const exec = vi.fn().mockReturnValue({ status: 0, stdout: 'p1111\ncnode\n' });
     const spawnImpl = vi.fn();
@@ -663,10 +711,10 @@ describe('cmdStatus — verified ownership only', () => {
         pid: 3333,
         prod: true,
         tailscale: true,
-        startedAt: '2026-07-31T18:30:00.000Z',
+        startedAt: STARTED_AT,
         root,
-        processStart: 'Fri Jul 31 18:29:59 2026',
-        launchId: '11111111-1111-4111-8111-111111111111',
+        processStart: PROCESS_START,
+        launchId: LAUNCH_ID,
       }),
     );
     const exec = vi.fn(cmd =>
@@ -695,19 +743,15 @@ describe('cmdStatus — verified ownership only', () => {
 });
 
 describe('cmdStop — never kills foreign processes', () => {
-  const checkoutRoot = '/repo/sur9e';
-  const processStart = 'Fri Jul 31 18:29:59 2026';
-  const launchId = '11111111-1111-4111-8111-111111111111';
-
   function writeManagedState(stateDir, overrides = {}) {
     const meta = {
       pid: 3333,
       prod: false,
       tailscale: false,
-      startedAt: '2026-07-31T18:30:00.000Z',
-      root: checkoutRoot,
-      processStart,
-      launchId,
+      startedAt: STARTED_AT,
+      root: CHECKOUT_ROOT,
+      processStart: PROCESS_START,
+      launchId: LAUNCH_ID,
       ...overrides,
     };
     writeFs(joinPath(stateDir, 'web.pid'), String(meta.pid));
@@ -720,15 +764,15 @@ describe('cmdStop — never kills foreign processes', () => {
     writeManagedState(stateDir);
     const exec = vi.fn((cmd, args) => {
       if (cmd === 'ps' && args?.includes('command=')) {
-        return { status: 0, stdout: `node ${checkoutRoot}/scripts/web.mjs\n` };
+        return { status: 0, stdout: `node ${CHECKOUT_ROOT}/scripts/web.mjs\n` };
       }
       return { status: 1, stdout: '' };
     });
     const inspectProcess = vi.fn().mockReturnValue({
       pid: 3333,
       ppid: 1,
-      command: `node ${checkoutRoot}/scripts/web.mjs`,
-      cwd: checkoutRoot,
+      command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+      cwd: CHECKOUT_ROOT,
       start: 'Sat Aug  1 01:00:00 2026',
     });
     const kill = vi.fn();
@@ -741,7 +785,7 @@ describe('cmdStop — never kills foreign processes', () => {
       error,
       log: vi.fn(),
       stateDir,
-      root: checkoutRoot,
+      root: CHECKOUT_ROOT,
     });
 
     expect(code).toBe(1);
@@ -757,7 +801,7 @@ describe('cmdStop — never kills foreign processes', () => {
       ppid: 1,
       command: 'node /repo/other/scripts/web.mjs',
       cwd: '/repo/other',
-      start: processStart,
+      start: PROCESS_START,
     });
     const kill = vi.fn();
     const error = vi.fn();
@@ -769,7 +813,7 @@ describe('cmdStop — never kills foreign processes', () => {
       error,
       log: vi.fn(),
       stateDir,
-      root: checkoutRoot,
+      root: CHECKOUT_ROOT,
     });
 
     expect(code).toBe(1);
@@ -783,9 +827,9 @@ describe('cmdStop — never kills foreign processes', () => {
     const validIdentity = {
       pid: 3333,
       ppid: 1,
-      command: `node ${checkoutRoot}/scripts/web.mjs`,
-      cwd: checkoutRoot,
-      start: processStart,
+      command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+      cwd: CHECKOUT_ROOT,
+      start: PROCESS_START,
     };
     const inspectProcess = vi
       .fn()
@@ -801,7 +845,7 @@ describe('cmdStop — never kills foreign processes', () => {
       error: vi.fn(),
       log: vi.fn(),
       stateDir,
-      root: checkoutRoot,
+      root: CHECKOUT_ROOT,
     });
 
     expect(code).toBe(1);
@@ -817,9 +861,9 @@ describe('cmdStop — never kills foreign processes', () => {
         {
           pid: 3333,
           ppid: 1,
-          command: `node ${checkoutRoot}/scripts/web.mjs`,
-          cwd: checkoutRoot,
-          start: processStart,
+          command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+          cwd: CHECKOUT_ROOT,
+          start: PROCESS_START,
         },
       ],
       [
@@ -848,7 +892,7 @@ describe('cmdStop — never kills foreign processes', () => {
       error: vi.fn(),
       log: vi.fn(),
       stateDir,
-      root: checkoutRoot,
+      root: CHECKOUT_ROOT,
       termWaitMs: 0,
       killWaitMs: 0,
       pollMs: 0,
@@ -961,7 +1005,10 @@ describe('cmdStop — suspended / wedged servers', () => {
     const stateDir = tmpStateDir();
     writeVerifiedState(stateDir);
     // lsof returns no listener → port is already free, no escalation needed.
-    const exec = vi.fn(cmd => ({ status: cmd === 'ps' ? 0 : 1, stdout: 'node scripts/web.mjs\n' }));
+    const exec = vi.fn(cmd => ({
+      status: cmd === 'ps' ? 0 : 1,
+      stdout: 'node scripts/web.mjs\n',
+    }));
     const kill = vi.fn();
     await cmdStop({
       exec,

--- a/test/web-launcher.test.mjs
+++ b/test/web-launcher.test.mjs
@@ -6,6 +6,7 @@ import { join as joinPath } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   cmdStart,
+  cmdStatus,
   cmdStop,
   enableServe,
   findTailscaleCli,
@@ -21,6 +22,38 @@ function tmpStateDir() {
 
 function readState(stateDir) {
   return JSON.parse(readFileSync(joinPath(stateDir, 'web.json'), 'utf-8'));
+}
+
+const CHECKOUT_ROOT = '/repo/sur9e';
+const PROCESS_START = 'Fri Jul 31 18:29:59 2026';
+const LAUNCH_ID = '11111111-1111-4111-8111-111111111111';
+const STARTED_AT = '2026-07-31T18:30:00.000Z';
+
+function writeVerifiedState(stateDir, overrides = {}) {
+  const meta = {
+    pid: 3333,
+    prod: false,
+    tailscale: false,
+    startedAt: STARTED_AT,
+    root: CHECKOUT_ROOT,
+    processStart: PROCESS_START,
+    launchId: LAUNCH_ID,
+    ...overrides,
+  };
+  writeFs(joinPath(stateDir, 'web.pid'), String(meta.pid));
+  writeFs(joinPath(stateDir, 'web.json'), JSON.stringify(meta));
+  return meta;
+}
+
+function verifiedIdentity(pid = 3333, overrides = {}) {
+  return {
+    pid,
+    ppid: 1,
+    command: `node ${CHECKOUT_ROOT}/scripts/web.mjs`,
+    cwd: CHECKOUT_ROOT,
+    start: PROCESS_START,
+    ...overrides,
+  };
 }
 
 function fakeChild(pid = 7001) {
@@ -215,6 +248,9 @@ describe('enableServe', () => {
 
 describe('managed launch mode', () => {
   const startedAt = '2026-07-31T18:30:00.000Z';
+  const checkoutRoot = '/repo/sur9e';
+  const launchId = '11111111-1111-4111-8111-111111111111';
+  const processStart = 'Fri Jul 31 18:29:59 2026';
 
   function startForeground({ prod = false, tailscale = false } = {}) {
     const stateDir = tmpStateDir();
@@ -250,6 +286,15 @@ describe('managed launch mode', () => {
         env: { SUR9E_WEB_SKIP_BUILD: '1' },
         processImpl,
         now: () => startedAt,
+        root: checkoutRoot,
+        launchId: () => launchId,
+        inspectProcess: pid => ({
+          pid,
+          ppid: 1,
+          command: `node ${checkoutRoot}/scripts/web.mjs`,
+          cwd: checkoutRoot,
+          start: processStart,
+        }),
       },
     );
     return { child, exec, processImpl, spawnImpl, stateDir };
@@ -260,15 +305,29 @@ describe('managed launch mode', () => {
     ['prod', true, false],
     ['prod + tailscale', true, true],
   ])('persists foreground %s metadata for orchestrator readers', (_label, prod, tailscale) => {
-    const { processImpl, stateDir } = startForeground({ prod, tailscale });
+    const { processImpl, spawnImpl, stateDir } = startForeground({ prod, tailscale });
     expect(readFileSync(joinPath(stateDir, 'web.pid'), 'utf-8')).toBe(String(processImpl.pid));
-    expect(readState(stateDir)).toEqual({ pid: processImpl.pid, prod, tailscale, startedAt });
-
-    const exec = vi.fn().mockReturnValue({
-      status: 0,
-      stdout: 'node /repo/scripts/web.mjs\n',
+    expect(readState(stateDir)).toEqual({
+      pid: processImpl.pid,
+      prod,
+      tailscale,
+      startedAt,
+      root: checkoutRoot,
+      processStart,
+      launchId,
     });
-    expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod, tailscale });
+
+    expect(spawnImpl.mock.calls[0][2].env).toMatchObject({
+      SUR9E_WEB_LAUNCH_ID: launchId,
+    });
+
+    expect(
+      getWebLaunchMode({
+        stateDir,
+        inspectProcess: pid => verifiedIdentity(pid),
+        root: checkoutRoot,
+      }),
+    ).toEqual({ prod, tailscale });
   });
 
   it('clears foreground state after signal-driven clean child exit', () => {
@@ -284,15 +343,23 @@ describe('managed launch mode', () => {
 
   it('does not clear state replaced by a different launcher before its child exits', () => {
     const { child, processImpl, stateDir } = startForeground({ prod: true });
-    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(joinPath(stateDir, 'web.pid'), String(processImpl.pid));
     writeFs(
       joinPath(stateDir, 'web.json'),
-      JSON.stringify({ pid: 8123, prod: false, tailscale: true, startedAt: 'later' }),
+      JSON.stringify({
+        pid: processImpl.pid,
+        prod: false,
+        tailscale: true,
+        startedAt: '2026-07-31T19:30:00.000Z',
+        root: checkoutRoot,
+        processStart: 'Fri Jul 31 19:29:59 2026',
+        launchId: '22222222-2222-4222-8222-222222222222',
+      }),
     );
 
     child.emit('exit', 1);
-    expect(readFileSync(joinPath(stateDir, 'web.pid'), 'utf-8')).toBe('8123');
-    expect(readState(stateDir).pid).toBe(8123);
+    expect(readFileSync(joinPath(stateDir, 'web.pid'), 'utf-8')).toBe(String(processImpl.pid));
+    expect(readState(stateDir).launchId).toBe('22222222-2222-4222-8222-222222222222');
     expect(processImpl.exit).toHaveBeenCalledWith(1);
   });
 
@@ -308,6 +375,68 @@ describe('managed launch mode', () => {
     );
     const exec = vi.fn().mockReturnValue(psResult);
     expect(getWebLaunchMode({ stateDir, exec })).toEqual({ prod: false, tailscale: false });
+  });
+
+  it('rejects a launcher from another checkout even when the command and PID look valid', () => {
+    const stateDir = tmpStateDir();
+    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(
+      joinPath(stateDir, 'web.json'),
+      JSON.stringify({
+        pid: 8123,
+        prod: true,
+        tailscale: true,
+        startedAt,
+        root: '/repo/sur9e',
+        processStart,
+        launchId,
+      }),
+    );
+    const exec = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: 'node /repo/sur9e/scripts/web.mjs\n',
+    });
+    const inspectProcess = vi.fn().mockReturnValue({
+      pid: 8123,
+      ppid: 1,
+      command: 'node /repo/other/scripts/web.mjs',
+      cwd: '/repo/other',
+      start: processStart,
+    });
+
+    expect(getWebLaunchMode({ stateDir, exec, inspectProcess, root: '/repo/sur9e' })).toEqual({
+      prod: false,
+      tailscale: false,
+    });
+  });
+
+  it('rejects a reused PID whose process start identity no longer matches', () => {
+    const stateDir = tmpStateDir();
+    writeFs(joinPath(stateDir, 'web.pid'), '8123');
+    writeFs(
+      joinPath(stateDir, 'web.json'),
+      JSON.stringify({
+        pid: 8123,
+        prod: true,
+        tailscale: true,
+        startedAt,
+        root: '/repo/sur9e',
+        processStart,
+        launchId,
+      }),
+    );
+    const inspectProcess = vi.fn().mockReturnValue({
+      pid: 8123,
+      ppid: 1,
+      command: 'node /repo/sur9e/scripts/web.mjs',
+      cwd: '/repo/sur9e',
+      start: 'Sat Aug  1 01:00:00 2026',
+    });
+
+    expect(getWebLaunchMode({ stateDir, inspectProcess, root: '/repo/sur9e' })).toEqual({
+      prod: false,
+      tailscale: false,
+    });
   });
 
   it('returns the safe dev-only fallback for malformed persisted state', () => {
@@ -337,6 +466,15 @@ describe('managed launch mode', () => {
         env: { TEST_MARKER: 'yes' },
         processImpl,
         now: () => startedAt,
+        root: checkoutRoot,
+        launchId: () => launchId,
+        inspectProcess: pid => ({
+          pid,
+          ppid: processImpl.pid,
+          command: `node ${checkoutRoot}/scripts/web.mjs`,
+          cwd: checkoutRoot,
+          start: processStart,
+        }),
       },
     );
 
@@ -346,7 +484,11 @@ describe('managed launch mode', () => {
       [expect.stringMatching(/scripts\/web\.mjs$/)],
       expect.objectContaining({
         detached: true,
-        env: { TEST_MARKER: 'yes', SUR9E_WEB_SKIP_BUILD: '1' },
+        env: {
+          TEST_MARKER: 'yes',
+          SUR9E_WEB_SKIP_BUILD: '1',
+          SUR9E_WEB_LAUNCH_ID: launchId,
+        },
       }),
     );
     expect(readState(stateDir)).toEqual({
@@ -354,6 +496,9 @@ describe('managed launch mode', () => {
       prod: false,
       tailscale: false,
       startedAt,
+      root: checkoutRoot,
+      processStart,
+      launchId,
     });
     expect(child.unref).toHaveBeenCalledOnce();
     expect(processImpl.on).not.toHaveBeenCalled();
@@ -392,7 +537,15 @@ describe('cmdStart — port guard', () => {
       const spawnImpl = vi.fn().mockReturnValue({ kill: vi.fn(), on: vi.fn() });
       void cmdStart(
         { command: 'start', prod: false, tailscale: true, detach: false },
-        { exec, spawnImpl, error: vi.fn(), log: vi.fn(), stateDir: tmpStateDir() },
+        {
+          exec,
+          spawnImpl,
+          error: vi.fn(),
+          log: vi.fn(),
+          stateDir: tmpStateDir(),
+          root: CHECKOUT_ROOT,
+          inspectProcess: pid => verifiedIdentity(pid),
+        },
       );
       expect(spawnImpl).toHaveBeenCalledTimes(1);
       const opts = spawnImpl.mock.calls[0][2];
@@ -418,7 +571,15 @@ describe('cmdStart — port guard', () => {
       // synchronously before the first await, so the assertion is safe.
       void cmdStart(
         { command: 'start', prod: false, tailscale: false, detach: false },
-        { exec, spawnImpl, error: vi.fn(), log: vi.fn(), stateDir: tmpStateDir() },
+        {
+          exec,
+          spawnImpl,
+          error: vi.fn(),
+          log: vi.fn(),
+          stateDir: tmpStateDir(),
+          root: CHECKOUT_ROOT,
+          inspectProcess: pid => verifiedIdentity(pid),
+        },
       );
       expect(spawnImpl).toHaveBeenCalledTimes(1);
       const [bin, args] = spawnImpl.mock.calls[0];
@@ -433,7 +594,212 @@ describe('cmdStart — port guard', () => {
   });
 });
 
+describe('cmdStatus — verified ownership only', () => {
+  it('does not report reused launcher metadata as managed or expose its tailscale mode', () => {
+    const stateDir = tmpStateDir();
+    const root = '/repo/sur9e';
+    writeFs(joinPath(stateDir, 'web.pid'), '3333');
+    writeFs(
+      joinPath(stateDir, 'web.json'),
+      JSON.stringify({
+        pid: 3333,
+        prod: true,
+        tailscale: true,
+        startedAt: '2026-07-31T18:30:00.000Z',
+        root,
+        processStart: 'Fri Jul 31 18:29:59 2026',
+        launchId: '11111111-1111-4111-8111-111111111111',
+      }),
+    );
+    const exec = vi.fn(cmd =>
+      cmd === 'lsof' ? { status: 0, stdout: 'p9999\ncnode\n' } : { status: 1, stdout: '' },
+    );
+    const log = vi.fn();
+
+    expect(
+      cmdStatus({
+        exec,
+        inspectProcess: () => ({
+          pid: 3333,
+          ppid: 1,
+          command: `node ${root}/scripts/web.mjs`,
+          cwd: root,
+          start: 'Sat Aug  1 01:00:00 2026',
+        }),
+        log,
+        root,
+        stateDir,
+      }),
+    ).toBe(0);
+    expect(log.mock.calls.flat().join('\n')).toMatch(/not managed/i);
+    expect(log.mock.calls.flat().join('\n')).not.toMatch(/tailnet/i);
+  });
+});
+
 describe('cmdStop — never kills foreign processes', () => {
+  const checkoutRoot = '/repo/sur9e';
+  const processStart = 'Fri Jul 31 18:29:59 2026';
+  const launchId = '11111111-1111-4111-8111-111111111111';
+
+  function writeManagedState(stateDir, overrides = {}) {
+    const meta = {
+      pid: 3333,
+      prod: false,
+      tailscale: false,
+      startedAt: '2026-07-31T18:30:00.000Z',
+      root: checkoutRoot,
+      processStart,
+      launchId,
+      ...overrides,
+    };
+    writeFs(joinPath(stateDir, 'web.pid'), String(meta.pid));
+    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify(meta));
+    return meta;
+  }
+
+  it('refuses a reused managed PID before sending any signal', async () => {
+    const stateDir = tmpStateDir();
+    writeManagedState(stateDir);
+    const exec = vi.fn((cmd, args) => {
+      if (cmd === 'ps' && args?.includes('command=')) {
+        return { status: 0, stdout: `node ${checkoutRoot}/scripts/web.mjs\n` };
+      }
+      return { status: 1, stdout: '' };
+    });
+    const inspectProcess = vi.fn().mockReturnValue({
+      pid: 3333,
+      ppid: 1,
+      command: `node ${checkoutRoot}/scripts/web.mjs`,
+      cwd: checkoutRoot,
+      start: 'Sat Aug  1 01:00:00 2026',
+    });
+    const kill = vi.fn();
+    const error = vi.fn();
+
+    const code = await cmdStop({
+      exec,
+      inspectProcess,
+      kill,
+      error,
+      log: vi.fn(),
+      stateDir,
+      root: checkoutRoot,
+    });
+
+    expect(code).toBe(1);
+    expect(kill).not.toHaveBeenCalled();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/ownership.*not killing/i);
+  });
+
+  it('refuses a launcher owned by another checkout before sending any signal', async () => {
+    const stateDir = tmpStateDir();
+    writeManagedState(stateDir);
+    const inspectProcess = vi.fn().mockReturnValue({
+      pid: 3333,
+      ppid: 1,
+      command: 'node /repo/other/scripts/web.mjs',
+      cwd: '/repo/other',
+      start: processStart,
+    });
+    const kill = vi.fn();
+    const error = vi.fn();
+
+    const code = await cmdStop({
+      exec: vi.fn().mockReturnValue({ status: 0, stdout: 'node scripts/web.mjs\n' }),
+      inspectProcess,
+      kill,
+      error,
+      log: vi.fn(),
+      stateDir,
+      root: checkoutRoot,
+    });
+
+    expect(code).toBe(1);
+    expect(kill).not.toHaveBeenCalled();
+    expect(error.mock.calls.flat().join('\n')).toMatch(/ownership.*not killing/i);
+  });
+
+  it('rechecks managed ownership immediately before each signal', async () => {
+    const stateDir = tmpStateDir();
+    writeManagedState(stateDir);
+    const validIdentity = {
+      pid: 3333,
+      ppid: 1,
+      command: `node ${checkoutRoot}/scripts/web.mjs`,
+      cwd: checkoutRoot,
+      start: processStart,
+    };
+    const inspectProcess = vi
+      .fn()
+      .mockReturnValueOnce(validIdentity)
+      .mockReturnValueOnce(validIdentity)
+      .mockReturnValue({ ...validIdentity, start: 'Sat Aug  1 01:00:00 2026' });
+    const kill = vi.fn();
+
+    const code = await cmdStop({
+      exec: vi.fn().mockReturnValue({ status: 1, stdout: '' }),
+      inspectProcess,
+      kill,
+      error: vi.fn(),
+      log: vi.fn(),
+      stateDir,
+      root: checkoutRoot,
+    });
+
+    expect(code).toBe(1);
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('never signals a foreign listener that takes or holds port 3000 during escalation', async () => {
+    const stateDir = tmpStateDir();
+    writeManagedState(stateDir);
+    const identities = new Map([
+      [
+        3333,
+        {
+          pid: 3333,
+          ppid: 1,
+          command: `node ${checkoutRoot}/scripts/web.mjs`,
+          cwd: checkoutRoot,
+          start: processStart,
+        },
+      ],
+      [
+        9999,
+        {
+          pid: 9999,
+          ppid: 1,
+          command: '/usr/local/bin/foreign-server',
+          cwd: '/repo/foreign',
+          start: 'Sat Aug  1 01:00:00 2026',
+        },
+      ],
+    ]);
+    const inspectProcess = vi.fn(pid => identities.get(pid) ?? null);
+    const exec = vi.fn(cmd =>
+      cmd === 'lsof'
+        ? { status: 0, stdout: 'p9999\ncforeign-server\n' }
+        : { status: 1, stdout: '' },
+    );
+    const kill = vi.fn();
+
+    const code = await cmdStop({
+      exec,
+      inspectProcess,
+      kill,
+      error: vi.fn(),
+      log: vi.fn(),
+      stateDir,
+      root: checkoutRoot,
+      termWaitMs: 0,
+      killWaitMs: 0,
+      pollMs: 0,
+    });
+
+    expect(code).toBe(1);
+    expect(kill).not.toHaveBeenCalledWith(9999, expect.anything());
+  });
+
   it('refuses when the PID file process is not our launcher', () => {
     const stateDir = tmpStateDir();
     writeFs(joinPath(stateDir, 'web.pid'), '2222');
@@ -453,8 +819,7 @@ describe('cmdStop — never kills foreign processes', () => {
 
   it('kills a live managed launcher and resets tailscale serve when we enabled it', async () => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '3333');
-    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify({ prod: true, tailscale: true }));
+    writeVerifiedState(stateDir, { prod: true, tailscale: true });
     const calls = [];
     const exec = vi.fn((cmd, args) => {
       calls.push([cmd, ...(args ?? [])].join(' '));
@@ -463,7 +828,15 @@ describe('cmdStop — never kills foreign processes', () => {
       return { status: 0, stdout: '' };
     });
     const kill = vi.fn();
-    await cmdStop({ exec, kill, error: vi.fn(), log: vi.fn(), stateDir });
+    await cmdStop({
+      exec,
+      inspectProcess: pid => verifiedIdentity(pid),
+      kill,
+      error: vi.fn(),
+      log: vi.fn(),
+      root: CHECKOUT_ROOT,
+      stateDir,
+    });
     expect(kill).toHaveBeenCalledWith(3333, 'SIGTERM');
     expect(calls.some(c => c.includes('serve reset'))).toBe(true);
     // State files must be gone after a successful stop.
@@ -473,8 +846,7 @@ describe('cmdStop — never kills foreign processes', () => {
 
   it('waits for the :3000 listener to clear after killing — stop && start must not race', async () => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '3333');
-    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify({ prod: false, tailscale: false }));
+    writeVerifiedState(stateDir);
     // The next-server child holds the port for the first two lsof polls
     // after SIGTERM, then releases it.
     let lsofCalls = 0;
@@ -486,7 +858,15 @@ describe('cmdStop — never kills foreign processes', () => {
           : { status: 1, stdout: '' };
       return { status: 1, stdout: '' };
     });
-    await cmdStop({ exec, kill: vi.fn(), error: vi.fn(), log: vi.fn(), stateDir });
+    await cmdStop({
+      exec,
+      inspectProcess: pid => verifiedIdentity(pid),
+      kill: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      root: CHECKOUT_ROOT,
+      stateDir,
+    });
     expect(lsofCalls).toBeGreaterThanOrEqual(3); // polled until the port was free
   });
 
@@ -521,20 +901,26 @@ describe('cmdStop — never kills foreign processes', () => {
 describe('cmdStop — suspended / wedged servers', () => {
   it('resumes a suspended tree (SIGCONT) before asking it to exit (SIGTERM)', async () => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '3333');
-    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify({ prod: false, tailscale: false }));
+    writeVerifiedState(stateDir);
     // lsof returns no listener → port is already free, no escalation needed.
     const exec = vi.fn(cmd => ({ status: cmd === 'ps' ? 0 : 1, stdout: 'node scripts/web.mjs\n' }));
     const kill = vi.fn();
-    await cmdStop({ exec, kill, error: vi.fn(), log: vi.fn(), stateDir });
+    await cmdStop({
+      exec,
+      inspectProcess: pid => verifiedIdentity(pid),
+      kill,
+      error: vi.fn(),
+      log: vi.fn(),
+      root: CHECKOUT_ROOT,
+      stateDir,
+    });
     const signals = kill.mock.calls.filter(c => c[0] === 3333).map(c => c[1]);
     expect(signals.slice(0, 2)).toEqual(['SIGCONT', 'SIGTERM']); // resume, then terminate
   });
 
   it('escalates to SIGKILL (launcher + actual port holder) when SIGTERM does not free :3000', async () => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '3333');
-    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify({ prod: false, tailscale: false }));
+    writeVerifiedState(stateDir);
     let sigkilled = false;
     const kill = vi.fn((_pid, sig) => {
       if (sig === 'SIGKILL') sigkilled = true;
@@ -549,10 +935,15 @@ describe('cmdStop — suspended / wedged servers', () => {
     const error = vi.fn();
     const code = await cmdStop({
       exec,
+      inspectProcess: pid =>
+        pid === 9999
+          ? verifiedIdentity(9999, { ppid: 3333, command: 'next-server' })
+          : verifiedIdentity(pid),
       kill,
       error,
       log: vi.fn(),
       stateDir,
+      root: CHECKOUT_ROOT,
       termWaitMs: 60,
       killWaitMs: 300,
       pollMs: 10,
@@ -566,8 +957,7 @@ describe('cmdStop — suspended / wedged servers', () => {
 
   it('reports failure honestly and KEEPS state when :3000 will not free even after SIGKILL', async () => {
     const stateDir = tmpStateDir();
-    writeFs(joinPath(stateDir, 'web.pid'), '3333');
-    writeFs(joinPath(stateDir, 'web.json'), JSON.stringify({ prod: false, tailscale: false }));
+    writeVerifiedState(stateDir);
     const exec = vi.fn(cmd => {
       if (cmd === 'ps') return { status: 0, stdout: 'node scripts/web.mjs\n' };
       if (cmd === 'lsof') return { status: 0, stdout: 'p9999\ncnode\n' }; // never clears
@@ -576,10 +966,15 @@ describe('cmdStop — suspended / wedged servers', () => {
     const error = vi.fn();
     const code = await cmdStop({
       exec,
+      inspectProcess: pid =>
+        pid === 9999
+          ? verifiedIdentity(9999, { ppid: 3333, command: 'next-server' })
+          : verifiedIdentity(pid),
       kill: vi.fn(),
       error,
       log: vi.fn(),
       stateDir,
+      root: CHECKOUT_ROOT,
       termWaitMs: 40,
       killWaitMs: 40,
       pollMs: 10,
@@ -591,7 +986,7 @@ describe('cmdStop — suspended / wedged servers', () => {
     expect(existsSync(joinPath(stateDir, 'web.pid'))).toBe(true);
   });
 
-  it("kills an untracked foreground dev server (Ctrl-Z'd `npm run web`) identified by its command", async () => {
+  it('refuses an untracked foreground dev server because no persisted ownership can be proved', async () => {
     const stateDir = tmpStateDir(); // foreground start writes no state file
     const root = '/repo/sur9e';
     let groupKilled = false;
@@ -615,20 +1010,21 @@ describe('cmdStop — suspended / wedged servers', () => {
       return { status: 1, stdout: '' };
     });
     const log = vi.fn();
+    const error = vi.fn();
     const code = await cmdStop({
       exec,
       kill,
-      error: vi.fn(),
+      error,
       log,
       stateDir,
       root,
       killWaitMs: 300,
       pollMs: 10,
     });
-    expect(kill).toHaveBeenCalledWith(77001, 'SIGCONT'); // resume the suspended tree
-    expect(kill).toHaveBeenCalledWith(-77000, 'SIGKILL'); // kill the whole process group
-    expect(code).toBe(0);
-    expect(log.mock.calls.flat().join('\n')).toMatch(/untracked sur9e dev server/i);
+    expect(kill).not.toHaveBeenCalled();
+    expect(code).toBe(1);
+    expect(log).not.toHaveBeenCalledWith(expect.stringMatching(/stopped/i));
+    expect(error.mock.calls.flat().join('\n')).toMatch(/not killing/i);
   });
 
   it('refuses (kill -9 hint, exit 1) a foreign listener that is NOT a sur9e server', async () => {
@@ -639,6 +1035,8 @@ describe('cmdStop — suspended / wedged servers', () => {
     const error = vi.fn();
     const code = await cmdStop({ exec, kill: vi.fn(), error, log: vi.fn(), stateDir });
     expect(code).toBe(1);
-    expect(error.mock.calls.flat().join('\n')).toMatch(/not a sur9e server.*kill -9 91548/s);
+    expect(error.mock.calls.flat().join('\n')).toMatch(
+      /no verified sur9e launch metadata.*not killing.*kill -9 91548/s,
+    );
   });
 });


### PR DESCRIPTION
## What changed

- add a Settings update flow that pulls the configured GitHub source and branch
- preserve protected user data while rebuilding and restarting the active local or Tailscale server
- restore the exact browser URL after restart downtime
- persist durable update jobs with ownership locks, interrupted-restart recovery, rollback, and stale-worker reconciliation
- align Check, Edit/Done, Update, and Roll back controls with shared Settings button sizing

## Why

Self-hosted users need a safe one-click update path that survives process restarts without losing their place or touching personal data.

## Validation

- full quick gate: 100 checks passed
- production build passed
- 5 Playwright update flows passed, including restart downtime and automatic rollback notice
- visually inspected 1280x800, 768x1024, and 375x667 Settings screenshots