### PR TITLE
test(update): allow integration suite under parallel load

### DIFF
--- a/test/update-system-integration.test.mjs
+++ b/test/update-system-integration.test.mjs
@@ -241,7 +241,7 @@ describe('update-system apply and rollback', () => {
     expect(existsSync(resolve(installed, 'scripts/web.mjs'))).toBe(false);
     expectPrivateFiles(installed, privateFiles);
     expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
-  });
+  }, 15_000);
 
   it('refuses dirty system paths with newlines and rename source records', () => {
     const { environment, installed } = createUpdateFixture();


### PR DESCRIPTION
## Summary

- give the broad update apply/rollback integration case a realistic timeout under the full parallel Vitest suite
- preserve the existing assertions and behavior unchanged

## Why

The test completes in isolation but can exceed Vitest's 5-second default when the entire suite runs concurrently.

## Validation

- `npm run test:quick` (100 passed)
- `npm run build`
