### PR TITLE
fix(offers): hide chat launcher behind filters

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -1317,6 +1317,15 @@
    mobile .chat-bubble rule above) is set on .chat-bubble / .chat-card
    above — these layer additional lifts on top of it. ── */
 
+/* The Offers filter drawer/sheet already owns the active `.open` state in
+   both table and kanban views. Hide the floating launcher while that modal
+   surface is open so it cannot overlap or compete with the filter controls. */
+body:has(.filter-panel.open) .chat-bubble {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 /* Pages with a floating .action-bar (report etc.) need the chat lifted
    above it. Action-bar default bottom: 28px, height ~50px → top ~78px.
    Lift to 90px. Scoped >640px: the ≤640px card is full-screen and the

--- a/test/chat-ui-style-contract.test.ts
+++ b/test/chat-ui-style-contract.test.ts
@@ -41,4 +41,12 @@ describe('chat UI style contract', () => {
       /\.chat-jobs__cancel:hover\s*\{[\s\S]*?background:\s*var\(--surface-danger-hover\)/,
     );
   });
+
+  it('hides the floating launcher while the offers filter panel is open', () => {
+    const chatCss = readFileSync(join(root, 'src/app/styles/chat.css'), 'utf8');
+
+    expect(chatCss).toMatch(
+      /body:has\(\.filter-panel\.open\) \.chat-bubble\s*\{[\s\S]*?visibility:\s*hidden;[\s\S]*?pointer-events:\s*none/,
+    );
+  });
 });

--- a/test/e2e/table.spec.ts
+++ b/test/e2e/table.spec.ts
@@ -14,3 +14,58 @@ test('/offers loads and clicking a row opens the offer drawer', async ({ page })
   // The detail drawer is #cdDrawer.cd-drawer; it gets `.on` once opened.
   await expect(page.locator('.cd-drawer.on')).toBeVisible();
 });
+
+test('offers filters hide the floating chat launcher in both views', async ({ page }) => {
+  const viewports = [
+    { name: 'desktop', width: 1280, height: 800 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'mobile', width: 375, height: 667 },
+  ];
+  const views = [
+    { name: 'table', url: '/offers' },
+    { name: 'kanban', url: '/offers?view=kanban' },
+  ];
+
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport);
+
+    for (const view of views) {
+      await page.goto(view.url);
+
+      const chatLauncher = page.getByRole('button', { name: 'Open chat' });
+      const filterButton = page.getByRole('button', { name: 'Filter offers' });
+      await expect(chatLauncher).toBeVisible();
+
+      await expect
+        .poll(async () => {
+          if ((await filterButton.getAttribute('aria-expanded')) !== 'true') {
+            await filterButton.click();
+          }
+          return filterButton.getAttribute('aria-expanded');
+        })
+        .toBe('true');
+      const filterPanel = page.getByRole('dialog', { name: 'Filters' });
+      await expect(filterPanel).toBeVisible();
+      await expect(chatLauncher).toBeHidden();
+      await expect
+        .poll(async () => {
+          const box = await filterPanel.boundingBox();
+          if (!box) return false;
+          return viewport.width <= 640
+            ? Math.abs(box.y + box.height - viewport.height) <= 1
+            : Math.abs(box.x + box.width - viewport.width) <= 1;
+        })
+        .toBe(true);
+
+      if (process.env.VISUAL_QA_DIR) {
+        await page.screenshot({
+          path: `${process.env.VISUAL_QA_DIR}/offers-filters-${view.name}-${viewport.name}.png`,
+        });
+      }
+
+      await page.getByRole('button', { name: 'Close filters' }).click();
+      await expect(page.getByRole('dialog', { name: 'Filters' })).toBeHidden();
+      await expect(chatLauncher).toBeVisible();
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- hide the floating chat launcher while the Offers filter dialog is open
- apply the behavior consistently to table and Kanban views
- restore the launcher immediately when filters close

## Verification
- `npx vitest run test/chat-ui-style-contract.test.ts` (4 passed)
- `PLAYWRIGHT_START_SERVER=1 PLAYWRIGHT_PORT=3103 PLAYWRIGHT_BASE_URL=http://127.0.0.1:3103 npx playwright test test/e2e/table.spec.ts --grep "offers filters hide the floating chat launcher"` (both views at desktop, tablet, mobile)
- `npm run lint`
- `npm run typecheck`
- `npm run build`