### PR TITLE
test(update): follow release version metadata

### DIFF
--- a/src/app/api/update/apply/__tests__/route.test.ts
+++ b/src/app/api/update/apply/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UpdateJob } from '@/lib/schemas/update-job';
 import type { StartUpdateJobResult } from '@/lib/server/update-orchestrator';
+import packageJson from '../../../../../../package.json';
 
 const mocks = vi.hoisted(() => ({
   getWebLaunchMode: vi.fn(),
@@ -29,7 +30,7 @@ function job(overrides: Partial<UpdateJob> = {}): UpdateJob {
     phase: 'queued',
     launchState: 'claim-pending',
     mode: { prod: false, tailscale: false },
-    fromVersion: '0.3.2',
+    fromVersion: packageJson.version,
     createdAt: '2026-07-31T20:00:00.000Z',
     updatedAt: '2026-07-31T20:00:00.000Z',
     ...overrides,
@@ -72,7 +73,7 @@ describe('POST /api/update/apply', () => {
     expect(mocks.startUpdateJob).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        fromVersion: '0.3.2',
+        fromVersion: packageJson.version,
         mode: { prod: false, tailscale: false },
       }),
     );


### PR DESCRIPTION
## What changed

- derive the update-route expectation from package metadata instead of hardcoding v0.3.2
- keep the mock durable job aligned with the version the route actually forwards

## Why

Release Please updates package metadata to v0.4.0 on the release PR. The hardcoded assertion made the release branch fail even though the route behaved correctly.

## Validation

- targeted update apply route: 17 tests passed
- full pre-commit quick gate passed on retry: 100 checks passed, 2,939 Vitest tests passed