### PR TITLE
fix(status): save evaluated before optional follow-up

### DIFF
--- a/src/app/styles/chrome.css
+++ b/src/app/styles/chrome.css
@@ -2666,8 +2666,6 @@ input[type="range"]::-moz-range-track {
 .delete-confirm-modal__foot,
 .range-modal__foot {
   display: flex;
-  /* wrap: the evaluate modal grows a third "Set status only" button on the
-     bulk status-change path — three buttons overflow a 375px-wide dialog. */
   flex-wrap: wrap;
   gap: var(--space-2);
   justify-content: flex-end;

--- a/src/components/modals/evaluate-modal.tsx
+++ b/src/components/modals/evaluate-modal.tsx
@@ -1,17 +1,11 @@
 'use client';
 
 // Context shape (passed via useModalStore.open('evaluate', context)):
-//   { num?: number }            — single-row evaluate (default copy)
-//   { count: number }           — batch evaluate (count > 1 switches title)
-//   { patchToEvaluated?: bool } — set by the report-page flow to PATCH
-//                                 the status to 'evaluated' before spawning.
-//   { onStatusOnly?: fn }       — set by the batch bar's "Change status →
-//                                 Evaluated" pick: renders an extra
-//                                 "Set status only" button that closes and
-//                                 applies the plain bulk PATCH without
-//                                 spawning jobs. Cancel/Escape/overlay-click
-//                                 stay a full abort (an accidental dismiss
-//                                 must never write).
+//   { num?: number }             — single-row evaluate (default copy)
+//   { count: number }            — batch evaluate (count > 1 switches title)
+//   { statusFollowup?: boolean } — the status was already persisted as
+//                                  Evaluated; this modal only offers the
+//                                  optional evaluation job.
 //
 // On submit:
 //   - Single-row → useJobAction('evaluate').run({ num, generate_pdf? })
@@ -29,7 +23,6 @@ import { Button } from '@/components/primitives';
 import { useToastStore } from '@/components/toast/toast-store';
 import { useJobAction } from '@/hooks/use-job-action';
 import { formatEstimate, JOB_TYPES_BY_TYPE, jobEstimateLabel } from '@/lib/job-types';
-import { updateApplicationStatusAction } from '@/server/actions/applications';
 import { useModalStore } from '@/stores/modal-store';
 import { useSelectionStore } from '@/stores/selection-store';
 import { runForNums } from './batch-run';
@@ -47,13 +40,10 @@ export function EvaluateModal() {
   const num = (context?.num as number | undefined) ?? undefined;
   const count = (context?.count as number | undefined) ?? undefined;
   const nums = (context?.nums as number[] | undefined) ?? undefined;
-  const patchToEvaluated = (context?.patchToEvaluated as boolean | undefined) ?? false;
+  const statusFollowup = (context?.statusFollowup as boolean | undefined) ?? false;
   // R2-5: insert the runningMode placeholder only on confirm. Undefined on
   // the batch path, where calling it is a no-op.
   const onConfirm = context?.onConfirm as (() => void) | undefined;
-  // Batch "Change status → Evaluated" pick: skip the jobs, just PATCH.
-  const onStatusOnly = context?.onStatusOnly as (() => void) | undefined;
-  const statusTriggered = patchToEvaluated || onStatusOnly != null;
   const isBatch = Number.isInteger(count) && (count as number) > 1;
 
   // Legacy `evaluate-modal.js` line 70-75: accept either confirm(num)
@@ -65,10 +55,8 @@ export function EvaluateModal() {
     title = `Run full evaluation for #${num}?`;
   }
 
-  // Run the job after the user confirms. For the report flow (single-row,
-  // patchToEvaluated=true) we PATCH the application status first so the
-  // status pill updates immediately, then spawn the eval job. Legacy did
-  // both in run-evaluate.js lines 49-58.
+  // Run the job after the user confirms. Status-triggered flows persist the
+  // Evaluated status before opening this optional follow-up.
   const handleSubmit = useCallback(async () => {
     close();
     onConfirm?.();
@@ -98,14 +86,6 @@ export function EvaluateModal() {
       return;
     }
     if (num == null) return;
-    if (patchToEvaluated) {
-      try {
-        await updateApplicationStatusAction({ num, status: 'evaluated' });
-      } catch (err) {
-        // Non-fatal — proceed with the spawn anyway.
-        console.warn('[evaluate-modal] status→evaluated failed:', err);
-      }
-    }
     await run({
       num,
       ...(generatePdf ? { generate_pdf: true } : {}),
@@ -116,7 +96,6 @@ export function EvaluateModal() {
     onConfirm,
     nums,
     num,
-    patchToEvaluated,
     generatePdf,
     generateCoverLetter,
     run,
@@ -148,7 +127,9 @@ export function EvaluateModal() {
             <li>
               <strong>Result:</strong>{' '}
               {[
-                'Status → Evaluated, full report',
+                statusFollowup
+                  ? 'Full evaluation report (status already Evaluated)'
+                  : 'Status → Evaluated, full report',
                 ...(generatePdf ? ['tailored CV PDF'] : []),
                 ...(generateCoverLetter ? ['cover letter PDF'] : []),
               ].join(' + ')}
@@ -179,20 +160,8 @@ export function EvaluateModal() {
         </div>
         <footer className="evaluate-modal__foot">
           <Button variant="secondary" className="evaluate-modal__cancel" onClick={close}>
-            {statusTriggered ? 'Not now' : 'Cancel'}
+            {statusFollowup ? 'Not now' : 'Cancel'}
           </Button>
-          {onStatusOnly ? (
-            <Button
-              variant="secondary"
-              className="evaluate-modal__status-only"
-              onClick={() => {
-                close();
-                onStatusOnly();
-              }}
-            >
-              Set status only
-            </Button>
-          ) : null}
           <Button variant="primary" className="evaluate-modal__submit" onClick={handleSubmit}>
             Run evaluation
           </Button>

--- a/src/components/status-popover-host.tsx
+++ b/src/components/status-popover-host.tsx
@@ -10,10 +10,9 @@
  * positioning + the PATCH on pick.
  *
  * Status picks go through interceptStatusPick so the pill behaves exactly
- * like the kanban drag: picking "evaluated" opens the evaluate confirm
- * modal, which offers BOTH "Run evaluation" (PATCH + spawn the eval job)
- * and "Set status only" (plain PATCH, no job) — the user chooses. Every
- * other transition is a plain PATCH.
+ * like the kanban drag: picking "evaluated" persists the status first, then
+ * opens an optional evaluation follow-up. Every other transition is a plain
+ * PATCH.
  */
 
 import { useToastStore } from '@/components/toast/toast-store';
@@ -57,18 +56,15 @@ export function StatusPopoverHost() {
           return;
         }
         if (intercept.kind === 'evaluate-modal') {
-          // patchToEvaluated → "Run evaluation" flips status then spawns the
-          // job; onStatusOnly → "Set status only" just flips to evaluated
-          // with no job (same plain PATCH the hook toasts on error).
-          openModal('evaluate', {
-            num,
-            patchToEvaluated: true,
-            onStatusOnly: () =>
-              updateStatus(
-                { num, status: 'evaluated' },
-                { onSuccess: () => pushToast('success', `#${num} → evaluated`) },
-              ),
-          });
+          updateStatus(
+            { num, status: 'evaluated' },
+            {
+              onSuccess: () => {
+                pushToast('success', `#${num} → evaluated`);
+                openModal('evaluate', { num, statusFollowup: true });
+              },
+            },
+          );
           return;
         }
         // Failure toast comes from useUpdateApplicationStatus's hook-level

--- a/src/features/home/pending-offers-section.tsx
+++ b/src/features/home/pending-offers-section.tsx
@@ -77,15 +77,15 @@ export function PendingOffersSection({ offers }: { offers: PendingOffer[] }) {
   const updateStatus = useUpdateApplicationStatus();
 
   function evaluate(o: PendingOffer) {
-    openModal('evaluate', {
-      num: o.num,
-      patchToEvaluated: true,
-      // EvaluateModal fires onConfirm *before* its own status PATCH, and
-      // the action only revalidates /offers, /pipeline and /report — Home
-      // isn't in that list, so refresh from here. The pill may lag by one
-      // frame; the next refresh settles it.
-      onConfirm: () => router.refresh(),
-    });
+    updateStatus.mutate(
+      { num: o.num, status: 'evaluated' },
+      {
+        onSuccess: () => {
+          router.refresh();
+          openModal('evaluate', { num: o.num, statusFollowup: true });
+        },
+      },
+    );
   }
 
   function setStatus(o: PendingOffer, status: 'applied' | 'discarded') {

--- a/src/features/pipeline/board.tsx
+++ b/src/features/pipeline/board.tsx
@@ -150,20 +150,22 @@ export function Board({
       const prevStatus = (row.status || '').toLowerCase();
       if (prevStatus === newStatus) return;
 
-      // Optimistic PATCH with revert-on-failure — shared by the plain-pick
-      // path and the evaluate modal's "Set status only" choice.
+      // Optimistic PATCH with revert-on-failure — shared by plain picks and
+      // the Evaluated transition that precedes its optional follow-up.
       const patchStatus = async (status: ColumnKey) => {
         setOptimisticStatus(m => new Map(m).set(num, status));
         try {
           const result = await updateApplicationStatusAction({ num, status });
-          openStatusFollowup(result.followup);
+          if (result.followup) openStatusFollowup(result.followup);
           // Refetch — drops our optimistic entry on next render. Invalidate
           // both 'applications' (table/board) and 'report' (open report
           // page) so neither surface keeps a stale status.
           await queryClient.invalidateQueries({ queryKey: ['applications'] });
           await queryClient.invalidateQueries({ queryKey: ['report'] });
+          return true;
         } catch (err) {
           push('danger', err instanceof Error ? err.message : 'Failed to update status');
+          return false;
         } finally {
           setOptimisticStatus(m => {
             const next = new Map(m);
@@ -175,26 +177,22 @@ export function Board({
 
       // Shared per-offer transition rules (same module drives the status
       // pill popovers in the table / drawer / report hero): any → evaluated
-      // opens the evaluate confirm modal, which offers "Run evaluation"
-      // (flip + spawn the eval job) and "Set status only" (plain flip, no
-      // job). Return early — the PATCH below would race the modal's own.
+      // persists first, then opens the optional evaluation follow-up.
       const intercept = interceptStatusPick(prevStatus, newStatus);
       if (intercept.kind === 'blocked') {
         push('info', `#${num} ${intercept.message}`);
         return;
       }
       if (intercept.kind === 'evaluate-modal') {
-        openModal('evaluate', {
-          num,
-          patchToEvaluated: true,
-          onStatusOnly: () => void patchStatus(newStatus),
-        });
+        if (await patchStatus(newStatus)) {
+          openModal('evaluate', { num, statusFollowup: true });
+        }
         return;
       }
 
       await patchStatus(newStatus);
     },
-    [effectiveRows, push, queryClient],
+    [effectiveRows, openModal, openStatusFollowup, push, queryClient],
   );
 
   // Card click delegates to parent (the page wires the drawer + dblclick → /report).

--- a/src/features/table/batch-action-bar.tsx
+++ b/src/features/table/batch-action-bar.tsx
@@ -54,23 +54,25 @@ export function BatchActionBar() {
     // (network drop, payload parse error) would otherwise vanish as an
     // unhandled rejection — toast it and keep the selection so the user can
     // retry.
-    let ok: number;
-    let failed: number;
+    let result: Awaited<ReturnType<typeof batchUpdateApplicationStatusAction>>;
     try {
-      ({ ok, failed } = await batchUpdateApplicationStatusAction({
+      result = await batchUpdateApplicationStatusAction({
         nums,
         status: newStatus,
-      }));
+      });
     } catch (err) {
       push('danger', err instanceof Error ? err.message : 'Bulk status update failed');
-      return;
+      return [];
     }
+    const { ok, failed } = result;
     if (failed === 0) push('success', `Updated ${ok} offer${ok === 1 ? '' : 's'}`);
     else if (ok === 0) push('danger', `Failed to update ${failed} offers`);
     else push('info', `Updated ${ok} offers (${failed} failed)`);
     clear();
     queryClient.invalidateQueries({ queryKey: ['applications'] });
     queryClient.invalidateQueries({ queryKey: ['status-log'] });
+    const failedNums = new Set(result.errors.map(item => item.num));
+    return nums.filter(num => !failedNums.has(num));
   }
 
   async function handleBulkStatus(newStatus: ApplicationStatus) {
@@ -82,17 +84,17 @@ export function BatchActionBar() {
     // Bulk variant of the interceptStatusPick rule (single-row surfaces call
     // it directly — see status-popover-host.tsx). Selection statuses vary
     // per row, so instead of comparing prev/next we key off the pick alone:
-    // 'evaluated' routes through the evaluate confirm modal. Confirming
-    // spawns real evaluation jobs (nums[] fan-out); the modal's explicit
-    // "Set status only" button applies the plain bulk PATCH without running
-    // anything. Cancel / Escape / overlay-click abort entirely — they're
-    // indistinguishable from an accidental dismiss, so they must not write.
+    // 'evaluated' persists the bulk status change first, then offers the
+    // evaluation jobs as an optional follow-up for rows that succeeded.
     if (newStatus === 'evaluated') {
-      openModal('evaluate', {
-        count: liveNums.length,
-        nums: liveNums,
-        onStatusOnly: () => void applyBulkStatus(liveNums, 'evaluated'),
-      });
+      const updatedNums = await applyBulkStatus(liveNums, 'evaluated');
+      if (updatedNums.length > 0) {
+        openModal('evaluate', {
+          count: updatedNums.length,
+          nums: updatedNums,
+          statusFollowup: true,
+        });
+      }
       return;
     }
 

--- a/src/features/table/offers-table.tsx
+++ b/src/features/table/offers-table.tsx
@@ -145,15 +145,14 @@ export function OffersTable({ rows, tableRef, wrapRef }: OffersTableProps) {
     // accepts the setOptimistic call. TanStack's `mutate` is fire-and-forget
     // here — onError pops a toast via the host hook; on success the
     // ['applications'] invalidation triggers a refetch + auto-reconcile.
-    const patchStatus = (status: ApplicationStatus) =>
+    const patchStatus = (status: ApplicationStatus, onSuccess?: () => void) =>
       startTransition(() => {
         applyOptimistic({ type: 'status', num, status });
-        updateStatus({ num, status });
+        updateStatus({ num, status }, { onSuccess });
       });
     // Same rules as the kanban drag (interceptStatusPick): picking
-    // "evaluated" opens the evaluate confirm modal, which offers "Run
-    // evaluation" (PATCH + spawn the eval job) and "Set status only" (plain
-    // PATCH, no job). Every other transition flips the pill directly.
+    // "evaluated" persists the status first, then opens the optional
+    // evaluation follow-up. Every other transition flips the pill directly.
     const row = optimisticRows.find(r => r.num === num);
     const intercept = interceptStatusPick(row?.status, newStatus);
     if (intercept.kind === 'blocked') {
@@ -161,11 +160,7 @@ export function OffersTable({ rows, tableRef, wrapRef }: OffersTableProps) {
       return;
     }
     if (intercept.kind === 'evaluate-modal') {
-      openModal('evaluate', {
-        num,
-        patchToEvaluated: true,
-        onStatusOnly: () => patchStatus(newStatus),
-      });
+      patchStatus(newStatus, () => openModal('evaluate', { num, statusFollowup: true }));
       return;
     }
     patchStatus(newStatus);

--- a/src/lib/status-transitions.ts
+++ b/src/lib/status-transitions.ts
@@ -4,10 +4,9 @@
 // (StatusPopoverHost), and the table's status pill (offers-table.tsx).
 //
 // Rules (originally encoded only in the board's drag handler):
-//   - anything → evaluated: the change must go through the evaluate confirm
-//     modal (openModal('evaluate', { num, patchToEvaluated: true })) so the
-//     status flip and the evaluation job stay one gesture — a silent PATCH
-//     would leave an "Evaluated" row with no evaluation behind it.
+//   - anything → evaluated: persist the new status first, then open the
+//     evaluation modal as an optional follow-up. Dismissing with "Not now"
+//     keeps the already-saved status.
 //   - evaluated → screened: a plain PATCH like any other transition
 //     (maintainer decision 2026-06-11; previously blocked). The status is
 //     the pipeline stage only — the evaluation report keeps its `state:
@@ -17,9 +16,8 @@
 // Bulk surfaces (batch-action-bar.tsx) can't call this directly — the
 // selection's per-row statuses vary, so there is no single `currentStatus`.
 // They apply the same intent by keying off the pick alone: choosing
-// 'evaluated' opens the evaluate confirm modal with the selected nums[]
-// (confirm = spawn real evaluation jobs; an explicit "Set status only"
-// button = plain bulk PATCH; Cancel/Escape = abort).
+// 'evaluated' persists the bulk status change first, then opens the optional
+// evaluation follow-up with the successfully updated nums[].
 //
 // Client-safe, framework-free, pure — unit-tested in
 // src/lib/__tests__/status-transitions.test.ts.

--- a/test/components/board-status-followup.test.tsx
+++ b/test/components/board-status-followup.test.tsx
@@ -140,16 +140,20 @@ describe('Board status follow-ups', () => {
     expect(openStatusFollowup).not.toHaveBeenCalled();
   });
 
-  it('continues to intercept Evaluated without starting a direct status mutation', () => {
+  it('persists Evaluated before opening its optional evaluation follow-up', async () => {
+    vi.mocked(updateApplicationStatusAction).mockResolvedValueOnce({
+      updated: { num: 7, status: 'Evaluated' },
+      followup: null,
+    } as Awaited<ReturnType<typeof updateApplicationStatusAction>>);
     renderBoard();
 
     dropCard('evaluated');
 
-    expect(updateApplicationStatusAction).not.toHaveBeenCalled();
-    expect(openStatusFollowup).not.toHaveBeenCalled();
-    expect(useModalStore.getState().modal).toBe('evaluate');
-    expect(useModalStore.getState().context).toEqual(
-      expect.objectContaining({ num: 7, patchToEvaluated: true }),
+    await waitFor(() =>
+      expect(updateApplicationStatusAction).toHaveBeenCalledWith({ num: 7, status: 'evaluated' }),
     );
+    expect(openStatusFollowup).not.toHaveBeenCalled();
+    await waitFor(() => expect(useModalStore.getState().modal).toBe('evaluate'));
+    expect(useModalStore.getState().context).toEqual({ num: 7, statusFollowup: true });
   });
 });

--- a/test/components/status-followup-modals.test.tsx
+++ b/test/components/status-followup-modals.test.tsx
@@ -62,27 +62,37 @@ describe('status follow-up modal copy', () => {
     expect(screen.queryByRole('button', { name: 'Not now' })).toBeNull();
   });
 
-  it('labels EvaluateModal dismissal Not now while preserving Set status only', () => {
-    const onStatusOnly = vi.fn();
-    renderModal('evaluate', <EvaluateModal />, { num: 7, patchToEvaluated: true, onStatusOnly });
+  it('treats EvaluateModal as an optional follow-up after status is already saved', () => {
+    renderModal('evaluate', <EvaluateModal />, { num: 7, statusFollowup: true });
 
     expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Set status only' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Set status only' })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
 
     expect(useModalStore.getState().modal).toBeNull();
-    expect(onStatusOnly).not.toHaveBeenCalled();
     expect(updateApplicationStatusAction).not.toHaveBeenCalled();
     expect(runJob).not.toHaveBeenCalled();
   });
 
+  it('runs evaluation without attempting a second status write', () => {
+    renderModal('evaluate', <EvaluateModal />, { num: 7, statusFollowup: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run evaluation' }));
+
+    expect(updateApplicationStatusAction).not.toHaveBeenCalled();
+    expect(runJob).toHaveBeenCalledWith({ num: 7 });
+  });
+
   it('labels bulk status-triggered EvaluateModal dismissal Not now', () => {
-    const onStatusOnly = vi.fn();
-    renderModal('evaluate', <EvaluateModal />, { count: 2, nums: [7, 8], onStatusOnly });
+    renderModal('evaluate', <EvaluateModal />, {
+      count: 2,
+      nums: [7, 8],
+      statusFollowup: true,
+    });
 
     expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Set status only' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Set status only' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
   });
 

--- a/test/components/status-popover-host.test.tsx
+++ b/test/components/status-popover-host.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatusPopoverHost } from '@/components/status-popover-host';
+import { useModalStore } from '@/stores/modal-store';
+import { useStatusPopoverStore } from '@/stores/status-popover-store';
+
+const mutateStatus = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/use-applications', () => ({
+  useUpdateApplicationStatus: () => ({ mutate: mutateStatus }),
+}));
+
+vi.mock('@/components/status-popover', () => ({
+  StatusPopover: ({ onPick }: { onPick: (status: 'evaluated') => void }) => (
+    <button type="button" onClick={() => onPick('evaluated')}>
+      Evaluated
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useModalStore.setState({ modal: null, context: null });
+  useStatusPopoverStore.setState({ open: null });
+});
+
+describe('StatusPopoverHost evaluated follow-up', () => {
+  function openPopover() {
+    useStatusPopoverStore.getState().show({
+      anchor: document.createElement('button'),
+      num: 7,
+      currentStatus: 'Screened',
+    });
+    render(<StatusPopoverHost />);
+  }
+
+  it('opens evaluation only after the Evaluated status save succeeds', () => {
+    mutateStatus.mockImplementation((_input, options) => options?.onSuccess?.());
+    openPopover();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Evaluated' }));
+
+    expect(mutateStatus).toHaveBeenCalledWith(
+      { num: 7, status: 'evaluated' },
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    expect(useModalStore.getState()).toEqual(
+      expect.objectContaining({
+        modal: 'evaluate',
+        context: { num: 7, statusFollowup: true },
+      }),
+    );
+  });
+
+  it('does not open evaluation when the status save fails', () => {
+    mutateStatus.mockImplementation(() => undefined);
+    openPopover();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Evaluated' }));
+
+    expect(mutateStatus).toHaveBeenCalledOnce();
+    expect(useModalStore.getState().modal).toBeNull();
+  });
+});

--- a/test/evaluated-status-followup-contract.test.ts
+++ b/test/evaluated-status-followup-contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const read = (path: string) => readFileSync(join(ROOT, path), 'utf-8');
+
+const STATUS_SURFACES = [
+  'src/components/status-popover-host.tsx',
+  'src/features/home/pending-offers-section.tsx',
+  'src/features/pipeline/board.tsx',
+  'src/features/table/offers-table.tsx',
+  'src/features/table/batch-action-bar.tsx',
+];
+
+describe('evaluated status follow-up contract', () => {
+  it.each(STATUS_SURFACES)('%s opens evaluation as an optional post-save follow-up', path => {
+    const source = read(path);
+    expect(source).toContain('statusFollowup: true');
+    expect(source).not.toContain('patchToEvaluated');
+    expect(source).not.toContain('onStatusOnly');
+  });
+
+  it('removes status persistence and the redundant status-only action from EvaluateModal', () => {
+    const source = read('src/components/modals/evaluate-modal.tsx');
+    expect(source).not.toContain('Set status only');
+    expect(source).not.toContain('updateApplicationStatusAction');
+    expect(source).not.toContain('patchToEvaluated');
+    expect(source).not.toContain('onStatusOnly');
+  });
+});


### PR DESCRIPTION
## Summary
- persist the Evaluated status before opening the evaluation follow-up, matching Interview and Offer received
- remove the redundant **Set status only** action; status-triggered modals now offer only **Not now** and **Run evaluation**
- keep the saved status when evaluation is deferred, and do not open the follow-up when the status write fails
- apply the same contract to table, Kanban, status popovers, Home, and bulk changes

## Root cause
Remote `main` still made the evaluation modal own the status write. Dismissing the modal therefore aborted the transition, while other guided status transitions saved first and treated their modal as an optional follow-up.

## Verification
- `npx vitest run test/components/status-followup-modals.test.tsx test/components/board-status-followup.test.tsx test/components/status-popover-host.test.tsx test/evaluated-status-followup-contract.test.ts` — 20 passed
- `npm run test:quick` — 100 checks passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- isolated Playwright tracker copy: desktop 1280×800, tablet 768×1024, mobile 375×667; status remained Evaluated after **Not now** and reload

Supersedes #36 with a fresh reproduction, test-first implementation, and end-to-end browser verification.