### PR TITLE
docs(contributing): clarify pull request scope

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,14 @@
 
 <!-- Describe the user-facing or technical change and why it is needed. -->
 
+## PR scope
+
+<!-- State the one primary outcome. Explain why any secondary changes must ship with it. -->
+
+- [ ] This PR has one independently reviewable and revertible outcome
+- [ ] Included refactoring is required for that outcome
+- [ ] Unrelated features, refactors, and fixes were moved to separate PRs
+
 ## Validation checklist
 
 - [ ] `npm run test:quick`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,8 +139,9 @@ Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.m
 in full. Treat each pull request as the unit of history because this repository
 squash-merges: one independently reviewable outcome per PR, with its required
 implementation, tests, documentation, and tightly coupled refactoring together.
-Publish each completed independent PR promptly. `CONTRIBUTING.md` is the source
-of truth for scope decisions, split examples, commit style, and review expectations.
+After explicit authorization to push and open PRs, publish each completed
+independent PR promptly. `CONTRIBUTING.md` is the source of truth for scope
+decisions, split examples, commit style, and review expectations.
 
 1. **Branch from current `main`.** Fetch first, then use a short-lived branch or
    isolated worktree. Never commit or push implementation work directly to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,9 @@ weekly npm and GitHub Actions PRs; never auto-merge them. See
 
 ## Development and release lifecycle
 
-Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
-in full. Treat each pull request as the unit of history because this repository
+Before implementing, committing, pushing, or opening a PR for a repository
+change, read [`CONTRIBUTING.md`](CONTRIBUTING.md) in full. Treat each pull request
+as the unit of history because this repository
 squash-merges: one independently reviewable outcome per PR, with its required
 implementation, tests, documentation, and tightly coupled refactoring together.
 After explicit authorization to push and open PRs, publish each completed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ tracks every application — all on your machine.
 **Mission:** quality over quantity. AI gives the job-seeker velocity and
 clarity, never shortcuts — sur9e will never auto-submit an application.
 
-This file is both the **operating manual for the AI agent** (the agent IS the
-CLI — read this on every session) and the **orientation doc for contributors**.
-The same content lives in `AGENTS.md` for non-Claude agents; keep the two files
-in sync when editing either.
+This file is the **operating manual for the AI agent** (the agent IS the CLI —
+read this on every session). The detailed human-and-agent contribution workflow
+lives in [`CONTRIBUTING.md`](CONTRIBUTING.md). This operating manual is stored as
+both `CLAUDE.md` and `AGENTS.md`; keep those files byte-identical.
 
 **Honesty rule:** never hallucinate. If unsure, state uncertainty. Say "I don't
 know" rather than guess.
@@ -26,6 +26,7 @@ know" rather than guess.
 | Architecture (system flow)     | [`docs/architecture.md`](docs/architecture.md)                    |
 | Setup & prerequisites          | [`docs/setup.md`](docs/setup.md)                                  |
 | Personalization guide          | [`docs/customization.md`](docs/customization.md)                  |
+| Contribution workflow          | [`CONTRIBUTING.md`](CONTRIBUTING.md)                              |
 | Releases & repo automation     | [`docs/releasing.md`](docs/releasing.md)                          |
 | Bugs / feature requests        | GitHub Issues in this repo                                        |
 | Your CV                        | `inputs/personalization/cv.md` (gitignored)                       |
@@ -134,13 +135,12 @@ weekly npm and GitHub Actions PRs; never auto-merge them. See
 
 ## Development and release lifecycle
 
-Treat each pull request as the unit of history because this repository squash-merges.
-Split independent features and fixes into separate, logically scoped PRs; keep one
-behavior's implementation, tests, and documentation together. Avoid both catch-all
-PRs that hide multiple changes behind one title and noisy micro-PRs that separate
-tightly coupled work. Publish each completed, independently reviewable PR as soon as
-it is ready instead of stockpiling finished PRs for a bulk push. A dependent PR may
-wait only until its base change is merged.
+Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
+in full. Treat each pull request as the unit of history because this repository
+squash-merges: one independently reviewable outcome per PR, with its required
+implementation, tests, documentation, and tightly coupled refactoring together.
+Publish each completed independent PR promptly. `CONTRIBUTING.md` is the source
+of truth for scope decisions, split examples, commit style, and review expectations.
 
 1. **Branch from current `main`.** Fetch first, then use a short-lived branch or
    isolated worktree. Never commit or push implementation work directly to
@@ -207,40 +207,11 @@ wait only until its base change is merged.
 
 ## Contributing (humans and AI agents)
 
-sur9e is built largely with AI coding agents, and AI-assisted contributions
-are welcome. The rules:
-
-- **You own what you submit.** Review and understand every AI-generated line
-  before opening a PR. "The agent wrote it" is not a review.
-- **Run the gates.** `npm run test:quick` and `npm run build` must pass before a
-  PR. New behavior needs tests; behavior-preserving refactors must prove nothing
-  changed (existing tests pass unmodified).
-- **Protect the user-data boundary.** `src/lib/repo-path-policy.mjs` is the
-  executable source of truth shared by updates and CI. Protected paths must
-  never be tracked or used as test fixtures; only its enumerated scaffolding is
-  exempt. Keep the policy, [`docs/data-contract.md`](docs/data-contract.md), and
-  their tests aligned.
-- **Use Conventional Commit PR titles.** Format:
-  `<type>(<optional-scope>)!?: <description>`; allowed types are `feat`, `fix`,
-  `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, and `revert`.
-- **Use squash merges only.** The validated PR title must become the squash
-  commit's Conventional header; only GitHub's ` (#<number>)` suffix is allowed.
-  Keep the squash body blank so internal commit messages cannot affect Release
-  Please. Remote enforcement is a maintainer prerequisite; do not assume it is
-  enabled until the GitHub settings are verified.
-- **Leave releases to Release Please.** Ordinary PRs must not manually edit
-  generated release metadata. Maintainers follow
-  [`docs/releasing.md`](docs/releasing.md).
-- **Match the existing patterns** (see Critical rules above) instead of
-  introducing parallel ones. One source of truth per concern.
-- **No auto-submit features, ever.** PRs that automate the final
-  Submit/Send/Apply step of a job application will be rejected — this is a
-  product principle, not a style preference.
-- **Accessibility is part of done.** Keyboard navigation, labels, and focus
-  management ship with the feature, not after it.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow and
-[`SECURITY.md`](SECURITY.md) for the security posture.
+Humans and AI agents follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor
+ownership, PR scope, commit and PR style, validation, review, and AI-disclosure
+requirements. The Critical rules and lifecycle gates in this manual remain
+mandatory. Release work additionally follows [`docs/releasing.md`](docs/releasing.md),
+and security-sensitive work follows [`SECURITY.md`](SECURITY.md).
 
 ## Update check protocol
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,9 @@ Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.m
 in full. Treat each pull request as the unit of history because this repository
 squash-merges: one independently reviewable outcome per PR, with its required
 implementation, tests, documentation, and tightly coupled refactoring together.
-Publish each completed independent PR promptly. `CONTRIBUTING.md` is the source
-of truth for scope decisions, split examples, commit style, and review expectations.
+After explicit authorization to push and open PRs, publish each completed
+independent PR promptly. `CONTRIBUTING.md` is the source of truth for scope
+decisions, split examples, commit style, and review expectations.
 
 1. **Branch from current `main`.** Fetch first, then use a short-lived branch or
    isolated worktree. Never commit or push implementation work directly to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,9 @@ weekly npm and GitHub Actions PRs; never auto-merge them. See
 
 ## Development and release lifecycle
 
-Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
-in full. Treat each pull request as the unit of history because this repository
+Before implementing, committing, pushing, or opening a PR for a repository
+change, read [`CONTRIBUTING.md`](CONTRIBUTING.md) in full. Treat each pull request
+as the unit of history because this repository
 squash-merges: one independently reviewable outcome per PR, with its required
 implementation, tests, documentation, and tightly coupled refactoring together.
 After explicit authorization to push and open PRs, publish each completed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,10 @@ tracks every application — all on your machine.
 **Mission:** quality over quantity. AI gives the job-seeker velocity and
 clarity, never shortcuts — sur9e will never auto-submit an application.
 
-This file is both the **operating manual for the AI agent** (the agent IS the
-CLI — read this on every session) and the **orientation doc for contributors**.
-The same content lives in `AGENTS.md` for non-Claude agents; keep the two files
-in sync when editing either.
+This file is the **operating manual for the AI agent** (the agent IS the CLI —
+read this on every session). The detailed human-and-agent contribution workflow
+lives in [`CONTRIBUTING.md`](CONTRIBUTING.md). This operating manual is stored as
+both `CLAUDE.md` and `AGENTS.md`; keep those files byte-identical.
 
 **Honesty rule:** never hallucinate. If unsure, state uncertainty. Say "I don't
 know" rather than guess.
@@ -26,6 +26,7 @@ know" rather than guess.
 | Architecture (system flow)     | [`docs/architecture.md`](docs/architecture.md)                    |
 | Setup & prerequisites          | [`docs/setup.md`](docs/setup.md)                                  |
 | Personalization guide          | [`docs/customization.md`](docs/customization.md)                  |
+| Contribution workflow          | [`CONTRIBUTING.md`](CONTRIBUTING.md)                              |
 | Releases & repo automation     | [`docs/releasing.md`](docs/releasing.md)                          |
 | Bugs / feature requests        | GitHub Issues in this repo                                        |
 | Your CV                        | `inputs/personalization/cv.md` (gitignored)                       |
@@ -134,13 +135,12 @@ weekly npm and GitHub Actions PRs; never auto-merge them. See
 
 ## Development and release lifecycle
 
-Treat each pull request as the unit of history because this repository squash-merges.
-Split independent features and fixes into separate, logically scoped PRs; keep one
-behavior's implementation, tests, and documentation together. Avoid both catch-all
-PRs that hide multiple changes behind one title and noisy micro-PRs that separate
-tightly coupled work. Publish each completed, independently reviewable PR as soon as
-it is ready instead of stockpiling finished PRs for a bulk push. A dependent PR may
-wait only until its base change is merged.
+Before implementing a repository change, read [`CONTRIBUTING.md`](CONTRIBUTING.md)
+in full. Treat each pull request as the unit of history because this repository
+squash-merges: one independently reviewable outcome per PR, with its required
+implementation, tests, documentation, and tightly coupled refactoring together.
+Publish each completed independent PR promptly. `CONTRIBUTING.md` is the source
+of truth for scope decisions, split examples, commit style, and review expectations.
 
 1. **Branch from current `main`.** Fetch first, then use a short-lived branch or
    isolated worktree. Never commit or push implementation work directly to
@@ -207,40 +207,11 @@ wait only until its base change is merged.
 
 ## Contributing (humans and AI agents)
 
-sur9e is built largely with AI coding agents, and AI-assisted contributions
-are welcome. The rules:
-
-- **You own what you submit.** Review and understand every AI-generated line
-  before opening a PR. "The agent wrote it" is not a review.
-- **Run the gates.** `npm run test:quick` and `npm run build` must pass before a
-  PR. New behavior needs tests; behavior-preserving refactors must prove nothing
-  changed (existing tests pass unmodified).
-- **Protect the user-data boundary.** `src/lib/repo-path-policy.mjs` is the
-  executable source of truth shared by updates and CI. Protected paths must
-  never be tracked or used as test fixtures; only its enumerated scaffolding is
-  exempt. Keep the policy, [`docs/data-contract.md`](docs/data-contract.md), and
-  their tests aligned.
-- **Use Conventional Commit PR titles.** Format:
-  `<type>(<optional-scope>)!?: <description>`; allowed types are `feat`, `fix`,
-  `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, and `revert`.
-- **Use squash merges only.** The validated PR title must become the squash
-  commit's Conventional header; only GitHub's ` (#<number>)` suffix is allowed.
-  Keep the squash body blank so internal commit messages cannot affect Release
-  Please. Remote enforcement is a maintainer prerequisite; do not assume it is
-  enabled until the GitHub settings are verified.
-- **Leave releases to Release Please.** Ordinary PRs must not manually edit
-  generated release metadata. Maintainers follow
-  [`docs/releasing.md`](docs/releasing.md).
-- **Match the existing patterns** (see Critical rules above) instead of
-  introducing parallel ones. One source of truth per concern.
-- **No auto-submit features, ever.** PRs that automate the final
-  Submit/Send/Apply step of a job application will be rejected — this is a
-  product principle, not a style preference.
-- **Accessibility is part of done.** Keyboard navigation, labels, and focus
-  management ship with the feature, not after it.
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow and
-[`SECURITY.md`](SECURITY.md) for the security posture.
+Humans and AI agents follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor
+ownership, PR scope, commit and PR style, validation, review, and AI-disclosure
+requirements. The Critical rules and lifecycle gates in this manual remain
+mandatory. Release work additionally follows [`docs/releasing.md`](docs/releasing.md),
+and security-sensitive work follows [`SECURITY.md`](SECURITY.md).
 
 ## Update check protocol
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,10 @@ Each PR must deliver one independently reviewable and revertible outcome:
   them would leave the feature incomplete or unsafe.
 - Group fixes that share a root cause or component; do not create a micro-PR for
   every line. Avoid both catch-all PRs and artificial fragmentation.
-- Open each completed, independent PR promptly instead of stockpiling several
-  finished changes for one bulk push. Base dependent work on updated `main`
-  after its prerequisite merges rather than opening a stack where practical.
+- AI agents must obtain explicit authorization before pushing or opening a PR.
+  Once authorized, open each completed, independent PR promptly instead of
+  stockpiling finished changes for one bulk push. Base dependent work on updated
+  `main` after its prerequisite merges rather than opening a stack where practical.
 - If a branch already mixes independent work, split it before detailed review.
   For example, submit an independent feature, an unrelated refactor, and
   unrelated fixes as separate PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ are the most valuable thing you can send.
 - Read [`CLAUDE.md`](CLAUDE.md) / [`AGENTS.md`](AGENTS.md) (same content,
   different agent runtimes). They are the operating manual: architecture,
   critical rules, and the patterns your change must follow.
+- If you use an AI coding agent, explicitly tell it to read this file before it
+  implements, commits, pushes, or opens a PR. Humans and agents follow the same
+  contribution workflow.
 - Check existing [GitHub Issues](https://github.com/arspesk/sur9e/issues)
   before opening a new one or starting a large change. For anything bigger
   than a bugfix, open an issue first so we can agree on the approach.
@@ -91,6 +94,31 @@ welcome — under these rules:
 
 ## Commit & PR style
 
+### Scope each PR around one outcome
+
+A pull request is the unit of permanent history because Sur9e squash-merges.
+Each PR must deliver one independently reviewable and revertible outcome:
+
+- Keep that outcome's implementation, tests, documentation, and required
+  refactoring together.
+- Move unrelated features, opportunistic refactors, and bug fixes to separate
+  PRs. A feature plus a refactor or fix belongs together only when separating
+  them would leave the feature incomplete or unsafe.
+- Group fixes that share a root cause or component; do not create a micro-PR for
+  every line. Avoid both catch-all PRs and artificial fragmentation.
+- Open each completed, independent PR promptly instead of stockpiling several
+  finished changes for one bulk push. Base dependent work on updated `main`
+  after its prerequisite merges rather than opening a stack where practical.
+- If a branch already mixes independent work, split it before detailed review.
+  For example, submit an independent feature, an unrelated refactor, and
+  unrelated fixes as separate PRs.
+
+The PR description must state the primary outcome and explain why any secondary
+changes are necessary for it. Maintainers may ask for an oversized or mixed PR
+to be split before reviewing the implementation in detail.
+
+### Titles, commits, and merge history
+
 - PR titles must follow
   `<type>(<optional-scope>)!?: <description>`. Allowed types are `feat`, `fix`,
   `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, and `revert`.
@@ -102,9 +130,13 @@ welcome — under these rules:
   messages cannot affect Release Please. Remote enforcement is a maintainer
   prerequisite and must not be assumed active until the GitHub settings are
   verified.
-- Logically grouped commits; one concern per PR.
+- Working commits may capture review iterations, but keep them understandable
+  enough to inspect while the PR is open. They are not the permanent project
+  history; the validated PR title becomes the single squash commit on `main`.
 - Frontend changes: include desktop (1280×800), tablet (768×1024), and mobile
   (375×667) screenshots in the PR.
+- Accessibility is part of done: keyboard navigation, labels, and focus
+  management ship with the change.
 
 ## Maintainer-only tools
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,10 @@ to be split before reviewing the implementation in detail.
   messages cannot affect Release Please. Remote enforcement is a maintainer
   prerequisite and must not be assumed active until the GitHub settings are
   verified.
-- Working commits may capture review iterations, but keep them understandable
-  enough to inspect while the PR is open. They are not the permanent project
-  history; the validated PR title becomes the single squash commit on `main`.
+- Working commits may capture review iterations, but keep them logically grouped,
+  well-described, and understandable enough to inspect while the PR is open. They
+  are not the permanent project history; the validated PR title becomes the single
+  squash commit on `main`.
 - Frontend changes: include desktop (1280×800), tablet (768×1024), and mobile
   (375×667) screenshots in the PR.
 - Accessibility is part of done: keyboard navigation, labels, and focus


### PR DESCRIPTION
## What changed

- make `CONTRIBUTING.md` the detailed source of truth for contributor workflow
- define one independently reviewable and revertible outcome per PR, with examples for mixed feature, refactor, and bug-fix branches
- require agents to read the contributor workflow while retaining critical guardrails in byte-identical `AGENTS.md` and `CLAUDE.md`
- add PR-scope confirmation to the pull request template

## PR scope

- [x] This PR has one independently reviewable and revertible outcome
- [x] Included refactoring is required for that outcome
- [x] Unrelated features, refactors, and fixes were moved to separate PRs

## Validation checklist

- [x] `npm run test:quick` — 100 passed, 0 failed
- [x] `npm run build`
- [x] `cmp -s AGENTS.md CLAUDE.md`
- [x] `npx prettier --check AGENTS.md CLAUDE.md CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md`

## Visual changes

Not applicable.

## AI assistance disclosure

Codex updated and validated the documentation under maintainer direction.

- [x] I reviewed and understand every AI-assisted change
