### PR TITLE
feat(update): check automatically on settings entry

### DIFF
--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
     error: null,
   } as Record<string, unknown>,
   active: {
-    data: { job: null },
+    data: undefined,
     isError: false,
     error: null,
   } as Record<string, unknown>,
@@ -96,7 +96,7 @@ beforeEach(() => {
   mocks.check = { isPending: false, mutateAsync: vi.fn() };
   mocks.apply = { isPending: false, mutateAsync: vi.fn() };
   mocks.job = { data: undefined, isError: false, error: null };
-  mocks.active = { data: { job: null }, isError: false, error: null };
+  mocks.active = { data: undefined, isError: false, error: null };
   mocks.rollback = { isPending: false, mutateAsync: vi.fn() };
   mocks.requestedJobIds = [];
   mocks.activeEnabled = [];
@@ -110,6 +110,57 @@ afterEach(() => {
 });
 
 describe('SystemSection update status', () => {
+  it('checks automatically when Settings mounts', async () => {
+    const check = vi.fn().mockResolvedValue({
+      status: 'update-available',
+      local: '0.3.2',
+      remote: '0.4.0',
+      changelog: 'Faster restart. Improved update recovery.',
+    });
+    mocks.check = { isPending: false, mutateAsync: check };
+    mocks.active = { data: { job: null }, isError: false, error: null };
+
+    renderSection();
+
+    expect(await screen.findByText('v0.4.0 available')).toBeTruthy();
+    expect(check).toHaveBeenCalledOnce();
+    expect(screen.getByRole('button', { name: 'Update now' })).toBeTruthy();
+  });
+
+  it('keeps an automatic check failure inline without showing a toast', async () => {
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockRejectedValue(new Error('update service unavailable')),
+    };
+    mocks.active = { data: { job: null }, isError: false, error: null };
+
+    renderSection();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('update service unavailable');
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it('still toasts when a manual retry fails', async () => {
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockRejectedValue(new Error('update service unavailable')),
+    };
+    mocks.active = { data: { job: null }, isError: false, error: null };
+    renderSection();
+    await screen.findByRole('alert');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
+
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts).toEqual([
+        expect.objectContaining({
+          tone: 'danger',
+          message: expect.stringContaining('update service unavailable'),
+        }),
+      ]),
+    );
+  });
+
   it('discovers and attaches the latest durable job when this tab has no retained id', async () => {
     window.history.replaceState({}, '', '/settings?view=system#system');
     mocks.active = {
@@ -132,6 +183,7 @@ describe('SystemSection update status', () => {
     expect(mocks.activeEnabled).toContain(true);
     expect(mocks.activeEnabled.at(-1)).toBe(false);
     expect(mocks.requestedJobIds).toContain(JOB_ID);
+    expect(mocks.check.mutateAsync).not.toHaveBeenCalled();
     expect(screen.getByRole('status')).toHaveTextContent('Preparing recovery');
   });
 
@@ -143,6 +195,7 @@ describe('SystemSection update status', () => {
 
     expect(mocks.activeEnabled.length).toBeGreaterThan(0);
     expect(mocks.activeEnabled.every(enabled => !enabled)).toBe(true);
+    expect(mocks.check.mutateAsync).not.toHaveBeenCalled();
   });
 
   it('discards a corrupt retained job id instead of trapping the controls', () => {

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { Button, HelperText, Input, Label } from '@/components/primitives';
@@ -130,6 +130,7 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
   const [jobId, setJobId] = useState<string | null>(readActiveJobId);
   const [discoveryAttached, setDiscoveryAttached] = useState(false);
   const [resultNotice, setResultNotice] = useState<ResultNotice | null>(null);
+  const autoCheckStarted = useRef(false);
 
   const versionQuery = useVersion();
   const installedVersion = versionQuery.isPending ? '…' : (versionQuery.data?.version ?? '?');
@@ -201,26 +202,39 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
     navigate(href);
   }, [job, navigate]);
 
-  const checkUpdates = useCallback(async () => {
-    if (job?.phase === 'failed') setJobId(null);
-    setIsChecking(true);
-    setCheckError(null);
-    try {
-      const result = await updateCheck.mutateAsync();
-      setCheckResult(result);
-      if (result.status === 'offline') {
-        setCheckError('Could not reach the update service. Try checking again.');
-      } else if (result.status === 'dismissed') {
-        setCheckError('The update check was dismissed. Try checking again when you are ready.');
+  const checkUpdates = useCallback(
+    async ({ silent = false }: { silent?: boolean } = {}) => {
+      if (job?.phase === 'failed') setJobId(null);
+      setIsChecking(true);
+      setCheckError(null);
+      try {
+        const result = await updateCheck.mutateAsync();
+        setCheckResult(result);
+        if (result.status === 'offline') {
+          setCheckError('Could not reach the update service. Try checking again.');
+        } else if (result.status === 'dismissed') {
+          setCheckError('The update check was dismissed. Try checking again when you are ready.');
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setCheckError(`Update check failed: ${message}. Try checking again.`);
+        if (!silent) {
+          pushToast('danger', `Update check failed (${message}) — try again later.`);
+        }
+      } finally {
+        setIsChecking(false);
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setCheckError(`Update check failed: ${message}. Try checking again.`);
-      pushToast('danger', `Update check failed (${message}) — try again later.`);
-    } finally {
-      setIsChecking(false);
-    }
-  }, [job?.phase, pushToast, updateCheck]);
+    },
+    [job?.phase, pushToast, updateCheck],
+  );
+
+  useEffect(() => {
+    if (autoCheckStarted.current || jobId || discoveryAttached) return;
+    const discoverySettled = activeUpdateJob.data !== undefined || activeUpdateJob.isError;
+    if (!discoverySettled || activeUpdateJob.data?.job) return;
+    autoCheckStarted.current = true;
+    void checkUpdates({ silent: true });
+  }, [activeUpdateJob.data, activeUpdateJob.isError, checkUpdates, discoveryAttached, jobId]);
 
   const applyUpdate = useCallback(async () => {
     if (checkResult?.status !== 'update-available') return;
@@ -406,7 +420,7 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
           <Button
             variant="secondary"
             id="checkUpdates"
-            onClick={checkUpdates}
+            onClick={() => void checkUpdates()}
             disabled={actionsPending}
           >
             {checkLabel}

--- a/test/e2e/settings-update.spec.ts
+++ b/test/e2e/settings-update.spec.ts
@@ -67,6 +67,29 @@ async function stubReadOnlySystemEndpoints(page: Page) {
   });
 }
 
+test('checks for updates on Settings entry before the update section is viewed', async ({
+  page,
+}) => {
+  const checkRequests: string[] = [];
+  page.on('request', request => {
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === '/api/update/check') {
+      checkRequests.push(request.url());
+    }
+  });
+  await stubReadOnlySystemEndpoints(page);
+
+  await page.goto('/settings');
+  const section = page.locator('section#system');
+
+  await expect(section).not.toBeInViewport();
+  await expect.poll(() => checkRequests.length).toBe(1);
+  await expect(section.getByText('v0.4.0 available')).toBeAttached();
+
+  await section.scrollIntoViewIfNeeded();
+  await expect(section.getByText('v0.4.0 available')).toBeVisible();
+});
+
 test('runs the one-click update flow through restart downtime and restores the exact URL', async ({
   page,
 }) => {
@@ -105,7 +128,15 @@ test('runs the one-click update flow through restart downtime and restores the e
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(availableCheck),
+        body: JSON.stringify(
+          installedVersion === availableCheck.remote
+            ? {
+                status: 'up-to-date',
+                local: installedVersion,
+                remote: installedVersion,
+              }
+            : availableCheck,
+        ),
       });
     }
     if (pathname === '/api/update/apply' && request.method() === 'POST') {
@@ -147,13 +178,10 @@ test('runs the one-click update flow through restart downtime and restores the e
   await page.goto(SETTINGS_HREF);
   await page.waitForLoadState('networkidle');
   const section = page.locator('section#system');
-  await expect(section.getByText('Not checked yet')).toBeVisible();
-  await expect(section.getByRole('button', { name: 'Update now' })).toHaveCount(0);
-
-  await section.getByRole('button', { name: 'Check for updates' }).click();
   await expect(section.getByText('v0.4.0 available')).toBeVisible();
   await expect(section.getByText(availableCheck.changelog)).toBeVisible();
   await expect(section.getByRole('button', { name: 'Update now' })).toBeVisible();
+  expect(checkCalls).toBe(1);
 
   await section.getByRole('button', { name: 'Update now' }).click();
   const dialog = page.getByRole('dialog', {
@@ -200,7 +228,7 @@ test('runs the one-click update flow through restart downtime and restores the e
       timeout: 10_000,
     },
   );
-  expect(checkCalls).toBe(1);
+  expect(checkCalls).toBeGreaterThanOrEqual(2);
   expect(applyCalls).toBe(1);
   expect(rollbackCalls).toBe(0);
   expect(statusCalls).toBeGreaterThanOrEqual(6);
@@ -208,7 +236,7 @@ test('runs the one-click update flow through restart downtime and restores the e
 
   await page.reload();
   await page.waitForLoadState('networkidle');
-  await expect(page.locator('section#system').getByText('Not checked yet')).toBeVisible();
+  await expect(page.locator('section#system').getByText('Up to date')).toBeVisible();
   await expect(page.locator('section#system').getByText('Update complete')).toHaveCount(0);
   await expect(page.locator('#aboutVersion')).toHaveText('v0.4.0');
 });
@@ -235,7 +263,7 @@ test('consumes an automatic rollback notice for one load', async ({ page }) => {
 
   await page.reload();
   await page.waitForLoadState('networkidle');
-  await expect(page.locator('section#system').getByText('Not checked yet')).toBeVisible();
+  await expect(page.locator('section#system').getByText('v0.4.0 available')).toBeVisible();
   await expect(page.getByText(/automatically recovered v0\.3\.2/i)).toHaveCount(0);
 });
 
@@ -254,7 +282,7 @@ for (const viewport of [
 
     const section = page.locator('section#system');
     await section.scrollIntoViewIfNeeded();
-    const check = section.getByRole('button', { name: 'Check for updates' });
+    const check = section.getByRole('button', { name: 'Check again' });
     const edit = section.locator('button[aria-controls="system-update-source-fields"]');
     const rollback = section.getByRole('button', { name: 'Roll back' });
     await expect(check).toBeVisible();


### PR DESCRIPTION
## Summary
- check for updates once when the Settings page is entered
- show current update status before the user reaches Updates & about
- retain Check again as a manual retry without automatically applying updates

## Verification
- `npx vitest run src/features/settings/sections/__tests__/system-section.test.tsx` (22 passed)
- `PLAYWRIGHT_START_SERVER=1 PLAYWRIGHT_PORT=3101 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3101 npx playwright test test/e2e/settings-update.spec.ts` (6 passed; desktop, tablet, mobile, restart/recovery flow)
- `npm run lint`
- `npm run typecheck`