### PR TITLE
fix(providers): recover from hung retryable failures

### DIFF
--- a/batch/lib/llm.mjs
+++ b/batch/lib/llm.mjs
@@ -25,6 +25,61 @@ function defaultExec(cmd, args, opts) {
   return spawnSync(cmd, args, { encoding: "utf-8", ...opts });
 }
 
+const TERMINAL_FAILURE_GRACE_MS = 1000;
+
+function descendantPids(pid) {
+  if (!Number.isInteger(pid) || pid <= 1 || process.platform === "win32") return [];
+  const found = [];
+  const visited = new Set([pid]);
+  const visit = (parentPid) => {
+    // `ps --ppid` is GNU-only; macOS ships BSD ps. `pgrep -P` is available
+    // on both supported Unix families and returns one direct child per line.
+    const result = spawnSync("pgrep", ["-P", String(parentPid)], {
+      encoding: "utf-8",
+    });
+    if (result.status !== 0) return;
+    const children = String(result.stdout ?? "")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map(Number)
+      .filter(
+        (childPid) =>
+          Number.isInteger(childPid) && childPid > 1 && childPid !== process.pid && !visited.has(childPid),
+      );
+    for (const childPid of children) {
+      visited.add(childPid);
+      visit(childPid);
+      found.push(childPid);
+    }
+  };
+  visit(pid);
+  return found;
+}
+
+/** Stop the provider wrapper and every descendant it spawned. */
+export function terminateProviderTree(child, signal = "SIGTERM") {
+  const pid = child?.pid;
+  if (process.platform === "win32" && Number.isInteger(pid)) {
+    const args = ["/PID", String(pid), "/T"];
+    if (signal === "SIGKILL") args.push("/F");
+    spawnSync("taskkill", args, { stdio: "ignore" });
+    return;
+  }
+  for (const childPid of descendantPids(pid)) {
+    try {
+      process.kill(childPid, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
 export function resolveRuntimeForMode(rootPath, modeId, { execImpl = defaultExec } = {}) {
   const overrideArgs = [];
   // Per-run override forwarded by runner.ts (params.platform/model →
@@ -113,6 +168,7 @@ function runOnce(
     logsDir,
     execImpl = defaultExec,
     spawnImpl = nodeSpawn,
+    signal,
     // Echo the provider's streams to OUR stdout/stderr as they arrive, so a
     // parent that captures this process's output (the job runner persisting
     // mode-runner stdout into the job record) shows progress live. Opt-in:
@@ -135,11 +191,74 @@ function runOnce(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let stoppingCategory = null;
+    let cancelled = false;
+    let forceTimer = null;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (forceTimer) clearTimeout(forceTimer);
+      signal?.removeEventListener("abort", abort);
+      resolvePromise(result);
+    };
+    const stopGracefully = () => {
+      try {
+        terminateProviderTree(child, "SIGTERM");
+      } catch {}
+      forceTimer = setTimeout(() => {
+        try {
+          terminateProviderTree(child, "SIGKILL");
+        } catch {}
+        // A broken wrapper can fail to emit `close` even after its process
+        // tree is gone. Do not turn a recognized provider failure into the
+        // full mode timeout; settle from the diagnostic that initiated stop.
+        const settleTimer = setTimeout(() => {
+          finish(
+            cancelled
+              ? {
+                  ok: false,
+                  cancelled: true,
+                  error: "cancelled",
+                  stdout,
+                  stderr,
+                  promptText: prompt,
+                }
+              : {
+                  ok: false,
+                  error: `provider ${stoppingCategory}`,
+                  failureCategory: stoppingCategory,
+                  stdout,
+                  stderr,
+                  promptText: prompt,
+                },
+          );
+        }, 50);
+        settleTimer.unref?.();
+      }, TERMINAL_FAILURE_GRACE_MS);
+      forceTimer.unref?.();
+    };
+    const abort = () => {
+      if (settled || cancelled) return;
+      cancelled = true;
+      stopGracefully();
+    };
+    const detectStreamedTerminalFailure = () => {
+      if (settled || cancelled || stoppingCategory) return;
+      // Provider CLIs reserve stderr for diagnostics. Restrict early
+      // termination to that channel so a successful model answer that merely
+      // discusses a "rate limit" cannot be mistaken for a CLI failure.
+      const category = classifyProviderError(runtime?.provider ?? "claude", stderr);
+      if (!isRetryable(category)) return;
+      stoppingCategory = category;
+      stopGracefully();
+    };
     const timer = setTimeout(() => {
       try {
-        child.kill("SIGKILL");
+        terminateProviderTree(child, "SIGKILL");
       } catch {}
-      resolvePromise({
+      finish({
         ok: false,
         error: `timeout ${timeoutMs}ms`,
         stdout,
@@ -156,18 +275,30 @@ function runOnce(
       const text = d.toString();
       stderr += text;
       if (tee) process.stderr.write(text);
+      detectStreamedTerminalFailure();
     });
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
     child.on("close", (code) => {
-      clearTimeout(timer);
-      resolvePromise(
-        code === 0
+      finish(
+        cancelled
+          ? { ok: false, cancelled: true, error: "cancelled", stdout, stderr, promptText: prompt }
+          : stoppingCategory && (code === null || code === 0)
+            ? {
+                ok: false,
+                error: `provider ${stoppingCategory}`,
+                failureCategory: stoppingCategory,
+                stdout,
+                stderr,
+                promptText: prompt,
+              }
+            : code === 0
           ? { ok: true, stdout, stderr, promptText: prompt }
           : { ok: false, error: `exit ${code}`, stdout, stderr, promptText: prompt },
       );
     });
     child.on("error", (err) => {
-      clearTimeout(timer);
-      resolvePromise({ ok: false, error: err.message, stdout, stderr, promptText: prompt });
+      finish({ ok: false, error: err.message, stdout, stderr, promptText: prompt });
     });
   });
 }
@@ -176,6 +307,7 @@ export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
   const { runtime, tee = false } = opts;
   const first = await runOnce(rootPath, modeId, prompt, opts, runtime);
   if (first.ok) return first;
+  if (first.cancelled) return first;
   // Timeouts never retry: a fallback attempt would double a multi-minute
   // hang, and a timeout is not evidence of a model-side problem.
   if (typeof first.error === "string" && first.error.startsWith("timeout")) return first;
@@ -186,7 +318,8 @@ export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
   // from the PRIMARY provider's CLI, so classifying under any other provider's
   // signature table would invite false-positive retries (e.g. job output
   // quoting a JD phrase that matches another provider's needle).
-  const category = classifyProviderError(runtime?.provider ?? "claude", combined);
+  const category =
+    first.failureCategory ?? classifyProviderError(runtime?.provider ?? "claude", combined);
   if (!isRetryable(category)) return first;
 
   const fromTo = {
@@ -204,10 +337,17 @@ export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
     model: fallback.model,
   });
   if (!second.ok) {
+    const primaryLabel = `${runtime.provider}/${runtime.model}`;
+    const fallbackLabel = `${fallback.provider}/${fallback.model}`;
+    const primaryDiagnostic = String(first.stderr || first.stdout || first.error || "(no output)");
+    const fallbackDiagnostic = String(
+      second.stderr || second.stdout || second.error || "(no output)",
+    );
     return {
       ...second,
       stdout: `${marker}\n${second.stdout}`,
-      error: `primary: ${first.error} (${category}); fallback: ${second.error}`,
+      stderr: `[PRIMARY ${primaryLabel}]\n${primaryDiagnostic}\n[FALLBACK ${fallbackLabel}]\n${fallbackDiagnostic}`,
+      error: `primary ${primaryLabel}: ${first.error} (${category}); fallback ${fallbackLabel}: ${second.error}`,
     };
   }
   return { ...second, stdout: `${marker}\n${second.stdout}`, usedFallback: fromTo };

--- a/batch/lib/llm.mjs
+++ b/batch/lib/llm.mjs
@@ -130,10 +130,10 @@ export function terminateProviderTree(
   }
   if (child?.[ISOLATED_PROVIDER_GROUP] && Number.isInteger(pid) && pid > 1) {
     try {
-      // The detached supervisor owns a separate detached provider group. Ask
-      // it to SIGKILL that group so the supervisor can preserve the provider's
-      // real exit status and clean up after an uncatchable worker death.
-      child.kill("SIGTERM");
+      // The detached supervisor is the process-group leader and the provider
+      // inherits that group. This remains effective even if the supervisor has
+      // already exited while one of its provider descendants is still alive.
+      killImpl(-pid, signal);
     } catch (error) {
       if (error?.code !== "ESRCH") throw error;
     }
@@ -198,13 +198,21 @@ function processGroupIsAlive(processGroupId) {
   if (!Number.isInteger(processGroupId) || processGroupId <= 1 || process.platform === "win32") {
     return false;
   }
-  try {
-    process.kill(-processGroupId, 0);
-    return true;
-  } catch (error) {
-    if (error?.code === "ESRCH") return false;
-    return true;
-  }
+  // BSD ps and procps disagree about `-g`; filter an explicit PGID column.
+  // Zombies are already terminal and cannot overlap/fork into the fallback.
+  const result = spawnSync("ps", ["-A", "-o", "pid=", "-o", "pgid=", "-o", "stat="], {
+    encoding: "utf-8",
+    detached: true,
+  });
+  if (result.error || result.status !== 0) return true;
+  return String(result.stdout ?? "")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .some((line) => {
+      const [pid, pgid, state = ""] = line.trim().split(/\s+/, 3);
+      return Number(pid) > 1 && Number(pgid) === processGroupId && !state.includes("Z");
+    });
 }
 
 export function resolveRuntimeForMode(rootPath, modeId, { execImpl = defaultExec } = {}) {
@@ -278,7 +286,14 @@ export function buildSpawnArgsForMode(
       const error = new Error(`provider command build timed out after ${commandTimeoutMs}ms`);
       error.code = "ETIMEDOUT";
       error.stderr = String(result.stderr ?? "");
-      error.cleanupFailed = error.stderr.includes(PROVIDER_CLEANUP_FAILED_MARKER);
+      // Timed production builders already run under provider-supervisor via
+      // defaultExec. Verify its known process group as an extra guard for a
+      // surviving D-state member; custom execImpl fakes may omit result.pid.
+      error.cleanupFailed =
+        error.stderr.includes(PROVIDER_CLEANUP_FAILED_MARKER) ||
+        (process.platform !== "win32" &&
+          Number.isInteger(result.pid) &&
+          processGroupIsAlive(result.pid));
       throw error;
     }
     if (result.status !== 0) {
@@ -308,6 +323,7 @@ function runOnce(
     execImpl = defaultExec,
     spawnImpl = nodeSpawn,
     signal,
+    isolateProviderGroup: isolateProviderGroupOption,
     // Echo the provider's streams to OUR stdout/stderr as they arrive, so a
     // parent that captures this process's output (the job runner persisting
     // mode-runner stdout into the job record) shows progress live. Opt-in:
@@ -360,7 +376,9 @@ function runOnce(
       });
       return;
     }
-    const isolateProviderGroup = process.platform !== "win32" && spawnImpl === nodeSpawn;
+    const isolateProviderGroup =
+      process.platform !== "win32" &&
+      (isolateProviderGroupOption ?? spawnImpl === nodeSpawn);
     const child = spawnImpl(
       isolateProviderGroup ? process.execPath : built.spawn.cmd,
       isolateProviderGroup
@@ -395,6 +413,7 @@ function runOnce(
     const trackedDescendants = new Set();
     let timer = null;
     let settleTimer = null;
+    let settlePollMs = PROCESS_TREE_POLL_MS;
     const finish = (result) => {
       if (settled) return;
       settled = true;
@@ -502,8 +521,8 @@ function runOnce(
         );
         return;
       }
-      settleTimer = setTimeout(settleStoppedAttempt, PROCESS_TREE_POLL_MS);
-      settleTimer.unref?.();
+      settleTimer = setTimeout(settleStoppedAttempt, settlePollMs);
+      settlePollMs = Math.min(settlePollMs * 2, 100);
     };
 
     const killTree = (killSignal) => {
@@ -564,8 +583,10 @@ function runOnce(
     });
     child.stderr.on("data", (d) => {
       const text = d.toString();
+      const cleanupWindow =
+        stderr.slice(-(PROVIDER_CLEANUP_FAILED_MARKER.length - 1)) + text;
       stderr += text;
-      cleanupFailureReported ||= stderr.includes(PROVIDER_CLEANUP_FAILED_MARKER);
+      cleanupFailureReported ||= cleanupWindow.includes(PROVIDER_CLEANUP_FAILED_MARKER);
       if (tee) process.stderr.write(text);
       detectStreamedTerminalFailure();
     });

--- a/batch/lib/llm.mjs
+++ b/batch/lib/llm.mjs
@@ -8,10 +8,12 @@
 // Extracted from batch/screen.mjs and generalized to any mode.
 // execImpl/spawnImpl are injectable for tests.
 //
-// Fallback retry: when a run fails (and is NOT a timeout) and the runtime
-// carries a `.fallback = {provider, model}` pair, the combined output is
-// classified via cli/classify-error.mjs; a retryable category triggers ONE
-// retry on the fallback pair. On fallback success the result gains a
+// Fallback retry: when a run fails with a retryable provider error or a silent
+// timeout and the runtime carries a `.fallback = {provider, model}` pair, ONE
+// retry runs on the fallback pair. Each attempt has the configured provider
+// timeout and the full operation is capped at two such budgets; the primary
+// process tree must be gone before the fallback starts. On fallback success
+// the result gains a
 // `usedFallback` field and a `[FALLBACK] {json}` marker is prepended to
 // stdout (mirroring the `[USAGE]` marker) so the job runner can re-stamp the
 // record with the model that actually ran. A double failure returns a
@@ -19,15 +21,41 @@
 
 import { spawn as nodeSpawn, spawnSync } from "node:child_process";
 import { unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { classifyProviderError, isRetryable } from "../../cli/classify-error.mjs";
 
 function defaultExec(cmd, args, opts) {
+  if (process.platform !== "win32" && Number.isFinite(opts?.timeout) && opts.timeout > 0) {
+    return spawnSync(
+      process.execPath,
+      [
+        PROVIDER_SUPERVISOR,
+        "--parent-pid",
+        String(process.pid),
+        "--",
+        cmd,
+        ...args,
+      ],
+      {
+        encoding: "utf-8",
+        ...opts,
+        detached: true,
+        // The supervisor converts this catchable signal into a process-group
+        // SIGKILL, so a timed-out npx/tsx builder cannot leave descendants.
+        killSignal: "SIGTERM",
+      },
+    );
+  }
   return spawnSync(cmd, args, { encoding: "utf-8", ...opts });
 }
 
-const TERMINAL_FAILURE_GRACE_MS = 1000;
+const PROCESS_TREE_EXIT_GRACE_MS = 1000;
+const PROCESS_TREE_POLL_MS = 10;
+const STREAMED_ERROR_TAIL_CHARS = 16 * 1024;
+const ISOLATED_PROVIDER_GROUP = Symbol("sur9e.isolated-provider-group");
+const PROVIDER_SUPERVISOR = resolve(import.meta.dirname, "provider-supervisor.mjs");
 
-function descendantPids(pid) {
+function descendantPids(pid, { freeze = false } = {}) {
   if (!Number.isInteger(pid) || pid <= 1 || process.platform === "win32") return [];
   const found = [];
   const visited = new Set([pid]);
@@ -46,9 +74,16 @@ function descendantPids(pid) {
       .filter(
         (childPid) =>
           Number.isInteger(childPid) && childPid > 1 && childPid !== process.pid && !visited.has(childPid),
-      );
+    );
     for (const childPid of children) {
       visited.add(childPid);
+      if (freeze) {
+        try {
+          process.kill(childPid, "SIGSTOP");
+        } catch (error) {
+          if (error?.code !== "ESRCH") throw error;
+        }
+      }
       visit(childPid);
       found.push(childPid);
     }
@@ -63,10 +98,38 @@ export function terminateProviderTree(child, signal = "SIGTERM") {
   if (process.platform === "win32" && Number.isInteger(pid)) {
     const args = ["/PID", String(pid), "/T"];
     if (signal === "SIGKILL") args.push("/F");
-    spawnSync("taskkill", args, { stdio: "ignore" });
-    return;
+    const result = spawnSync("taskkill", args, { stdio: "ignore" });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`taskkill failed for provider process ${pid} (exit ${result.status})`);
+    }
+    return [];
   }
-  for (const childPid of descendantPids(pid)) {
+  if (child?.[ISOLATED_PROVIDER_GROUP] && Number.isInteger(pid) && pid > 1) {
+    try {
+      process.kill(-pid, signal);
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+    return [];
+  }
+  const canFreeze =
+    signal === "SIGKILL" &&
+    Number.isInteger(pid) &&
+    pid > 1 &&
+    typeof child?.spawnfile === "string";
+  if (canFreeze) {
+    try {
+      // Freeze the wrapper before walking its descendants. Each descendant is
+      // frozen before recursion, so no process in the tree can fork between
+      // discovery and the final SIGKILL pass.
+      process.kill(pid, "SIGSTOP");
+    } catch (error) {
+      if (error?.code !== "ESRCH") throw error;
+    }
+  }
+  const descendants = descendantPids(pid, { freeze: canFreeze });
+  for (const childPid of descendants) {
     try {
       process.kill(childPid, signal);
     } catch (error) {
@@ -77,6 +140,31 @@ export function terminateProviderTree(child, signal = "SIGTERM") {
     child.kill(signal);
   } catch (error) {
     if (error?.code !== "ESRCH") throw error;
+  }
+  return descendants;
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    return true;
+  }
+}
+
+function processGroupIsAlive(processGroupId) {
+  if (!Number.isInteger(processGroupId) || processGroupId <= 1 || process.platform === "win32") {
+    return false;
+  }
+  try {
+    process.kill(-processGroupId, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    return true;
   }
 }
 
@@ -106,7 +194,7 @@ export function buildSpawnArgsForMode(
   rootPath,
   modeId,
   prompt,
-  { logsDir, execImpl = defaultExec, runtime } = {},
+  { logsDir, execImpl = defaultExec, runtime, commandTimeoutMs } = {},
 ) {
   // Prompt goes through a tmp file: it inlines CV/profile/JD/mode bodies
   // and can be tens of KB — too big for argv across the extra shim hop.
@@ -140,8 +228,18 @@ export function buildSpawnArgsForMode(
         // spawn ran claude) is structurally impossible with an explicit pair.
         ...(runtime ? ["--platform", runtime.provider, "--model", runtime.model] : []),
       ],
-      { cwd: rootPath },
+      {
+        cwd: rootPath,
+        ...(Number.isFinite(commandTimeoutMs) && commandTimeoutMs > 0
+          ? { timeout: commandTimeoutMs, killSignal: "SIGTERM" }
+          : {}),
+      },
     );
+    if (result.error?.code === "ETIMEDOUT") {
+      const error = new Error(`provider command build timed out after ${commandTimeoutMs}ms`);
+      error.code = "ETIMEDOUT";
+      throw error;
+    }
     if (result.status !== 0) {
       throw new Error(
         `build-claude-cmd.mjs failed for ${modeId} (exit ${result.status}): ${result.stderr || result.stdout || "(no output)"}`,
@@ -178,94 +276,242 @@ function runOnce(
   runtime,
 ) {
   return new Promise((resolvePromise) => {
+    const attemptDeadline = Date.now() + timeoutMs;
     let built;
     try {
-      built = buildSpawnArgsForMode(rootPath, modeId, prompt, { logsDir, execImpl, runtime });
+      built = buildSpawnArgsForMode(rootPath, modeId, prompt, {
+        logsDir,
+        execImpl,
+        runtime,
+        commandTimeoutMs: timeoutMs,
+      });
     } catch (err) {
-      resolvePromise({ ok: false, error: err.message, stdout: "", stderr: "", promptText: prompt });
+      resolvePromise(
+        err?.code === "ETIMEDOUT"
+          ? {
+              ok: false,
+              error: `timeout ${timeoutMs}ms`,
+              failureCategory: "timeout",
+              stdout: "",
+              stderr: "",
+              promptText: prompt,
+              // spawnSync cannot verify a timed-out npx/tsx descendant tree on
+              // Windows. Suppress fallback rather than overlap an orphaned
+              // builder with a second provider attempt.
+              ...(process.platform === "win32" ? { cleanupFailed: true } : {}),
+            }
+          : { ok: false, error: err.message, stdout: "", stderr: "", promptText: prompt },
+      );
       return;
     }
-    const child = spawnImpl(built.spawn.cmd, built.spawn.args, {
-      cwd: rootPath,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const providerTimeoutMs = attemptDeadline - Date.now();
+    if (providerTimeoutMs <= 0) {
+      resolvePromise({
+        ok: false,
+        error: `timeout ${timeoutMs}ms`,
+        failureCategory: "timeout",
+        stdout: "",
+        stderr: "",
+        promptText: prompt,
+      });
+      return;
+    }
+    const isolateProviderGroup = process.platform !== "win32" && spawnImpl === nodeSpawn;
+    const child = spawnImpl(
+      isolateProviderGroup ? process.execPath : built.spawn.cmd,
+      isolateProviderGroup
+        ? [
+            PROVIDER_SUPERVISOR,
+            "--parent-pid",
+            String(process.pid),
+            "--",
+            built.spawn.cmd,
+            ...built.spawn.args,
+          ]
+        : built.spawn.args,
+      {
+        cwd: rootPath,
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: isolateProviderGroup,
+      },
+    );
+    if (isolateProviderGroup && Number.isInteger(child.pid) && child.pid > 1) {
+      child[ISOLATED_PROVIDER_GROUP] = true;
+    }
     let stdout = "";
     let stderr = "";
     let settled = false;
     let stoppingCategory = null;
-    let cancelled = false;
-    let forceTimer = null;
+    let stopReason = null;
+    let hardStopStartedAt = 0;
+    let hardStopFailed = false;
+    let childClosed = false;
+    let childExitCode = null;
+    const trackedDescendants = new Set();
+    let timer = null;
+    let settleTimer = null;
     const finish = (result) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      if (forceTimer) clearTimeout(forceTimer);
+      if (settleTimer) clearTimeout(settleTimer);
       signal?.removeEventListener("abort", abort);
       resolvePromise(result);
     };
-    const stopGracefully = () => {
-      try {
-        terminateProviderTree(child, "SIGTERM");
-      } catch {}
-      forceTimer = setTimeout(() => {
-        try {
-          terminateProviderTree(child, "SIGKILL");
-        } catch {}
-        // A broken wrapper can fail to emit `close` even after its process
-        // tree is gone. Do not turn a recognized provider failure into the
-        // full mode timeout; settle from the diagnostic that initiated stop.
-        const settleTimer = setTimeout(() => {
-          finish(
-            cancelled
-              ? {
-                  ok: false,
-                  cancelled: true,
-                  error: "cancelled",
-                  stdout,
-                  stderr,
-                  promptText: prompt,
-                }
-              : {
-                  ok: false,
-                  error: `provider ${stoppingCategory}`,
-                  failureCategory: stoppingCategory,
-                  stdout,
-                  stderr,
-                  promptText: prompt,
-                },
-          );
-        }, 50);
-        settleTimer.unref?.();
-      }, TERMINAL_FAILURE_GRACE_MS);
-      forceTimer.unref?.();
-    };
-    const abort = () => {
-      if (settled || cancelled) return;
-      cancelled = true;
-      stopGracefully();
-    };
-    const detectStreamedTerminalFailure = () => {
-      if (settled || cancelled || stoppingCategory) return;
-      // Provider CLIs reserve stderr for diagnostics. Restrict early
-      // termination to that channel so a successful model answer that merely
-      // discusses a "rate limit" cannot be mistaken for a CLI failure.
-      const category = classifyProviderError(runtime?.provider ?? "claude", stderr);
-      if (!isRetryable(category)) return;
-      stoppingCategory = category;
-      stopGracefully();
-    };
-    const timer = setTimeout(() => {
-      try {
-        terminateProviderTree(child, "SIGKILL");
-      } catch {}
-      finish({
+
+    const stoppedResult = (cleanupFailed = false) => {
+      const cleanupSuffix = cleanupFailed ? "; provider process tree did not terminate" : "";
+      if (stopReason === "process_exit") {
+        if (cleanupFailed) {
+          return {
+            ok: false,
+            error: `exit ${childExitCode}${cleanupSuffix}`,
+            stdout,
+            stderr,
+            promptText: prompt,
+            cleanupFailed: true,
+          };
+        }
+        return childExitCode === 0
+          ? { ok: true, stdout, stderr, promptText: prompt }
+          : { ok: false, error: `exit ${childExitCode}`, stdout, stderr, promptText: prompt };
+      }
+      if (stopReason === "cancelled") {
+        return {
+          ok: false,
+          cancelled: true,
+          error: `cancelled${cleanupSuffix}`,
+          stdout,
+          stderr,
+          promptText: prompt,
+          ...(cleanupFailed ? { cleanupFailed: true } : {}),
+        };
+      }
+      if (stopReason === "timeout") {
+        return {
+          ok: false,
+          error: `timeout ${timeoutMs}ms${cleanupSuffix}`,
+          failureCategory: "timeout",
+          stdout,
+          stderr,
+          promptText: prompt,
+          ...(cleanupFailed ? { cleanupFailed: true } : {}),
+        };
+      }
+      if (childClosed && childExitCode !== null && childExitCode !== 0) {
+        return {
+          ok: false,
+          error: `exit ${childExitCode}${cleanupSuffix}`,
+          failureCategory: stoppingCategory,
+          stdout,
+          stderr,
+          promptText: prompt,
+          ...(cleanupFailed ? { cleanupFailed: true } : {}),
+        };
+      }
+      return {
         ok: false,
-        error: `timeout ${timeoutMs}ms`,
+        error: `provider ${stoppingCategory}${cleanupSuffix}`,
+        failureCategory: stoppingCategory,
         stdout,
         stderr,
         promptText: prompt,
-      });
-    }, timeoutMs);
+        ...(cleanupFailed ? { cleanupFailed: true } : {}),
+      };
+    };
+
+    const settleStoppedAttempt = () => {
+      if (settled || !stopReason) return;
+      const descendantsAlive = [...trackedDescendants].some(processIsAlive);
+      const isolatedGroupAlive =
+        child[ISOLATED_PROVIDER_GROUP] && processGroupIsAlive(child.pid);
+      // Real ChildProcess instances expose spawnfile. Test doubles settle via
+      // their close event instead of probing an arbitrary fake pid.
+      const rootAlive =
+        !childClosed &&
+        !child[ISOLATED_PROVIDER_GROUP] &&
+        typeof child.spawnfile === "string" &&
+        processIsAlive(child.pid);
+      if (
+        !descendantsAlive &&
+        !isolatedGroupAlive &&
+        !rootAlive &&
+        childClosed &&
+        !hardStopFailed
+      ) {
+        finish(stoppedResult());
+        return;
+      }
+      if (
+        hardStopStartedAt > 0 &&
+        Date.now() - hardStopStartedAt >= PROCESS_TREE_EXIT_GRACE_MS
+      ) {
+        finish(
+          stoppedResult(
+            descendantsAlive ||
+              isolatedGroupAlive ||
+              rootAlive ||
+              !childClosed ||
+              hardStopFailed,
+          ),
+        );
+        return;
+      }
+      settleTimer = setTimeout(settleStoppedAttempt, PROCESS_TREE_POLL_MS);
+      settleTimer.unref?.();
+    };
+
+    const killTree = (killSignal) => {
+      let failed = false;
+      try {
+        for (const pid of terminateProviderTree(child, killSignal)) trackedDescendants.add(pid);
+      } catch {
+        failed = true;
+      }
+      // The wrapper may have exited after the first traversal. Keep signaling
+      // every descendant already discovered so escalation cannot lose it.
+      for (const pid of trackedDescendants) {
+        try {
+          process.kill(pid, killSignal);
+        } catch (error) {
+          if (error?.code !== "ESRCH") failed = true;
+        }
+      }
+      if (killSignal === "SIGKILL") hardStopFailed = failed;
+    };
+
+    const stopImmediately = () => {
+      if (!hardStopStartedAt) hardStopStartedAt = Date.now();
+      killTree("SIGKILL");
+      settleStoppedAttempt();
+    };
+
+    const abort = () => {
+      if (settled || stopReason === "cancelled") return;
+      clearTimeout(timer);
+      stopReason = "cancelled";
+      stopImmediately();
+    };
+    const detectStreamedTerminalFailure = () => {
+      if (settled || stopReason || stoppingCategory) return;
+      // Provider CLIs reserve stderr for diagnostics. Restrict early
+      // termination to that channel so a successful model answer that merely
+      // discusses a "rate limit" cannot be mistaken for a CLI failure.
+      const category = classifyProviderError(
+        runtime?.provider ?? "claude",
+        stderr.slice(-STREAMED_ERROR_TAIL_CHARS),
+      );
+      if (!isRetryable(category)) return;
+      stoppingCategory = category;
+      stopReason = "provider";
+      clearTimeout(timer);
+      stopImmediately();
+    };
+    timer = setTimeout(() => {
+      if (settled || stopReason) return;
+      stopReason = "timeout";
+      stopImmediately();
+    }, providerTimeoutMs);
     child.stdout.on("data", (d) => {
       const text = d.toString();
       stdout += text;
@@ -277,42 +523,56 @@ function runOnce(
       if (tee) process.stderr.write(text);
       detectStreamedTerminalFailure();
     });
-    if (signal?.aborted) abort();
-    else signal?.addEventListener("abort", abort, { once: true });
     child.on("close", (code) => {
+      childClosed = true;
+      childExitCode = code;
+      if (stopReason) {
+        settleStoppedAttempt();
+        return;
+      }
+      if (child[ISOLATED_PROVIDER_GROUP] && processGroupIsAlive(child.pid)) {
+        stopReason = "process_exit";
+        stopImmediately();
+        return;
+      }
       finish(
-        cancelled
-          ? { ok: false, cancelled: true, error: "cancelled", stdout, stderr, promptText: prompt }
-          : stoppingCategory && (code === null || code === 0)
-            ? {
-                ok: false,
-                error: `provider ${stoppingCategory}`,
-                failureCategory: stoppingCategory,
-                stdout,
-                stderr,
-                promptText: prompt,
-              }
-            : code === 0
+        childExitCode === 0
           ? { ok: true, stdout, stderr, promptText: prompt }
-          : { ok: false, error: `exit ${code}`, stdout, stderr, promptText: prompt },
+          : { ok: false, error: `exit ${childExitCode}`, stdout, stderr, promptText: prompt },
       );
     });
     child.on("error", (err) => {
+      if (stopReason) {
+        settleStoppedAttempt();
+        return;
+      }
       finish({ ok: false, error: err.message, stdout, stderr, promptText: prompt });
     });
+    if (signal?.aborted) abort();
+    else signal?.addEventListener("abort", abort, { once: true });
   });
 }
 
 export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
   const { runtime, tee = false } = opts;
-  const first = await runOnce(rootPath, modeId, prompt, opts, runtime);
+  const fallback = runtime?.fallback;
+  const hasFallback = Boolean(fallback?.provider && fallback?.model);
+  const timeoutMs =
+    Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0 ? Math.floor(opts.timeoutMs) : 600000;
+  // `timeoutMs` remains the per-provider contract (evaluate is allowed its
+  // existing 15 minutes). A configured fallback gets at most one equally
+  // bounded attempt, so the operation cannot outlive two provider budgets.
+  const deadline = Date.now() + timeoutMs * (hasFallback ? 2 : 1);
+  const first = await runOnce(
+    rootPath,
+    modeId,
+    prompt,
+    { ...opts, timeoutMs },
+    runtime,
+  );
   if (first.ok) return first;
   if (first.cancelled) return first;
-  // Timeouts never retry: a fallback attempt would double a multi-minute
-  // hang, and a timeout is not evidence of a model-side problem.
-  if (typeof first.error === "string" && first.error.startsWith("timeout")) return first;
-  const fallback = runtime?.fallback;
-  if (!fallback?.provider || !fallback?.model) return first;
+  if (!hasFallback || first.cleanupFailed) return first;
   const combined = `${first.stderr ?? ""}\n${first.stdout ?? ""}\n${first.error ?? ""}`;
   // Classify ONCE under the primary provider. The failure text always comes
   // from the PRIMARY provider's CLI, so classifying under any other provider's
@@ -320,7 +580,15 @@ export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
   // quoting a JD phrase that matches another provider's needle).
   const category =
     first.failureCategory ?? classifyProviderError(runtime?.provider ?? "claude", combined);
-  if (!isRetryable(category)) return first;
+  if (category !== "timeout" && !isRetryable(category)) return first;
+
+  // Cancellation can land after the first attempt settles but before the
+  // retry is spawned. It must win that race and suppress fallback entirely.
+  if (opts.signal?.aborted) {
+    return { ...first, cancelled: true, error: "cancelled" };
+  }
+  const fallbackTimeoutMs = Math.min(timeoutMs, deadline - Date.now());
+  if (fallbackTimeoutMs <= 0) return first;
 
   const fromTo = {
     from: { provider: runtime.provider, model: runtime.model },
@@ -332,10 +600,14 @@ export async function runModeLLM(rootPath, modeId, prompt, opts = {}) {
   // it is also embedded in the returned stdout so per-run log files carry it.
   if (tee) process.stdout.write(`${marker}\n`);
 
-  const second = await runOnce(rootPath, modeId, prompt, opts, {
-    provider: fallback.provider,
-    model: fallback.model,
-  });
+  const second = await runOnce(
+    rootPath,
+    modeId,
+    prompt,
+    { ...opts, timeoutMs: fallbackTimeoutMs },
+    { provider: fallback.provider, model: fallback.model },
+  );
+  if (second.cancelled) return second;
   if (!second.ok) {
     const primaryLabel = `${runtime.provider}/${runtime.model}`;
     const fallbackLabel = `${fallback.provider}/${fallback.model}`;

--- a/batch/lib/llm.mjs
+++ b/batch/lib/llm.mjs
@@ -52,19 +52,33 @@ function defaultExec(cmd, args, opts) {
 const PROCESS_TREE_EXIT_GRACE_MS = 1000;
 const PROCESS_TREE_POLL_MS = 10;
 const STREAMED_ERROR_TAIL_CHARS = 16 * 1024;
+const PROVIDER_CLEANUP_FAILED_MARKER = "[SUR9E_PROVIDER_CLEANUP_FAILED]";
 const ISOLATED_PROVIDER_GROUP = Symbol("sur9e.isolated-provider-group");
 const PROVIDER_SUPERVISOR = resolve(import.meta.dirname, "provider-supervisor.mjs");
 
-function descendantPids(pid, { freeze = false } = {}) {
-  if (!Number.isInteger(pid) || pid <= 1 || process.platform === "win32") return [];
+function descendantPids(
+  pid,
+  {
+    freeze = false,
+    platform = process.platform,
+    spawnSyncImpl = spawnSync,
+    killImpl = process.kill,
+    onError = () => {},
+  } = {},
+) {
+  if (!Number.isInteger(pid) || pid <= 1 || platform === "win32") return [];
   const found = [];
   const visited = new Set([pid]);
   const visit = (parentPid) => {
     // `ps --ppid` is GNU-only; macOS ships BSD ps. `pgrep -P` is available
     // on both supported Unix families and returns one direct child per line.
-    const result = spawnSync("pgrep", ["-P", String(parentPid)], {
+    const result = spawnSyncImpl("pgrep", ["-P", String(parentPid)], {
       encoding: "utf-8",
     });
+    if (result.error) {
+      onError(result.error);
+      return;
+    }
     if (result.status !== 0) return;
     const children = String(result.stdout ?? "")
       .trim()
@@ -77,13 +91,16 @@ function descendantPids(pid, { freeze = false } = {}) {
     );
     for (const childPid of children) {
       visited.add(childPid);
+      let vanished = false;
       if (freeze) {
         try {
-          process.kill(childPid, "SIGSTOP");
+          killImpl(childPid, "SIGSTOP");
         } catch (error) {
-          if (error?.code !== "ESRCH") throw error;
+          if (error?.code === "ESRCH") vanished = true;
+          else onError(error);
         }
       }
+      if (vanished) continue;
       visit(childPid);
       found.push(childPid);
     }
@@ -93,21 +110,30 @@ function descendantPids(pid, { freeze = false } = {}) {
 }
 
 /** Stop the provider wrapper and every descendant it spawned. */
-export function terminateProviderTree(child, signal = "SIGTERM") {
+export function terminateProviderTree(
+  child,
+  signal = "SIGTERM",
+  { platform = process.platform, spawnSyncImpl = spawnSync, killImpl = process.kill } = {},
+) {
   const pid = child?.pid;
-  if (process.platform === "win32" && Number.isInteger(pid)) {
+  if (platform === "win32" && Number.isInteger(pid) && pid > 1) {
     const args = ["/PID", String(pid), "/T"];
     if (signal === "SIGKILL") args.push("/F");
-    const result = spawnSync("taskkill", args, { stdio: "ignore" });
+    const result = spawnSyncImpl("taskkill", args, { encoding: "utf-8" });
     if (result.error) throw result.error;
-    if (result.status !== 0) {
+    const diagnostic = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const alreadyGone = result.status === 128 || /not found|no running instance/i.test(diagnostic);
+    if (result.status !== 0 && !alreadyGone) {
       throw new Error(`taskkill failed for provider process ${pid} (exit ${result.status})`);
     }
     return [];
   }
   if (child?.[ISOLATED_PROVIDER_GROUP] && Number.isInteger(pid) && pid > 1) {
     try {
-      process.kill(-pid, signal);
+      // The detached supervisor owns a separate detached provider group. Ask
+      // it to SIGKILL that group so the supervisor can preserve the provider's
+      // real exit status and clean up after an uncatchable worker death.
+      child.kill("SIGTERM");
     } catch (error) {
       if (error?.code !== "ESRCH") throw error;
     }
@@ -118,29 +144,42 @@ export function terminateProviderTree(child, signal = "SIGTERM") {
     Number.isInteger(pid) &&
     pid > 1 &&
     typeof child?.spawnfile === "string";
+  let cleanupError = null;
+  const rememberError = (error) => {
+    cleanupError ??= error;
+  };
+  let freezeDescendants = canFreeze;
   if (canFreeze) {
     try {
       // Freeze the wrapper before walking its descendants. Each descendant is
       // frozen before recursion, so no process in the tree can fork between
       // discovery and the final SIGKILL pass.
-      process.kill(pid, "SIGSTOP");
+      killImpl(pid, "SIGSTOP");
     } catch (error) {
-      if (error?.code !== "ESRCH") throw error;
+      if (error?.code !== "ESRCH") rememberError(error);
+      freezeDescendants = false;
     }
   }
-  const descendants = descendantPids(pid, { freeze: canFreeze });
+  const descendants = descendantPids(pid, {
+    freeze: freezeDescendants,
+    platform,
+    spawnSyncImpl,
+    killImpl,
+    onError: rememberError,
+  });
   for (const childPid of descendants) {
     try {
-      process.kill(childPid, signal);
+      killImpl(childPid, signal);
     } catch (error) {
-      if (error?.code !== "ESRCH") throw error;
+      if (error?.code !== "ESRCH") rememberError(error);
     }
   }
   try {
     child.kill(signal);
   } catch (error) {
-    if (error?.code !== "ESRCH") throw error;
+    if (error?.code !== "ESRCH") rememberError(error);
   }
+  if (cleanupError) throw cleanupError;
   return descendants;
 }
 
@@ -238,6 +277,8 @@ export function buildSpawnArgsForMode(
     if (result.error?.code === "ETIMEDOUT") {
       const error = new Error(`provider command build timed out after ${commandTimeoutMs}ms`);
       error.code = "ETIMEDOUT";
+      error.stderr = String(result.stderr ?? "");
+      error.cleanupFailed = error.stderr.includes(PROVIDER_CLEANUP_FAILED_MARKER);
       throw error;
     }
     if (result.status !== 0) {
@@ -293,12 +334,15 @@ function runOnce(
               error: `timeout ${timeoutMs}ms`,
               failureCategory: "timeout",
               stdout: "",
-              stderr: "",
+              stderr: err?.stderr ?? "",
               promptText: prompt,
               // spawnSync cannot verify a timed-out npx/tsx descendant tree on
-              // Windows. Suppress fallback rather than overlap an orphaned
-              // builder with a second provider attempt.
-              ...(process.platform === "win32" ? { cleanupFailed: true } : {}),
+              // Windows. The POSIX supervisor marks the same condition if its
+              // bounded process-group verification fails. Either case must
+              // suppress fallback rather than overlap a surviving builder.
+              ...(process.platform === "win32" || err?.cleanupFailed
+                ? { cleanupFailed: true }
+                : {}),
             }
           : { ok: false, error: err.message, stdout: "", stderr: "", promptText: prompt },
       );
@@ -347,6 +391,7 @@ function runOnce(
     let hardStopFailed = false;
     let childClosed = false;
     let childExitCode = null;
+    let cleanupFailureReported = false;
     const trackedDescendants = new Set();
     let timer = null;
     let settleTimer = null;
@@ -520,12 +565,28 @@ function runOnce(
     child.stderr.on("data", (d) => {
       const text = d.toString();
       stderr += text;
+      cleanupFailureReported ||= stderr.includes(PROVIDER_CLEANUP_FAILED_MARKER);
       if (tee) process.stderr.write(text);
       detectStreamedTerminalFailure();
     });
     child.on("close", (code) => {
       childClosed = true;
       childExitCode = code;
+      if (cleanupFailureReported) {
+        finish(
+          stopReason
+            ? stoppedResult(true)
+            : {
+                ok: false,
+                error: "provider process tree did not terminate",
+                stdout,
+                stderr,
+                promptText: prompt,
+                cleanupFailed: true,
+              },
+        );
+        return;
+      }
       if (stopReason) {
         settleStoppedAttempt();
         return;

--- a/batch/lib/provider-supervisor.mjs
+++ b/batch/lib/provider-supervisor.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from 'node:child_process';
+
+const separator = process.argv.indexOf('--');
+const parentIndex = process.argv.indexOf('--parent-pid');
+const expectedParentPid = Number(parentIndex >= 0 ? process.argv[parentIndex + 1] : 0);
+const command = separator >= 0 ? process.argv[separator + 1] : '';
+const args = separator >= 0 ? process.argv.slice(separator + 2) : [];
+
+if (!command || !Number.isInteger(expectedParentPid) || expectedParentPid <= 1) {
+  console.error('provider-supervisor: expected --parent-pid <pid> -- <command> [args...]');
+  process.exit(2);
+}
+
+let terminating = false;
+function terminateGroup() {
+  if (terminating) return;
+  terminating = true;
+  try {
+    // The supervisor is spawned detached and is therefore its process-group
+    // leader. SIGKILL the group so the provider and every tool it spawned die
+    // even when the worker parent disappeared without running cleanup.
+    process.kill(-process.pid, 'SIGKILL');
+  } catch {
+    process.exit(1);
+  }
+}
+
+function remainingGroupMembers() {
+  const result = spawnSync('ps', ['-o', 'pid=', '-o', 'stat=', '-g', String(process.pid)], {
+    encoding: 'utf8',
+    detached: true,
+  });
+  if (result.status !== 0) throw new Error('could not verify provider process group cleanup');
+  return String(result.stdout ?? '')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const [pid, state = ''] = line.trim().split(/\s+/, 2);
+      return { pid: Number(pid), state };
+    })
+    .filter(member =>
+      Number.isInteger(member.pid) && member.pid > 1 && member.pid !== process.pid
+    );
+}
+
+function signalMembers(members, signal) {
+  for (const { pid } of members) {
+    try {
+      process.kill(pid, signal);
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error;
+    }
+  }
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function cleanupRemainingGroupMembers() {
+  const freezeDeadline = Date.now() + 500;
+
+  while (Date.now() < freezeDeadline) {
+    const members = remainingGroupMembers();
+    if (members.length === 0) return;
+
+    // Stop every known member before killing any of them. Re-enumerate until
+    // membership is stable and every member is stopped (or already a zombie),
+    // closing the window in which a surviving helper could fork another child.
+    signalMembers(members, 'SIGSTOP');
+    await delay(5);
+    const verified = remainingGroupMembers();
+    const targeted = new Set(members.map(member => member.pid));
+    const frozen = verified.every(
+      member => targeted.has(member.pid) && /[TZ]/.test(member.state),
+    );
+    if (!frozen) continue;
+
+    signalMembers(verified, 'SIGKILL');
+    const reapDeadline = Date.now() + 1000;
+    while (Date.now() < reapDeadline) {
+      if (remainingGroupMembers().length === 0) return;
+      await delay(10);
+    }
+    throw new Error('provider descendants did not terminate');
+  }
+
+  throw new Error('provider descendants could not be frozen');
+}
+
+for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+  process.on(signal, terminateGroup);
+}
+
+const provider = spawn(command, args, {
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+
+const parentWatch = setInterval(() => {
+  if (process.ppid !== expectedParentPid) terminateGroup();
+}, 100);
+
+provider.on('error', error => {
+  clearInterval(parentWatch);
+  console.error(error.message);
+  process.exit(1);
+});
+
+provider.on('close', async (code, signal) => {
+  // A provider wrapper can exit while a tool/daemon it spawned remains in the
+  // group. Freeze and remove those descendants before reporting the provider's
+  // real exit status, so success remains success and fallback cannot overlap it.
+  try {
+    await cleanupRemainingGroupMembers();
+  } catch {
+    terminateGroup();
+    return;
+  }
+  clearInterval(parentWatch);
+  if (signal) {
+    process.exit(1);
+  } else {
+    process.exit(code ?? 1);
+  }
+});

--- a/batch/lib/provider-supervisor.mjs
+++ b/batch/lib/provider-supervisor.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn, spawnSync } from 'node:child_process';
+import { writeSync } from 'node:fs';
 
 const separator = process.argv.indexOf('--');
 const parentIndex = process.argv.indexOf('--parent-pid');
@@ -15,9 +16,6 @@ if (!command || !Number.isInteger(expectedParentPid) || expectedParentPid <= 1) 
 
 const provider = spawn(command, args, {
   stdio: ['ignore', 'inherit', 'inherit'],
-  // Keep the supervisor outside the provider group. It can then atomically
-  // SIGKILL the provider and all descendants without losing its own exit code.
-  detached: true,
 });
 
 const CLEANUP_FAILED_MARKER = '[SUR9E_PROVIDER_CLEANUP_FAILED]';
@@ -27,70 +25,112 @@ let terminating = false;
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-function providerGroupHasLiveMembers() {
-  if (!Number.isInteger(provider.pid) || provider.pid <= 1) return false;
+function remainingGroupMembers() {
   // BSD ps and procps disagree about `-g`. Enumerate explicitly and filter by
-  // PGID so this check means the same thing on macOS and Linux. A zombie has
-  // already received SIGKILL and cannot execute or fork, so it is safe for the
-  // supervisor to leave reaping to the OS while still blocking on D/T/R/S/etc.
+  // PGID so this query means the same thing on macOS and Linux.
   const result = spawnSync('ps', ['-A', '-o', 'pid=', '-o', 'pgid=', '-o', 'stat='], {
     encoding: 'utf8',
     detached: true,
   });
   if (result.error) throw result.error;
-  if (result.status !== 0) throw new Error(`ps failed while verifying provider cleanup`);
+  if (result.status !== 0) throw new Error('ps failed while verifying provider cleanup');
   return String(result.stdout ?? '')
     .trim()
     .split('\n')
     .filter(Boolean)
-    .some(line => {
+    .map(line => {
       const [pid, pgid, state = ''] = line.trim().split(/\s+/, 3);
-      return Number(pid) > 1 && Number(pgid) === provider.pid && !state.includes('Z');
-    });
+      return { pid: Number(pid), pgid: Number(pgid), state };
+    })
+    .filter(member =>
+      Number.isInteger(member.pid) &&
+      member.pid > 1 &&
+      member.pid !== process.pid &&
+      member.pgid === process.pid
+    );
 }
 
-function killProviderGroup() {
-  if (!Number.isInteger(provider.pid) || provider.pid <= 1) return;
-  try {
-    process.kill(-provider.pid, 'SIGKILL');
-  } catch (error) {
-    if (error?.code !== 'ESRCH') throw error;
+function liveGroupMembers() {
+  // Zombies have already received their terminal signal and cannot execute or
+  // fork. Reaping them is the OS's responsibility; every other state blocks a
+  // fallback from starting.
+  return remainingGroupMembers().filter(member => !member.state.includes('Z'));
+}
+
+function signalMembers(members, signal) {
+  for (const { pid } of members) {
+    try {
+      process.kill(pid, signal);
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error;
+    }
   }
 }
 
-async function killProviderGroupAndWait() {
-  killProviderGroup();
-  const deadline = Date.now() + GROUP_EXIT_GRACE_MS;
-  while (providerGroupHasLiveMembers() && Date.now() < deadline) {
-    await delay(GROUP_POLL_MS);
-  }
-  if (providerGroupHasLiveMembers()) {
-    throw new Error('provider process group did not terminate');
-  }
-}
-
-function exitForCleanupFailure(error) {
-  console.error(`${CLEANUP_FAILED_MARKER} ${error?.message ?? 'provider cleanup failed'}`);
-  process.exit(1);
-}
-
-async function terminateProviderGroup() {
+function terminateGroup() {
   if (terminating) return;
   terminating = true;
   try {
-    await killProviderGroupAndWait();
+    // The supervisor is the detached process-group leader and the provider
+    // inherits this group. One uncatchable signal therefore reaches the
+    // supervisor, provider wrapper, and every non-detached descendant.
+    process.kill(-process.pid, 'SIGKILL');
+  } catch {
     process.exit(1);
-  } catch (error) {
-    exitForCleanupFailure(error);
   }
 }
 
+async function cleanupRemainingGroupMembers() {
+  const freezeDeadline = Date.now() + 500;
+  let pollMs = GROUP_POLL_MS;
+
+  while (Date.now() < freezeDeadline) {
+    const members = liveGroupMembers();
+    if (members.length === 0) return;
+
+    // Freeze every known member and re-enumerate until the set is stable. Once
+    // all live members are stopped, none can fork between verification and the
+    // final individual SIGKILL pass (which leaves the supervisor alive).
+    signalMembers(members, 'SIGSTOP');
+    await delay(5);
+    const verified = liveGroupMembers();
+    const targeted = new Set(members.map(member => member.pid));
+    const frozen = verified.every(
+      member => targeted.has(member.pid) && member.state.includes('T'),
+    );
+    if (!frozen) {
+      await delay(pollMs);
+      pollMs = Math.min(pollMs * 2, 100);
+      continue;
+    }
+
+    signalMembers(verified, 'SIGKILL');
+    const exitDeadline = Date.now() + GROUP_EXIT_GRACE_MS;
+    pollMs = GROUP_POLL_MS;
+    while (Date.now() < exitDeadline) {
+      if (liveGroupMembers().length === 0) return;
+      await delay(pollMs);
+      pollMs = Math.min(pollMs * 2, 100);
+    }
+    throw new Error('provider process group did not terminate');
+  }
+
+  throw new Error('provider process group could not be frozen');
+}
+
+function exitForCleanupFailure(error) {
+  try {
+    writeSync(2, `${CLEANUP_FAILED_MARKER} ${error?.message ?? 'provider cleanup failed'}\n`);
+  } catch {}
+  terminateGroup();
+}
+
 for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
-  process.on(signal, () => void terminateProviderGroup());
+  process.on(signal, terminateGroup);
 }
 
 const parentWatch = setInterval(() => {
-  if (process.ppid !== expectedParentPid) void terminateProviderGroup();
+  if (process.ppid !== expectedParentPid) terminateGroup();
 }, 100);
 
 provider.on('error', error => {
@@ -101,18 +141,18 @@ provider.on('error', error => {
 
 provider.on('close', async (code, signal) => {
   if (terminating) return;
-  terminating = true;
-  clearInterval(parentWatch);
   // A provider wrapper can exit while a tool/daemon it spawned remains in the
-  // provider group. The supervisor lives in a different group, so this atomic
-  // kill preserves the provider's exit status while preventing overlap with a
-  // fallback attempt.
+  // group. Remove those descendants before forwarding the wrapper's real exit
+  // status; parent-death monitoring stays active throughout this cleanup.
   try {
-    await killProviderGroupAndWait();
+    await cleanupRemainingGroupMembers();
   } catch (error) {
     exitForCleanupFailure(error);
     return;
   }
+  if (terminating) return;
+  terminating = true;
+  clearInterval(parentWatch);
   if (signal) {
     process.exit(1);
   } else {

--- a/batch/lib/provider-supervisor.mjs
+++ b/batch/lib/provider-supervisor.mjs
@@ -13,92 +13,84 @@ if (!command || !Number.isInteger(expectedParentPid) || expectedParentPid <= 1) 
   process.exit(2);
 }
 
-let terminating = false;
-function terminateGroup() {
-  if (terminating) return;
-  terminating = true;
-  try {
-    // The supervisor is spawned detached and is therefore its process-group
-    // leader. SIGKILL the group so the provider and every tool it spawned die
-    // even when the worker parent disappeared without running cleanup.
-    process.kill(-process.pid, 'SIGKILL');
-  } catch {
-    process.exit(1);
-  }
-}
+const provider = spawn(command, args, {
+  stdio: ['ignore', 'inherit', 'inherit'],
+  // Keep the supervisor outside the provider group. It can then atomically
+  // SIGKILL the provider and all descendants without losing its own exit code.
+  detached: true,
+});
 
-function remainingGroupMembers() {
-  const result = spawnSync('ps', ['-o', 'pid=', '-o', 'stat=', '-g', String(process.pid)], {
+const CLEANUP_FAILED_MARKER = '[SUR9E_PROVIDER_CLEANUP_FAILED]';
+const GROUP_EXIT_GRACE_MS = 1000;
+const GROUP_POLL_MS = 10;
+let terminating = false;
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+function providerGroupHasLiveMembers() {
+  if (!Number.isInteger(provider.pid) || provider.pid <= 1) return false;
+  // BSD ps and procps disagree about `-g`. Enumerate explicitly and filter by
+  // PGID so this check means the same thing on macOS and Linux. A zombie has
+  // already received SIGKILL and cannot execute or fork, so it is safe for the
+  // supervisor to leave reaping to the OS while still blocking on D/T/R/S/etc.
+  const result = spawnSync('ps', ['-A', '-o', 'pid=', '-o', 'pgid=', '-o', 'stat='], {
     encoding: 'utf8',
     detached: true,
   });
-  if (result.status !== 0) throw new Error('could not verify provider process group cleanup');
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`ps failed while verifying provider cleanup`);
   return String(result.stdout ?? '')
     .trim()
     .split('\n')
     .filter(Boolean)
-    .map(line => {
-      const [pid, state = ''] = line.trim().split(/\s+/, 2);
-      return { pid: Number(pid), state };
-    })
-    .filter(member =>
-      Number.isInteger(member.pid) && member.pid > 1 && member.pid !== process.pid
-    );
+    .some(line => {
+      const [pid, pgid, state = ''] = line.trim().split(/\s+/, 3);
+      return Number(pid) > 1 && Number(pgid) === provider.pid && !state.includes('Z');
+    });
 }
 
-function signalMembers(members, signal) {
-  for (const { pid } of members) {
-    try {
-      process.kill(pid, signal);
-    } catch (error) {
-      if (error?.code !== 'ESRCH') throw error;
-    }
+function killProviderGroup() {
+  if (!Number.isInteger(provider.pid) || provider.pid <= 1) return;
+  try {
+    process.kill(-provider.pid, 'SIGKILL');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
   }
 }
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-
-async function cleanupRemainingGroupMembers() {
-  const freezeDeadline = Date.now() + 500;
-
-  while (Date.now() < freezeDeadline) {
-    const members = remainingGroupMembers();
-    if (members.length === 0) return;
-
-    // Stop every known member before killing any of them. Re-enumerate until
-    // membership is stable and every member is stopped (or already a zombie),
-    // closing the window in which a surviving helper could fork another child.
-    signalMembers(members, 'SIGSTOP');
-    await delay(5);
-    const verified = remainingGroupMembers();
-    const targeted = new Set(members.map(member => member.pid));
-    const frozen = verified.every(
-      member => targeted.has(member.pid) && /[TZ]/.test(member.state),
-    );
-    if (!frozen) continue;
-
-    signalMembers(verified, 'SIGKILL');
-    const reapDeadline = Date.now() + 1000;
-    while (Date.now() < reapDeadline) {
-      if (remainingGroupMembers().length === 0) return;
-      await delay(10);
-    }
-    throw new Error('provider descendants did not terminate');
+async function killProviderGroupAndWait() {
+  killProviderGroup();
+  const deadline = Date.now() + GROUP_EXIT_GRACE_MS;
+  while (providerGroupHasLiveMembers() && Date.now() < deadline) {
+    await delay(GROUP_POLL_MS);
   }
+  if (providerGroupHasLiveMembers()) {
+    throw new Error('provider process group did not terminate');
+  }
+}
 
-  throw new Error('provider descendants could not be frozen');
+function exitForCleanupFailure(error) {
+  console.error(`${CLEANUP_FAILED_MARKER} ${error?.message ?? 'provider cleanup failed'}`);
+  process.exit(1);
+}
+
+async function terminateProviderGroup() {
+  if (terminating) return;
+  terminating = true;
+  try {
+    await killProviderGroupAndWait();
+    process.exit(1);
+  } catch (error) {
+    exitForCleanupFailure(error);
+  }
 }
 
 for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
-  process.on(signal, terminateGroup);
+  process.on(signal, () => void terminateProviderGroup());
 }
 
-const provider = spawn(command, args, {
-  stdio: ['ignore', 'inherit', 'inherit'],
-});
-
 const parentWatch = setInterval(() => {
-  if (process.ppid !== expectedParentPid) terminateGroup();
+  if (process.ppid !== expectedParentPid) void terminateProviderGroup();
 }, 100);
 
 provider.on('error', error => {
@@ -108,16 +100,19 @@ provider.on('error', error => {
 });
 
 provider.on('close', async (code, signal) => {
+  if (terminating) return;
+  terminating = true;
+  clearInterval(parentWatch);
   // A provider wrapper can exit while a tool/daemon it spawned remains in the
-  // group. Freeze and remove those descendants before reporting the provider's
-  // real exit status, so success remains success and fallback cannot overlap it.
+  // provider group. The supervisor lives in a different group, so this atomic
+  // kill preserves the provider's exit status while preventing overlap with a
+  // fallback attempt.
   try {
-    await cleanupRemainingGroupMembers();
-  } catch {
-    terminateGroup();
+    await killProviderGroupAndWait();
+  } catch (error) {
+    exitForCleanupFailure(error);
     return;
   }
-  clearInterval(parentWatch);
   if (signal) {
     process.exit(1);
   } else {

--- a/cli/classify-error.mjs
+++ b/cli/classify-error.mjs
@@ -92,10 +92,19 @@ const CATEGORY_ORDER = [
   'rate_limit',
 ];
 
-// Categories that justify a one-shot retry on the fallback pair. `auth`
-// (user must re-login), `context_overflow` (fails again), and `unknown`
-// (not model-related per the design decision) are deliberately excluded.
-const RETRYABLE = new Set(['model_not_found', 'rate_limit', 'overloaded', 'quota', 'install']);
+// Categories that justify a one-shot retry on the fallback pair. Auth is
+// provider-scoped: an expired Claude session says nothing about whether the
+// configured Codex/OpenCode fallback is authenticated, so it belongs on the
+// fallback path. `context_overflow` (same prompt fails again) and `unknown`
+// (not safely attributable to the provider) remain deliberately excluded.
+const RETRYABLE = new Set([
+  'auth',
+  'model_not_found',
+  'rate_limit',
+  'overloaded',
+  'quota',
+  'install',
+]);
 
 /**
  * Classify a provider CLI failure from its combined stdout+stderr text.

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -128,38 +128,54 @@ describe('spawnJob fallback metadata', () => {
       };
       persistJobRecord(root, job);
 
-      await spawnJob(root, job, { trackUsage: vi.fn() });
-      realWorkerProcessGroupId = readJobRecord(root, JOB_ID)?.processGroupId ?? null;
-      await vi.waitFor(
-        () => {
-          expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
-        },
-        { timeout: 5000, interval: 25 },
-      );
+      let descendantPid = 0;
+      try {
+        await spawnJob(root, job, { trackUsage: vi.fn() });
+        realWorkerProcessGroupId = readJobRecord(root, JOB_ID)?.processGroupId ?? null;
+        await vi.waitFor(() => expect(existsSync(descendantPidFile)).toBe(true), {
+          timeout: 5000,
+          interval: 25,
+        });
+        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        await vi.waitFor(
+          () => {
+            expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
+          },
+          { timeout: 5000, interval: 25 },
+        );
 
-      const completed = readJobRecord(root, JOB_ID);
-      expect(completed).toMatchObject({
-        status: 'done',
-        provider: fallback.provider,
-        model: fallback.model,
-        fallback: { from: primary, reason: 'timeout' },
-      });
-      expect(completed?.output).toContain('> build · glm-5.2');
-      expect(completed?.output).toContain('fallback completed');
-      expect(completed?.output).toContain(
-        `[FALLBACK] ${JSON.stringify({ from: primary, to: fallback, reason: 'timeout' })}`,
-      );
+        const completed = readJobRecord(root, JOB_ID);
+        expect(completed).toMatchObject({
+          status: 'done',
+          provider: fallback.provider,
+          model: fallback.model,
+          fallback: { from: primary, reason: 'timeout' },
+        });
+        expect(completed?.output).toContain('> build · glm-5.2');
+        expect(completed?.output).toContain('fallback completed');
+        expect(completed?.output).toContain(
+          `[FALLBACK] ${JSON.stringify({ from: primary, to: fallback, reason: 'timeout' })}`,
+        );
 
-      const descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
-      expect(descendantPid).toBeGreaterThan(1);
-      await vi.waitFor(
-        () => {
-          expect(() => process.kill(descendantPid, 0)).toThrow(
-            expect.objectContaining({ code: 'ESRCH' }),
-          );
-        },
-        { timeout: 1000, interval: 20 },
-      );
+        expect(descendantPid).toBeGreaterThan(1);
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(descendantPid, 0)).toThrow(
+              expect.objectContaining({ code: 'ESRCH' }),
+            );
+          },
+          { timeout: 1000, interval: 20 },
+        );
+      } finally {
+        if (descendantPid <= 1 && existsSync(descendantPidFile)) {
+          descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        }
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
     },
   );
 

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -1,16 +1,17 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { resolveModeRuntimeMock } = vi.hoisted(() => ({
+const { buildCommandMock, resolveModeRuntimeMock } = vi.hoisted(() => ({
+  buildCommandMock: vi.fn(() => ({ cmd: 'fake-worker', args: [] as string[] })),
   resolveModeRuntimeMock: vi.fn(),
 }));
 
 vi.mock('../command-registry', () => ({
-  buildCommand: vi.fn(() => ({ cmd: 'fake-worker', args: [] })),
+  buildCommand: buildCommandMock,
 }));
 
 vi.mock('../../providers/registry', () => ({
@@ -73,16 +74,94 @@ describe('extractFallbackStamp', () => {
 
 describe('spawnJob fallback metadata', () => {
   let root: string;
+  let realWorkerProcessGroupId: number | null;
 
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), 'sur9e-runner-fallback-stamp-'));
     mkdirSync(join(root, 'data/jobs'), { recursive: true });
+    buildCommandMock.mockReset();
+    buildCommandMock.mockReturnValue({ cmd: 'fake-worker', args: [] });
     resolveModeRuntimeMock.mockReset();
+    realWorkerProcessGroupId = null;
   });
 
   afterEach(() => {
+    if (
+      process.platform !== 'win32' &&
+      Number.isInteger(realWorkerProcessGroupId) &&
+      (realWorkerProcessGroupId as number) > 1
+    ) {
+      try {
+        process.kill(-(realWorkerProcessGroupId as number), 'SIGKILL');
+      } catch {}
+    }
     rmSync(root, { recursive: true, force: true });
   });
+
+  it.runIf(process.platform !== 'win32')(
+    'persists a real silent-timeout fallback and kills the primary descendant',
+    async () => {
+      const primary = { provider: 'opencode' as const, model: 'opencode-go/glm-5.2' };
+      const fallback = { provider: 'claude' as const, model: 'claude-sonnet-5' };
+      const descendantPidFile = join(root, 'descendant.pid');
+      const worker = join(process.cwd(), 'test/fixtures/fallback-timeout-worker.mjs');
+      buildCommandMock.mockReturnValue({
+        cmd: process.execPath,
+        args: [worker, root, descendantPidFile],
+      });
+      resolveModeRuntimeMock.mockReturnValue({
+        ...primary,
+        exec: 'headless',
+        resolvedFrom: 'global_default',
+        fallback,
+      });
+      const job: JobRecord = {
+        id: JOB_ID,
+        type: 'evaluate',
+        status: 'queued',
+        params: { num: 55 },
+        startedAt: '2026-08-01T20:00:00.000Z',
+        finishedAt: null,
+        output: '',
+        error: null,
+        exitCode: null,
+      };
+      persistJobRecord(root, job);
+
+      await spawnJob(root, job, { trackUsage: vi.fn() });
+      realWorkerProcessGroupId = readJobRecord(root, JOB_ID)?.processGroupId ?? null;
+      await vi.waitFor(
+        () => {
+          expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
+        },
+        { timeout: 5000, interval: 25 },
+      );
+
+      const completed = readJobRecord(root, JOB_ID);
+      expect(completed).toMatchObject({
+        status: 'done',
+        provider: fallback.provider,
+        model: fallback.model,
+        fallback: { from: primary, reason: 'timeout' },
+      });
+      expect(completed?.output).toContain('> build · glm-5.2');
+      expect(completed?.output).toContain('fallback completed');
+      expect(completed?.output).toContain(
+        `[FALLBACK] ${JSON.stringify({ from: primary, to: fallback, reason: 'timeout' })}`,
+      );
+
+      const descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+      expect(descendantPid).toBeGreaterThan(1);
+      await vi.waitFor(
+        () => {
+          expect(() => process.kill(descendantPid, 0)).toThrow(
+            expect.objectContaining({ code: 'ESRCH' }),
+          );
+        },
+        { timeout: 1000, interval: 20 },
+      );
+    },
+  );
 
   it.each([
     {

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -35,6 +35,31 @@ import { extractFallbackStamp, spawnJob } from '../runner';
 
 const JOB_ID = '0123456789abcdef';
 
+type KillProcess = (pid: number, signal: NodeJS.Signals) => unknown;
+
+function cleanupWorkerProcessGroup(
+  rootPath: string,
+  processGroupId: number | null,
+  killProcess: KillProcess = process.kill,
+): boolean {
+  if (
+    process.platform === 'win32' ||
+    typeof processGroupId !== 'number' ||
+    !Number.isInteger(processGroupId) ||
+    processGroupId <= 1
+  ) {
+    return false;
+  }
+  const job = readJobRecord(rootPath, JOB_ID);
+  if (job?.status !== 'running' || job.processGroupId !== processGroupId) return false;
+  try {
+    killProcess(-processGroupId, 'SIGKILL');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const PROVIDER_CASES = [
   {
     provider: 'claude' as const,
@@ -101,6 +126,36 @@ describe('extractFallbackStamp', () => {
   });
 });
 
+describe('cleanupWorkerProcessGroup', () => {
+  it.runIf(process.platform !== 'win32')(
+    'does not signal a terminal job process group whose id may have been reused',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'sur9e-terminal-worker-cleanup-'));
+      const processGroupId = 4321;
+      const killProcess = vi.fn();
+      persistJobRecord(root, {
+        id: JOB_ID,
+        type: 'evaluate',
+        status: 'done',
+        params: { num: 56 },
+        startedAt: '2026-08-02T01:29:47.873Z',
+        finishedAt: '2026-08-02T01:29:48.873Z',
+        output: 'fallback completed',
+        error: null,
+        exitCode: 0,
+        processGroupId,
+      });
+
+      try {
+        expect(cleanupWorkerProcessGroup(root, processGroupId, killProcess)).toBe(false);
+        expect(killProcess).not.toHaveBeenCalled();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
 describe('spawnJob fallback metadata', () => {
   let root: string;
   let realWorkerProcessGroupId: number | null;
@@ -115,15 +170,7 @@ describe('spawnJob fallback metadata', () => {
   });
 
   afterEach(() => {
-    if (
-      process.platform !== 'win32' &&
-      Number.isInteger(realWorkerProcessGroupId) &&
-      (realWorkerProcessGroupId as number) > 1
-    ) {
-      try {
-        process.kill(-(realWorkerProcessGroupId as number), 'SIGKILL');
-      } catch {}
-    }
+    cleanupWorkerProcessGroup(root, realWorkerProcessGroupId);
     rmSync(root, { recursive: true, force: true });
   });
 

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -364,6 +364,7 @@ fi
         }
       }
     },
+    15_000,
   );
 
   it.each(ONE_HOP_PROVIDER_PAIRS)(

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -1,6 +1,14 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -26,6 +34,27 @@ import { persistJobRecord, readJobRecord } from '../lifecycle';
 import { extractFallbackStamp, spawnJob } from '../runner';
 
 const JOB_ID = '0123456789abcdef';
+
+const PROVIDER_CASES = [
+  {
+    provider: 'claude' as const,
+    primaryModel: 'claude-opus-4-7',
+    fallbackModel: 'claude-sonnet-4-6',
+  },
+  { provider: 'codex' as const, primaryModel: 'gpt-5.4-mini', fallbackModel: 'gpt-5-codex' },
+  {
+    provider: 'opencode' as const,
+    primaryModel: 'opencode-go/glm-5.2',
+    fallbackModel: 'opencode/big-pickle',
+  },
+];
+
+const ONE_HOP_PROVIDER_PAIRS = PROVIDER_CASES.flatMap(primary =>
+  PROVIDER_CASES.map(fallback => ({
+    primary: { provider: primary.provider, model: primary.primaryModel },
+    fallback: { provider: fallback.provider, model: fallback.fallbackModel },
+  })),
+);
 
 function fakeChild(): ChildProcess & {
   stdout: NonNullable<ChildProcess['stdout']>;
@@ -183,20 +212,114 @@ describe('spawnJob fallback metadata', () => {
     },
   );
 
-  it.each([
-    {
-      primary: { provider: 'claude', model: 'claude-sonnet-4-6' },
-      fallback: { provider: 'codex', model: 'gpt-5.4-mini' },
+  it.runIf(process.platform !== 'win32')(
+    'persists an immediate OpenCode quota fallback from the real adapter command',
+    async () => {
+      const primary = { provider: 'opencode' as const, model: 'opencode-go/glm-5.2' };
+      const fallback = { provider: 'opencode' as const, model: 'opencode/big-pickle' };
+      const fakeBin = join(root, 'fake-bin');
+      const fakeOpencode = join(fakeBin, 'opencode');
+      const descendantPidFile = join(root, 'opencode-descendant.pid');
+      const worker = join(process.cwd(), 'test/fixtures/fallback-opencode-quota-worker.mjs');
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(
+        fakeOpencode,
+        `#!/bin/sh
+print_logs=false
+model=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --print-logs) print_logs=true ;;
+    -m|--model) shift; model="$1" ;;
+  esac
+  shift
+done
+if [ "$model" = "opencode-go/glm-5.2" ]; then
+  sleep 30 &
+  descendant=$!
+  printf '%s' "$descendant" > "$SUR9E_TEST_DESCENDANT_PID_FILE"
+  if [ "$print_logs" = true ]; then
+    printf '%s\n' 'AI_APICallError: Weekly usage limit reached. Resets in 1 day.' >&2
+  fi
+  wait "$descendant"
+else
+  printf '%s\n' 'fallback completed'
+fi
+`,
+        'utf8',
+      );
+      chmodSync(fakeOpencode, 0o755);
+      buildCommandMock.mockReturnValue({
+        cmd: process.execPath,
+        args: [worker, root, process.cwd(), fakeBin, descendantPidFile],
+      });
+      resolveModeRuntimeMock.mockReturnValue({
+        ...primary,
+        exec: 'headless',
+        resolvedFrom: 'mode_setting',
+        fallback,
+      });
+      const job: JobRecord = {
+        id: JOB_ID,
+        type: 'evaluate',
+        status: 'queued',
+        params: { num: 56 },
+        startedAt: '2026-08-02T01:29:47.873Z',
+        finishedAt: null,
+        output: '',
+        error: null,
+        exitCode: null,
+      };
+      persistJobRecord(root, job);
+
+      let descendantPid = 0;
+      try {
+        await spawnJob(root, job, { trackUsage: vi.fn() });
+        realWorkerProcessGroupId = readJobRecord(root, JOB_ID)?.processGroupId ?? null;
+        await vi.waitFor(
+          () => {
+            expect(existsSync(descendantPidFile)).toBe(true);
+            descendantPid = Number(readFileSync(descendantPidFile, 'utf8').trim());
+            expect(descendantPid).toBeGreaterThan(1);
+          },
+          { timeout: 5000, interval: 25 },
+        );
+        await vi.waitFor(() => expect(readJobRecord(root, JOB_ID)?.status).toBe('done'), {
+          timeout: 5000,
+          interval: 25,
+        });
+
+        const completed = readJobRecord(root, JOB_ID);
+        expect(completed).toMatchObject({
+          status: 'done',
+          provider: fallback.provider,
+          model: fallback.model,
+          fallback: { from: primary, reason: 'quota' },
+        });
+        expect(completed?.output).toContain('Weekly usage limit reached');
+        expect(completed?.output).toContain('fallback completed');
+        expect(completed?.output).toContain(
+          `[FALLBACK] ${JSON.stringify({ from: primary, to: fallback, reason: 'quota' })}`,
+        );
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(descendantPid, 0)).toThrow(
+              expect.objectContaining({ code: 'ESRCH' }),
+            );
+          },
+          { timeout: 1000, interval: 20 },
+        );
+      } finally {
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
     },
-    {
-      primary: { provider: 'codex', model: 'gpt-5.4-mini' },
-      fallback: { provider: 'opencode', model: 'opencode/big-pickle' },
-    },
-    {
-      primary: { provider: 'opencode', model: 'opencode/big-pickle' },
-      fallback: { provider: 'claude', model: 'claude-sonnet-4-6' },
-    },
-  ])(
+  );
+
+  it.each(ONE_HOP_PROVIDER_PAIRS)(
     're-stamps $primary.provider → $fallback.provider onto the selected fallback provider and model',
     async ({ primary, fallback }) => {
       resolveModeRuntimeMock.mockReturnValue({

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -329,10 +329,10 @@ fi
             descendantPid = Number(readFileSync(descendantPidFile, 'utf8').trim());
             expect(descendantPid).toBeGreaterThan(1);
           },
-          { timeout: 5000, interval: 25 },
+          { timeout: 10_000, interval: 25 },
         );
         await vi.waitFor(() => expect(readJobRecord(root, JOB_ID)?.status).toBe('done'), {
-          timeout: 5000,
+          timeout: 10_000,
           interval: 25,
         });
 
@@ -364,7 +364,7 @@ fi
         }
       }
     },
-    15_000,
+    25_000,
   );
 
   it.each(ONE_HOP_PROVIDER_PAIRS)(

--- a/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
+++ b/src/lib/server/jobs/__tests__/runner-fallback-stamp.test.ts
@@ -132,11 +132,14 @@ describe('spawnJob fallback metadata', () => {
       try {
         await spawnJob(root, job, { trackUsage: vi.fn() });
         realWorkerProcessGroupId = readJobRecord(root, JOB_ID)?.processGroupId ?? null;
-        await vi.waitFor(() => expect(existsSync(descendantPidFile)).toBe(true), {
-          timeout: 5000,
-          interval: 25,
-        });
-        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        await vi.waitFor(
+          () => {
+            expect(existsSync(descendantPidFile)).toBe(true);
+            descendantPid = Number(readFileSync(descendantPidFile, 'utf8').trim());
+            expect(descendantPid).toBeGreaterThan(1);
+          },
+          { timeout: 5000, interval: 25 },
+        );
         await vi.waitFor(
           () => {
             expect(readJobRecord(root, JOB_ID)?.status).toBe('done');
@@ -168,7 +171,8 @@ describe('spawnJob fallback metadata', () => {
         );
       } finally {
         if (descendantPid <= 1 && existsSync(descendantPidFile)) {
-          descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+          const parsedPid = Number(readFileSync(descendantPidFile, 'utf8').trim());
+          if (parsedPid > 1) descendantPid = parsedPid;
         }
         if (descendantPid > 1) {
           try {

--- a/src/lib/server/providers/__tests__/opencode.test.ts
+++ b/src/lib/server/providers/__tests__/opencode.test.ts
@@ -27,7 +27,7 @@ import opencode from '../opencode';
 
 describe('opencode provider', () => {
   describe('buildHeadlessArgs', () => {
-    it('produces opencode run -m <provider/model> "<prompt>"', () => {
+    it('prints OpenCode error logs while preserving the plain-text report stream', () => {
       const { cmd, args } = opencode.buildHeadlessArgs({
         prompt: 'Evaluate offer #42',
         model: 'anthropic/claude-3-haiku',
@@ -35,6 +35,8 @@ describe('opencode provider', () => {
       expect(cmd).toBe('/bin/bash');
       expect(args[0]).toBe('-c');
       expect(args[1]).toContain('opencode run');
+      expect(args[1]).toContain('--print-logs');
+      expect(args[1]).toContain('--log-level ERROR');
       expect(args[1]).toContain('-m anthropic/claude-3-haiku');
     });
 

--- a/src/lib/server/providers/opencode.ts
+++ b/src/lib/server/providers/opencode.ts
@@ -8,7 +8,9 @@
 //
 //   - Headless subcommand is `opencode run "<prompt>"` (positional prompt).
 //   - **Headless `run` stays plain-text**: `buildHeadlessArgs` deliberately
-//     emits plain stdout (token telemetry is estimated via tiktoken at job
+//     emits the report on plain stdout while forwarding ERROR-level OpenCode
+//     logs to stderr so the fallback classifier can see provider failures
+//     (token telemetry is estimated via tiktoken at job
 //     close), so every `BuildHeadlessOpts` field that implies a structured
 //     stream (outputFormat !== 'text', pipeToParser: true) throws rather than
 //     silently degrade. The interactive CHAT path is different: `buildChatArgs`
@@ -165,8 +167,11 @@ const opencode: Provider = {
     // Warp cli-agent notifier) hijack the output streams — machine events on
     // stdout, the model transcript ANSI-rendered on stderr — which broke
     // sentinel parsing in the provider matrix. Headless runs need the plain
-    // response on stdout.
-    const cmdline = `opencode run --pure -m ${model} ${escapeForBash(prompt)}`;
+    // response on stdout. --print-logs with ERROR-only verbosity exposes
+    // provider quota, rate-limit, auth, and model failures on stderr; without
+    // it OpenCode can log the terminal error privately and remain alive until
+    // sur9e's outer timeout instead of triggering the configured fallback.
+    const cmdline = `opencode run --pure --print-logs --log-level ERROR -m ${model} ${escapeForBash(prompt)}`;
     return { cmd: '/bin/bash', args: ['-c', cmdline] };
   },
 

--- a/test/classify-error.test.ts
+++ b/test/classify-error.test.ts
@@ -82,7 +82,7 @@ describe('isRetryable', () => {
     ['overloaded', true],
     ['quota', true],
     ['install', true],
-    ['auth', false],
+    ['auth', true],
     ['context_overflow', false],
     ['unknown', false],
   ])('%s → %s', (category, expected) => {

--- a/test/fixtures/fallback-opencode-quota-worker.mjs
+++ b/test/fixtures/fallback-opencode-quota-worker.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { mkdirSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import { runModeLLM } from '../../batch/lib/llm.mjs';
+
+const [jobRoot, repoRoot, fakeBin, descendantPidFile] = process.argv.slice(2);
+const logsDir = join(jobRoot, 'data', 'jobs', 'fallback-opencode-quota-logs');
+mkdirSync(logsDir, { recursive: true });
+
+process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH ?? ''}`;
+process.env.SUR9E_TEST_DESCENDANT_PID_FILE = descendantPidFile;
+
+const result = await runModeLLM(repoRoot, 'evaluate', 'integration prompt', {
+  logsDir,
+  runtime: {
+    provider: 'opencode',
+    model: 'opencode-go/glm-5.2',
+    fallback: { provider: 'opencode', model: 'opencode/big-pickle' },
+  },
+  timeoutMs: 1000,
+  tee: true,
+});
+
+if (!result.ok) {
+  console.error(`ERROR: ${result.error}`);
+  process.exitCode = 1;
+}

--- a/test/fixtures/fallback-opencode-quota-worker.mjs
+++ b/test/fixtures/fallback-opencode-quota-worker.mjs
@@ -18,7 +18,7 @@ const result = await runModeLLM(repoRoot, 'evaluate', 'integration prompt', {
     model: 'opencode-go/glm-5.2',
     fallback: { provider: 'opencode', model: 'opencode/big-pickle' },
   },
-  timeoutMs: 1000,
+  timeoutMs: 5000,
   tee: true,
 });
 

--- a/test/fixtures/fallback-timeout-worker.mjs
+++ b/test/fixtures/fallback-timeout-worker.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { runModeLLM } from '../../batch/lib/llm.mjs';
+
+const [rootPath, descendantPidFile, timeoutArg, primaryExitDelayArg] = process.argv.slice(2);
+const logsDir = join(rootPath, 'data', 'jobs', 'fallback-timeout-logs');
+mkdirSync(logsDir, { recursive: true });
+
+const primaryScript = String.raw`
+  const { spawn } = require('node:child_process');
+  const { writeFileSync } = require('node:fs');
+  const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+  });
+  writeFileSync(process.argv[1], String(descendant.pid));
+  process.stdout.write('> build · glm-5.2\n');
+  const exitDelay = Number(process.argv[2]);
+  if (exitDelay > 0) setTimeout(() => process.exit(1), exitDelay);
+  setInterval(() => {}, 1000);
+`;
+
+const execImpl = (_cmd, args) => {
+  const providerIndex = args.indexOf('--platform');
+  const provider = providerIndex >= 0 ? args[providerIndex + 1] : '';
+  const spawn =
+    provider === 'opencode'
+      ? {
+          cmd: process.execPath,
+          args: ['-e', primaryScript, descendantPidFile, primaryExitDelayArg ?? '0'],
+        }
+      : {
+          cmd: process.execPath,
+          args: ['-e', "process.stdout.write('fallback completed\\n')"],
+        };
+  return {
+    status: 0,
+    signal: null,
+    stdout: JSON.stringify(spawn),
+    stderr: '',
+  };
+};
+
+const result = await runModeLLM(rootPath, 'evaluate', 'integration prompt', {
+  logsDir,
+  runtime: {
+    provider: 'opencode',
+    model: 'opencode-go/glm-5.2',
+    fallback: { provider: 'claude', model: 'claude-sonnet-5' },
+  },
+  timeoutMs: Number(timeoutArg) || 1200,
+  execImpl,
+  tee: true,
+});
+
+if (!result.ok) {
+  console.error(`ERROR: ${result.error}`);
+  process.exitCode = 1;
+}

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -1,9 +1,10 @@
-import { EventEmitter } from 'node:events';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { EventEmitter, once } from 'node:events';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
-import { runModeLLM } from '../batch/lib/llm.mjs';
+import { describe, expect, it, vi } from 'vitest';
+import { runModeLLM, terminateProviderTree } from '../batch/lib/llm.mjs';
 
 type Attempt = { code: number; stdout?: string; stderr?: string };
 
@@ -50,6 +51,37 @@ const RUNTIME = {
 };
 
 describe('runModeLLM fallback retry', () => {
+  it.runIf(process.platform !== 'win32')(
+    'terminates the provider wrapper and its descendant process',
+    async () => {
+      const child = nodeSpawn('/bin/sh', ['-c', 'sleep 30 & echo $!; wait'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const [chunk] = (await once(child.stdout, 'data')) as [Buffer];
+      const descendantPid = Number(chunk.toString().trim());
+
+      try {
+        terminateProviderTree(child, 'SIGKILL');
+        await once(child, 'close');
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(descendantPid, 0)).toThrow(
+              expect.objectContaining({ code: 'ESRCH' }),
+            );
+          },
+          { timeout: 1000, interval: 20 },
+        );
+      } finally {
+        try {
+          process.kill(descendantPid, 'SIGKILL');
+        } catch {}
+        try {
+          child.kill('SIGKILL');
+        } catch {}
+      }
+    },
+  );
+
   it('retries once on a retryable failure and reports usedFallback', async () => {
     const f = makeFakes([
       { code: 1, stderr: 'exceeded retry limit, last status: 429 Too Many Requests' },
@@ -70,8 +102,35 @@ describe('runModeLLM fallback retry', () => {
     });
   });
 
-  it('does NOT retry a non-retryable failure (auth)', async () => {
-    const f = makeFakes([{ code: 1, stderr: 'OAuth token revoked' }]);
+  it.each([
+    ['claude', 'claude-sonnet-4-6', 'OAuth token revoked'],
+    ['codex', 'gpt-5.4-mini', 'refresh token expired'],
+    ['opencode', 'opencode/deepseek-v4-flash-free', 'ProviderAuthError: run opencode auth login'],
+  ])(
+    'retries a configured fallback after a terminal %s auth failure',
+    async (provider, model, stderr) => {
+      const f = makeFakes([
+        { code: 1, stderr },
+        { code: 0, stdout: 'fallback output' },
+      ]);
+      const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+        logsDir,
+        runtime: {
+          provider,
+          model,
+          fallback: { provider: 'claude', model: 'claude-sonnet-4-6' },
+        },
+        execImpl: f.execImpl,
+        spawnImpl: f.spawnImpl,
+      });
+      expect(r.ok).toBe(true);
+      expect(f.spawnedModels).toEqual([model, 'claude-sonnet-4-6']);
+      expect(r.usedFallback?.reason).toBe('auth');
+    },
+  );
+
+  it('does NOT retry a non-retryable context-overflow failure', async () => {
+    const f = makeFakes([{ code: 1, stderr: 'prompt is too long for the context window' }]);
     const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
       logsDir,
       runtime: RUNTIME,
@@ -116,6 +175,92 @@ describe('runModeLLM fallback retry', () => {
     expect(r.usedFallback).toBeUndefined();
   });
 
+  it.each([
+    ['claude', 'claude-sonnet-4-6', "You've hit your session limit. It resets at 3pm"],
+    ['codex', 'gpt-5.4-mini', "You've hit your usage limit. Switch to another model now."],
+    ['opencode', 'opencode/deepseek-v4-flash-free', 'Weekly usage limit reached. Resets in 1 day.'],
+  ])(
+    'terminates a hung %s process after streamed quota output and immediately uses fallback',
+    async (provider, model, stderr) => {
+      const f = makeFakes([{ code: 0 }]);
+      let spawnCount = 0;
+      const killed: Array<{ provider: string; signal: string }> = [];
+      const spawnImpl = () => {
+        const currentProvider = spawnCount === 0 ? provider : 'claude';
+        spawnCount += 1;
+        const child = new EventEmitter() as any;
+        child.pid = 9000 + spawnCount;
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = (signal: string) => {
+          killed.push({ provider: currentProvider, signal });
+          setImmediate(() => child.emit('close', null));
+          return true;
+        };
+        setImmediate(() => {
+          if (spawnCount === 1) {
+            child.stderr.emit('data', Buffer.from(stderr));
+            return;
+          }
+          child.stdout.emit('data', Buffer.from('fallback output'));
+          child.emit('close', 0);
+        });
+        return child;
+      };
+
+      const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+        logsDir,
+        runtime: {
+          provider,
+          model,
+          fallback: { provider: 'claude', model: 'claude-sonnet-4-6' },
+        },
+        timeoutMs: 100,
+        execImpl: f.execImpl,
+        spawnImpl,
+      });
+
+      expect(r.ok).toBe(true);
+      expect(r.stdout).toContain('fallback output');
+      expect(r.usedFallback?.reason).toBe('quota');
+      expect(killed).toContainEqual({ provider, signal: 'SIGTERM' });
+      expect(spawnCount).toBe(2);
+    },
+  );
+
+  it('cancellation terminates the active provider without invoking fallback', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    const controller = new AbortController();
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.pid = 9100;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      setImmediate(() => controller.abort());
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 100,
+      signal: controller.signal,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.cancelled).toBe(true);
+    expect(r.error).toBe('cancelled');
+    expect(spawnCount).toBe(1);
+  });
+
   it('both attempts fail → combined error naming both attempts', async () => {
     const f = makeFakes([
       {
@@ -133,6 +278,10 @@ describe('runModeLLM fallback retry', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toContain('primary');
     expect(r.error).toContain('fallback');
+    expect(r.error).toContain('claude/claude-opus-4-7');
+    expect(r.error).toContain('codex/gpt-5-codex');
+    expect(r.stderr).toContain('overloaded_error');
+    expect(r.stderr).toContain('Unauthorized');
     expect(f.spawnedModels).toEqual(['claude-opus-4-7', 'gpt-5-codex']);
     expect(r.usedFallback).toBeUndefined();
   });
@@ -255,8 +404,11 @@ describe('runModeLLM fallback retry', () => {
       expect(r.ok).toBe(false);
       expect(f.spawnedProviders).toEqual([primary.provider, fallback.provider]);
       expect(f.spawnedModels).toEqual([primary.model, fallback.model]);
-      expect(r.error).toBe('primary: exit 1 (overloaded); fallback: exit 1');
-      expect(r.stderr).toBe('fallback process failed');
+      expect(r.error).toBe(
+        `primary ${primary.provider}/${primary.model}: exit 1 (overloaded); fallback ${fallback.provider}/${fallback.model}: exit 1`,
+      );
+      expect(r.stderr).toContain(primaryError);
+      expect(r.stderr).toContain('fallback process failed');
       expect(r.usedFallback).toBeUndefined();
     },
   );

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn } from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
@@ -103,12 +103,18 @@ describe('runModeLLM fallback retry', () => {
   });
 
   it.each([
-    ['claude', 'claude-sonnet-4-6', 'OAuth token revoked'],
-    ['codex', 'gpt-5.4-mini', 'refresh token expired'],
-    ['opencode', 'opencode/deepseek-v4-flash-free', 'ProviderAuthError: run opencode auth login'],
+    ['claude', 'claude-sonnet-4-6', 'OAuth token revoked', 'codex', 'gpt-5.4-mini'],
+    ['codex', 'gpt-5.4-mini', 'refresh token expired', 'claude', 'claude-sonnet-4-6'],
+    [
+      'opencode',
+      'opencode/deepseek-v4-flash-free',
+      'ProviderAuthError: run opencode auth login',
+      'claude',
+      'claude-sonnet-4-6',
+    ],
   ])(
     'retries a configured fallback after a terminal %s auth failure',
-    async (provider, model, stderr) => {
+    async (provider, model, stderr, fallbackProvider, fallbackModel) => {
       const f = makeFakes([
         { code: 1, stderr },
         { code: 0, stdout: 'fallback output' },
@@ -118,13 +124,14 @@ describe('runModeLLM fallback retry', () => {
         runtime: {
           provider,
           model,
-          fallback: { provider: 'claude', model: 'claude-sonnet-4-6' },
+          fallback: { provider: fallbackProvider, model: fallbackModel },
         },
         execImpl: f.execImpl,
         spawnImpl: f.spawnImpl,
       });
       expect(r.ok).toBe(true);
-      expect(f.spawnedModels).toEqual([model, 'claude-sonnet-4-6']);
+      expect(f.spawnedProviders).toEqual([provider, fallbackProvider]);
+      expect(f.spawnedModels).toEqual([model, fallbackModel]);
       expect(r.usedFallback?.reason).toBe('auth');
     },
   );
@@ -154,25 +161,521 @@ describe('runModeLLM fallback retry', () => {
     expect(f.spawnedModels).toEqual(['claude-opus-4-7']);
   });
 
-  it('does NOT retry on timeout', async () => {
-    const f = makeFakes([{ code: 0, stdout: 'unused' }]);
-    const hangingSpawn = () => {
+  it.each([
+    ['claude', 'claude-sonnet-4-6'],
+    ['codex', 'gpt-5.4-mini'],
+    ['opencode', 'opencode-go/glm-5.2'],
+  ])('falls back after a silent %s timeout', async (provider, model) => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const killed: string[] = [];
+    const spawnImpl = () => {
+      spawnCount += 1;
       const child = new EventEmitter() as any;
       child.stdout = new EventEmitter();
       child.stderr = new EventEmitter();
-      child.kill = () => {};
+      child.kill = (signal: string) => {
+        killed.push(signal);
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      if (spawnCount === 2) {
+        setImmediate(() => {
+          child.stdout.emit('data', Buffer.from('fallback output'));
+          child.emit('close', 0);
+        });
+      }
       return child;
     };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: {
+        provider,
+        model,
+        fallback: { provider: 'claude', model: 'claude-sonnet-5' },
+      },
+      timeoutMs: 80,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(spawnCount).toBe(2);
+    expect(killed).toContain('SIGKILL');
+    expect(r.stdout).toContain('fallback output');
+    expect(r.usedFallback).toEqual({
+      from: { provider, model },
+      to: { provider: 'claude', model: 'claude-sonnet-5' },
+      reason: 'timeout',
+    });
+  });
+
+  it('returns a timeout without retrying when no fallback is configured', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: { provider: 'opencode', model: 'opencode-go/glm-5.2' },
+      timeoutMs: 40,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('timeout');
+    expect(spawnCount).toBe(1);
+    expect(r.usedFallback).toBeUndefined();
+  });
+
+  it('bounds command construction and falls back when the primary builder times out', async () => {
+    let buildCalls = 0;
+    const buildTimeouts: number[] = [];
+    const execImpl = (_cmd: string, _args: string[], options: { timeout?: number }) => {
+      buildCalls += 1;
+      buildTimeouts.push(options.timeout ?? -1);
+      if (buildCalls === 1) {
+        return {
+          status: null,
+          signal: 'SIGKILL',
+          stdout: '',
+          stderr: '',
+          error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+        };
+      }
+      return {
+        status: 0,
+        signal: null,
+        stdout: JSON.stringify({ cmd: 'fake', args: [] }),
+        stderr: '',
+      };
+    };
+    const spawnImpl = () => {
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => true;
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from('fallback output'));
+        child.emit('close', 0);
+      });
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 80,
+      execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.usedFallback?.reason).toBe('timeout');
+    expect(buildCalls).toBe(2);
+    expect(buildTimeouts).toEqual([80, 80]);
+  });
+
+  it('reports both provider/model pairs when fallback fails after a primary timeout', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      if (spawnCount === 2) {
+        setImmediate(() => {
+          child.stderr.emit('data', Buffer.from('fallback failed'));
+          child.emit('close', 1);
+        });
+      }
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 80,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(spawnCount).toBe(2);
+    expect(r.error).toContain('claude/claude-opus-4-7');
+    expect(r.error).toContain('codex/gpt-5-codex');
+    expect(r.error).toContain('(timeout)');
+    expect(r.stderr).toContain('fallback failed');
+  });
+
+  it('bounds a primary and fallback that both hang to two provider timeouts', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      return child;
+    };
+    const startedAt = Date.now();
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 100,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(spawnCount).toBe(2);
+    expect(Date.now() - startedAt).toBeLessThan(350);
+    expect(r.error).toContain('fallback codex/gpt-5-codex: timeout');
+  });
+
+  it('caps a fallback at one provider timeout after an immediate primary failure', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      if (spawnCount === 1) {
+        setImmediate(() => child.stderr.emit('data', Buffer.from('Provider is overloaded')));
+      }
+      return child;
+    };
+    const startedAt = Date.now();
+
     const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
       logsDir,
       runtime: RUNTIME,
       timeoutMs: 50,
       execImpl: f.execImpl,
-      spawnImpl: hangingSpawn,
+      spawnImpl,
     });
+
     expect(r.ok).toBe(false);
-    expect(r.error).toContain('timeout');
-    expect(r.usedFallback).toBeUndefined();
+    expect(spawnCount).toBe(2);
+    expect(r.error).toContain('fallback codex/gpt-5-codex: timeout 50ms');
+    expect(Date.now() - startedAt).toBeLessThan(150);
+  });
+
+  it('does not treat a child error during timeout cleanup as process closure', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('error', new Error('kill failed')));
+        return false;
+      };
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 20,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.cleanupFailed).toBe(true);
+    expect(r.error).toContain('provider process tree did not terminate');
+    expect(spawnCount).toBe(1);
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'kills the timed-out primary descendant before spawning fallback',
+    async () => {
+      const f = makeFakes([{ code: 0 }]);
+      let spawnCount = 0;
+      let descendantPid = 0;
+      let descendantAliveWhenFallbackStarted: boolean | null = null;
+      const spawnImpl = () => {
+        spawnCount += 1;
+        if (spawnCount === 1) {
+          const child = nodeSpawn('/bin/sh', ['-c', 'sleep 30 & echo $!; wait'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          child.stdout.once('data', chunk => {
+            descendantPid = Number(chunk.toString().trim());
+          });
+          return child;
+        }
+        try {
+          process.kill(descendantPid, 0);
+          descendantAliveWhenFallbackStarted = true;
+        } catch (error: any) {
+          if (error?.code !== 'ESRCH') throw error;
+          descendantAliveWhenFallbackStarted = false;
+        }
+        return nodeSpawn('/bin/sh', ['-c', 'printf "fallback output"'], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      };
+
+      try {
+        const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+          logsDir,
+          runtime: RUNTIME,
+          timeoutMs: 300,
+          execImpl: f.execImpl,
+          spawnImpl,
+        });
+        expect(r.ok).toBe(true);
+        expect(descendantPid).toBeGreaterThan(1);
+        expect(descendantAliveWhenFallbackStarted).toBe(false);
+      } finally {
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'kills an orphaned primary process group before fallback after wrapper exit',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'llm-fallback-orphan-'));
+      const descendantPidFile = join(root, 'descendant.pid');
+      const primaryScript = `
+        const { spawn } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+          stdio: 'ignore',
+        });
+        writeFileSync(process.argv[1], String(descendant.pid));
+        process.stderr.write('Provider is overloaded');
+        process.exit(1);
+      `;
+      const fallbackScript = `
+        const { readFileSync } = require('node:fs');
+        const pid = Number(readFileSync(process.argv[1], 'utf8'));
+        try {
+          process.kill(pid, 0);
+          process.stderr.write('primary descendant still alive');
+          process.exit(2);
+        } catch (error) {
+          if (error.code !== 'ESRCH') throw error;
+          process.stdout.write('fallback output');
+        }
+      `;
+      const execImpl = (_cmd: string, args: string[]) => {
+        const providerIndex = args.indexOf('--platform');
+        const provider = args[providerIndex + 1];
+        const spawn =
+          provider === 'claude'
+            ? { cmd: process.execPath, args: ['-e', fallbackScript, descendantPidFile] }
+            : { cmd: process.execPath, args: ['-e', primaryScript, descendantPidFile] };
+        return { status: 0, signal: null, stdout: JSON.stringify(spawn), stderr: '' };
+      };
+      let descendantPid = 0;
+
+      try {
+        const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+          logsDir: root,
+          runtime: {
+            provider: 'opencode',
+            model: 'opencode-go/glm-5.2',
+            fallback: { provider: 'claude', model: 'claude-sonnet-5' },
+          },
+          timeoutMs: 500,
+          execImpl,
+        });
+        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+
+        expect(r.ok).toBe(true);
+        expect(r.usedFallback?.reason).toBe('overloaded');
+        expect(r.stdout).toContain('fallback output');
+        expect(() => process.kill(descendantPid, 0)).toThrow(
+          expect.objectContaining({ code: 'ESRCH' }),
+        );
+      } finally {
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'preserves a successful provider exit while cleaning its lingering descendant',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'llm-provider-success-orphan-'));
+      const descendantPidFile = join(root, 'descendant.pid');
+      const primaryScript = `
+        const { spawn } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const descendant = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+          stdio: 'ignore',
+        });
+        writeFileSync(process.argv[1], String(descendant.pid));
+        process.stdout.write('primary output');
+        process.exit(0);
+      `;
+      const execImpl = () => ({
+        status: 0,
+        signal: null,
+        stdout: JSON.stringify({
+          cmd: process.execPath,
+          args: ['-e', primaryScript, descendantPidFile],
+        }),
+        stderr: '',
+      });
+      let descendantPid = 0;
+
+      try {
+        const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+          logsDir: root,
+          runtime: { provider: 'opencode', model: 'opencode-go/glm-5.2' },
+          timeoutMs: 500,
+          execImpl,
+        });
+        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+
+        expect(r.ok).toBe(true);
+        expect(r.stdout).toContain('primary output');
+        expect(r.usedFallback).toBeUndefined();
+        expect(() => process.kill(descendantPid, 0)).toThrow(
+          expect.objectContaining({ code: 'ESRCH' }),
+        );
+      } finally {
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'cleans an isolated provider group after an uncatchable worker kill without fallback',
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), 'llm-fallback-signal-'));
+      const descendantPidFile = join(root, 'descendant.pid');
+      const workerPath = join(process.cwd(), 'test/fixtures/fallback-timeout-worker.mjs');
+      const worker = nodeSpawn(
+        process.execPath,
+        [workerPath, root, descendantPidFile, '5000', '50'],
+        {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      let output = '';
+      worker.stdout.on('data', chunk => {
+        output += chunk.toString();
+      });
+      worker.stderr.on('data', chunk => {
+        output += chunk.toString();
+      });
+      let descendantPid = 0;
+
+      try {
+        await vi.waitFor(() => expect(existsSync(descendantPidFile)).toBe(true), {
+          timeout: 2000,
+          interval: 20,
+        });
+        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        worker.kill('SIGKILL');
+        const [code, signal] = (await once(worker, 'close')) as [number | null, string | null];
+
+        expect(code).toBeNull();
+        expect(signal).toBe('SIGKILL');
+        expect(output).not.toContain('[FALLBACK]');
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(descendantPid, 0)).toThrow(
+              expect.objectContaining({ code: 'ESRCH' }),
+            );
+          },
+          { timeout: 1000, interval: 20 },
+        );
+      } finally {
+        try {
+          worker.kill('SIGKILL');
+        } catch {}
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
+    },
+  );
+
+  it('detects a retryable signature split across bounded stderr-tail chunks', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      setImmediate(() => {
+        if (spawnCount === 1) {
+          child.stderr.emit('data', Buffer.from(`${'x'.repeat(20_000)}Provider is over`));
+          child.stderr.emit('data', Buffer.from('loaded'));
+        } else {
+          child.stdout.emit('data', Buffer.from('fallback output'));
+          child.emit('close', 0);
+        }
+      });
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 100,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.usedFallback?.reason).toBe('overloaded');
+    expect(spawnCount).toBe(2);
   });
 
   it.each([
@@ -189,7 +692,6 @@ describe('runModeLLM fallback retry', () => {
         const currentProvider = spawnCount === 0 ? provider : 'claude';
         spawnCount += 1;
         const child = new EventEmitter() as any;
-        child.pid = 9000 + spawnCount;
         child.stdout = new EventEmitter();
         child.stderr = new EventEmitter();
         child.kill = (signal: string) => {
@@ -223,7 +725,7 @@ describe('runModeLLM fallback retry', () => {
       expect(r.ok).toBe(true);
       expect(r.stdout).toContain('fallback output');
       expect(r.usedFallback?.reason).toBe('quota');
-      expect(killed).toContainEqual({ provider, signal: 'SIGTERM' });
+      expect(killed).toContainEqual({ provider, signal: 'SIGKILL' });
       expect(spawnCount).toBe(2);
     },
   );
@@ -235,7 +737,6 @@ describe('runModeLLM fallback retry', () => {
     const spawnImpl = () => {
       spawnCount += 1;
       const child = new EventEmitter() as any;
-      child.pid = 9100;
       child.stdout = new EventEmitter();
       child.stderr = new EventEmitter();
       child.kill = () => {
@@ -259,6 +760,44 @@ describe('runModeLLM fallback retry', () => {
     expect(r.cancelled).toBe(true);
     expect(r.error).toBe('cancelled');
     expect(spawnCount).toBe(1);
+  });
+
+  it('cancellation during the fallback attempt remains cancellation', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    const controller = new AbortController();
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', null));
+        return true;
+      };
+      setImmediate(() => {
+        if (spawnCount === 1) {
+          child.stderr.emit('data', Buffer.from('Provider is overloaded'));
+        } else {
+          controller.abort();
+        }
+      });
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 100,
+      signal: controller.signal,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.cancelled).toBe(true);
+    expect(r.error).toBe('cancelled');
+    expect(spawnCount).toBe(2);
   });
 
   it('both attempts fail → combined error naming both attempts', async () => {

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -875,6 +875,7 @@ describe('runModeLLM fallback retry', () => {
       });
       let descendantPid = 0;
       let supervisorPid = 0;
+      let supervisorGroupNeedsCleanup = false;
 
       try {
         descendantPid = await waitForPidFile(descendantPidFile);
@@ -892,6 +893,7 @@ describe('runModeLLM fallback retry', () => {
           },
           { timeout: 1000, interval: 20 },
         );
+        supervisorGroupNeedsCleanup = true;
 
         process.kill(supervisorPid, 'SIGKILL');
         const [code, signal] = (await once(worker, 'close')) as [number | null, string | null];
@@ -908,11 +910,12 @@ describe('runModeLLM fallback retry', () => {
           },
           { timeout: 1000, interval: 20 },
         );
+        supervisorGroupNeedsCleanup = false;
       } finally {
         try {
           worker.kill('SIGKILL');
         } catch {}
-        if (supervisorPid > 1) {
+        if (supervisorGroupNeedsCleanup && supervisorPid > 1) {
           try {
             process.kill(-supervisorPid, 'SIGKILL');
           } catch {}

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -1,4 +1,4 @@
-import { spawn as nodeSpawn } from 'node:child_process';
+import { spawn as nodeSpawn, spawnSync as nodeSpawnSync } from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -50,6 +50,19 @@ function trackedTempRoot(prefix: string) {
   const root = mkdtempSync(join(tmpdir(), prefix));
   trackedTempRoots.add(root);
   return root;
+}
+
+async function waitForPidFile(path: string, timeout = 2000) {
+  let pid = 0;
+  await vi.waitFor(
+    () => {
+      expect(existsSync(path)).toBe(true);
+      pid = Number(readFileSync(path, 'utf8').trim());
+      expect(pid).toBeGreaterThan(1);
+    },
+    { timeout, interval: 20 },
+  );
+  return pid;
 }
 
 afterEach(() => {
@@ -180,6 +193,36 @@ describe('runModeLLM fallback retry', () => {
       to: { provider: 'codex', model: 'gpt-5-codex' },
       reason: 'rate_limit',
     });
+  });
+
+  it('allows a wrapped spawn implementation to request provider-group isolation explicitly', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnedCommand = '';
+    let spawnedArgs: string[] = [];
+    const spawnImpl = (command: string, args: string[]) => {
+      spawnedCommand = command;
+      spawnedArgs = args;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => true;
+      setImmediate(() => child.emit('close', 0));
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: { provider: 'claude', model: 'claude-opus-4-7' },
+      timeoutMs: 100,
+      execImpl: f.execImpl,
+      spawnImpl,
+      isolateProviderGroup: true,
+    });
+
+    expect(r.ok).toBe(true);
+    expect(spawnedCommand).toBe(process.execPath);
+    expect(spawnedArgs[0]).toMatch(/provider-supervisor\.mjs$/);
+    expect(spawnedArgs).toContain('--parent-pid');
   });
 
   it.each([
@@ -544,10 +587,9 @@ describe('runModeLLM fallback retry', () => {
         return true;
       };
       setImmediate(() => {
-        child.stderr.emit(
-          'data',
-          Buffer.from('[SUR9E_PROVIDER_CLEANUP_FAILED] Provider is overloaded'),
-        );
+        const marker = '[SUR9E_PROVIDER_CLEANUP_FAILED]';
+        child.stderr.emit('data', Buffer.from(marker.slice(0, -5)));
+        child.stderr.emit('data', Buffer.from(`${marker.slice(-5)} Provider is overloaded`));
       });
       return child;
     };
@@ -758,11 +800,7 @@ describe('runModeLLM fallback retry', () => {
       let descendantPid = 0;
 
       try {
-        await vi.waitFor(() => expect(existsSync(descendantPidFile)).toBe(true), {
-          timeout: 2000,
-          interval: 20,
-        });
-        descendantPid = Number(readFileSync(descendantPidFile, 'utf8'));
+        descendantPid = await waitForPidFile(descendantPidFile);
         worker.kill('SIGKILL');
         const [code, signal] = (await once(worker, 'close')) as [number | null, string | null];
 
@@ -781,6 +819,77 @@ describe('runModeLLM fallback retry', () => {
         try {
           worker.kill('SIGKILL');
         } catch {}
+        if (descendantPid > 1) {
+          try {
+            process.kill(descendantPid, 'SIGKILL');
+          } catch {}
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'kills the provider group and falls back if its supervisor dies first',
+    async () => {
+      const root = trackedTempRoot('llm-fallback-dead-supervisor-');
+      const descendantPidFile = join(root, 'descendant.pid');
+      const workerPath = join(process.cwd(), 'test/fixtures/fallback-timeout-worker.mjs');
+      const worker = nodeSpawn(
+        process.execPath,
+        [workerPath, root, descendantPidFile, '200', '0'],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      let output = '';
+      worker.stdout.on('data', chunk => {
+        output += chunk.toString();
+      });
+      worker.stderr.on('data', chunk => {
+        output += chunk.toString();
+      });
+      let descendantPid = 0;
+      let supervisorPid = 0;
+
+      try {
+        descendantPid = await waitForPidFile(descendantPidFile);
+        await vi.waitFor(
+          () => {
+            const result = nodeSpawnSync('pgrep', ['-P', String(worker.pid)], {
+              encoding: 'utf8',
+            });
+            supervisorPid = Number(
+              String(result.stdout ?? '')
+                .trim()
+                .split(/\s+/)[0],
+            );
+            expect(supervisorPid).toBeGreaterThan(1);
+          },
+          { timeout: 1000, interval: 20 },
+        );
+
+        process.kill(supervisorPid, 'SIGKILL');
+        const [code, signal] = (await once(worker, 'close')) as [number | null, string | null];
+
+        expect(code).toBe(0);
+        expect(signal).toBeNull();
+        expect(output).toContain('[FALLBACK]');
+        expect(output).toContain('fallback completed');
+        await vi.waitFor(
+          () => {
+            expect(() => process.kill(descendantPid, 0)).toThrow(
+              expect.objectContaining({ code: 'ESRCH' }),
+            );
+          },
+          { timeout: 1000, interval: 20 },
+        );
+      } finally {
+        try {
+          worker.kill('SIGKILL');
+        } catch {}
+        if (supervisorPid > 1) {
+          try {
+            process.kill(-supervisorPid, 'SIGKILL');
+          } catch {}
+        }
         if (descendantPid > 1) {
           try {
             process.kill(descendantPid, 'SIGKILL');

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -80,6 +80,35 @@ const RUNTIME = {
   fallback: { provider: 'codex', model: 'gpt-5-codex' },
 };
 
+const PROVIDER_CASES = [
+  {
+    provider: 'claude',
+    primaryModel: 'claude-opus-4-7',
+    fallbackModel: 'claude-sonnet-4-6',
+    quota: "You've hit your session limit. It resets at 3pm",
+  },
+  {
+    provider: 'codex',
+    primaryModel: 'gpt-5.4-mini',
+    fallbackModel: 'gpt-5-codex',
+    quota: "You've hit your usage limit. Switch to another model now.",
+  },
+  {
+    provider: 'opencode',
+    primaryModel: 'opencode-go/glm-5.2',
+    fallbackModel: 'opencode/big-pickle',
+    quota: 'Weekly usage limit reached. Resets in 1 day.',
+  },
+] as const;
+
+const ONE_HOP_PROVIDER_PAIRS = PROVIDER_CASES.flatMap(primary =>
+  PROVIDER_CASES.map(fallback => ({
+    primary: { provider: primary.provider, model: primary.primaryModel },
+    fallback: { provider: fallback.provider, model: fallback.fallbackModel },
+    quota: primary.quota,
+  })),
+);
+
 describe('runModeLLM fallback retry', () => {
   it.runIf(process.platform !== 'win32')(
     'terminates the provider wrapper and its descendant process',
@@ -284,55 +313,53 @@ describe('runModeLLM fallback retry', () => {
     expect(f.spawnedModels).toEqual(['claude-opus-4-7']);
   });
 
-  it.each([
-    ['claude', 'claude-sonnet-4-6'],
-    ['codex', 'gpt-5.4-mini'],
-    ['opencode', 'opencode-go/glm-5.2'],
-  ])('falls back after a silent %s timeout', async (provider, model) => {
-    const f = makeFakes([{ code: 0 }]);
-    let spawnCount = 0;
-    const killed: string[] = [];
-    const spawnImpl = () => {
-      spawnCount += 1;
-      const child = new EventEmitter() as any;
-      child.stdout = new EventEmitter();
-      child.stderr = new EventEmitter();
-      child.kill = (signal: string) => {
-        killed.push(signal);
-        setImmediate(() => child.emit('close', null));
-        return true;
+  it.each(ONE_HOP_PROVIDER_PAIRS)(
+    'falls back after a silent $primary.provider → $fallback.provider timeout',
+    async ({ primary, fallback }) => {
+      const f = makeFakes([{ code: 0 }]);
+      let spawnCount = 0;
+      const killed: string[] = [];
+      const spawnImpl = () => {
+        spawnCount += 1;
+        const child = new EventEmitter() as any;
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = (signal: string) => {
+          killed.push(signal);
+          setImmediate(() => child.emit('close', null));
+          return true;
+        };
+        if (spawnCount === 2) {
+          setImmediate(() => {
+            child.stdout.emit('data', Buffer.from('fallback output'));
+            child.emit('close', 0);
+          });
+        }
+        return child;
       };
-      if (spawnCount === 2) {
-        setImmediate(() => {
-          child.stdout.emit('data', Buffer.from('fallback output'));
-          child.emit('close', 0);
-        });
-      }
-      return child;
-    };
 
-    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
-      logsDir,
-      runtime: {
-        provider,
-        model,
-        fallback: { provider: 'claude', model: 'claude-sonnet-5' },
-      },
-      timeoutMs: 80,
-      execImpl: f.execImpl,
-      spawnImpl,
-    });
+      const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+        logsDir,
+        runtime: {
+          ...primary,
+          fallback,
+        },
+        timeoutMs: 80,
+        execImpl: f.execImpl,
+        spawnImpl,
+      });
 
-    expect(r.ok).toBe(true);
-    expect(spawnCount).toBe(2);
-    expect(killed).toContain('SIGKILL');
-    expect(r.stdout).toContain('fallback output');
-    expect(r.usedFallback).toEqual({
-      from: { provider, model },
-      to: { provider: 'claude', model: 'claude-sonnet-5' },
-      reason: 'timeout',
-    });
-  });
+      expect(r.ok).toBe(true);
+      expect(spawnCount).toBe(2);
+      expect(killed).toContain('SIGKILL');
+      expect(r.stdout).toContain('fallback output');
+      expect(r.usedFallback).toEqual({
+        from: primary,
+        to: fallback,
+        reason: 'timeout',
+      });
+    },
+  );
 
   it('returns a timeout without retrying when no fallback is configured', async () => {
     const f = makeFakes([{ code: 0 }]);
@@ -936,18 +963,14 @@ describe('runModeLLM fallback retry', () => {
     expect(spawnCount).toBe(2);
   });
 
-  it.each([
-    ['claude', 'claude-sonnet-4-6', "You've hit your session limit. It resets at 3pm"],
-    ['codex', 'gpt-5.4-mini', "You've hit your usage limit. Switch to another model now."],
-    ['opencode', 'opencode/deepseek-v4-flash-free', 'Weekly usage limit reached. Resets in 1 day.'],
-  ])(
-    'terminates a hung %s process after streamed quota output and immediately uses fallback',
-    async (provider, model, stderr) => {
+  it.each(ONE_HOP_PROVIDER_PAIRS)(
+    'terminates a hung $primary.provider → $fallback.provider process after streamed quota output',
+    async ({ primary, fallback, quota }) => {
       const f = makeFakes([{ code: 0 }]);
       let spawnCount = 0;
       const killed: Array<{ provider: string; signal: string }> = [];
       const spawnImpl = () => {
-        const currentProvider = spawnCount === 0 ? provider : 'claude';
+        const currentProvider = spawnCount === 0 ? primary.provider : fallback.provider;
         spawnCount += 1;
         const child = new EventEmitter() as any;
         child.stdout = new EventEmitter();
@@ -959,7 +982,7 @@ describe('runModeLLM fallback retry', () => {
         };
         setImmediate(() => {
           if (spawnCount === 1) {
-            child.stderr.emit('data', Buffer.from(stderr));
+            child.stderr.emit('data', Buffer.from(quota));
             return;
           }
           child.stdout.emit('data', Buffer.from('fallback output'));
@@ -971,9 +994,8 @@ describe('runModeLLM fallback retry', () => {
       const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
         logsDir,
         runtime: {
-          provider,
-          model,
-          fallback: { provider: 'claude', model: 'claude-sonnet-4-6' },
+          ...primary,
+          fallback,
         },
         timeoutMs: 100,
         execImpl: f.execImpl,
@@ -983,7 +1005,9 @@ describe('runModeLLM fallback retry', () => {
       expect(r.ok).toBe(true);
       expect(r.stdout).toContain('fallback output');
       expect(r.usedFallback?.reason).toBe('quota');
-      expect(killed).toContainEqual({ provider, signal: 'SIGKILL' });
+      expect(killed).toContainEqual({ provider: primary.provider, signal: 'SIGKILL' });
+      expect(f.spawnedProviders).toEqual([primary.provider, fallback.provider]);
+      expect(f.spawnedModels).toEqual([primary.model, fallback.model]);
       expect(spawnCount).toBe(2);
     },
   );

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -1,9 +1,9 @@
 import { spawn as nodeSpawn } from 'node:child_process';
 import { EventEmitter, once } from 'node:events';
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { runModeLLM, terminateProviderTree } from '../batch/lib/llm.mjs';
 
 type Attempt = { code: number; stdout?: string; stderr?: string };
@@ -44,6 +44,23 @@ function makeFakes(attempts: Attempt[]) {
 }
 
 const logsDir = mkdtempSync(join(tmpdir(), 'llm-fallback-'));
+const trackedTempRoots = new Set<string>();
+
+function trackedTempRoot(prefix: string) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  trackedTempRoots.add(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of trackedTempRoots) rmSync(root, { recursive: true, force: true });
+  trackedTempRoots.clear();
+});
+
+afterAll(() => {
+  rmSync(logsDir, { recursive: true, force: true });
+});
+
 const RUNTIME = {
   provider: 'claude',
   model: 'claude-opus-4-7',
@@ -81,6 +98,69 @@ describe('runModeLLM fallback retry', () => {
       }
     },
   );
+
+  it('treats an already-exited Windows provider tree as cleaned up', () => {
+    const spawnSyncImpl = vi.fn(() => ({
+      status: 128,
+      stdout: '',
+      stderr: 'ERROR: The process "4321" not found.',
+    }));
+
+    expect(
+      terminateProviderTree({ pid: 4321 }, 'SIGKILL', {
+        platform: 'win32',
+        spawnSyncImpl: spawnSyncImpl as any,
+      }),
+    ).toEqual([]);
+    expect(spawnSyncImpl).toHaveBeenCalledWith('taskkill', ['/PID', '4321', '/T', '/F'], {
+      encoding: 'utf-8',
+    });
+  });
+
+  it('still reports Windows provider-tree cleanup failures other than an absent process', () => {
+    const spawnSyncImpl = vi.fn(() => ({
+      status: 1,
+      stdout: '',
+      stderr: 'ERROR: Access is denied.',
+    }));
+
+    expect(() =>
+      terminateProviderTree({ pid: 4321 }, 'SIGKILL', {
+        platform: 'win32',
+        spawnSyncImpl: spawnSyncImpl as any,
+      }),
+    ).toThrow('taskkill failed');
+  });
+
+  it('kills every discovered descendant even when freezing one of them fails', () => {
+    const children = new Map([
+      [100, '101\n102\n'],
+      [101, '103\n'],
+    ]);
+    const spawnSyncImpl = vi.fn((_cmd: string, args: string[]) => {
+      const stdout = children.get(Number(args[1])) ?? '';
+      return { status: stdout ? 0 : 1, stdout, stderr: '' };
+    });
+    const killImpl = vi.fn((pid: number, signal?: string | number) => {
+      if (pid === 102 && signal === 'SIGSTOP') {
+        throw Object.assign(new Error('freeze denied'), { code: 'EPERM' });
+      }
+      return true as const;
+    });
+    const child = { pid: 100, spawnfile: 'fake-provider', kill: vi.fn() };
+
+    expect(() =>
+      terminateProviderTree(child, 'SIGKILL', {
+        platform: 'darwin',
+        spawnSyncImpl: spawnSyncImpl as any,
+        killImpl,
+      }),
+    ).toThrow('freeze denied');
+    expect(killImpl).toHaveBeenCalledWith(103, 'SIGKILL');
+    expect(killImpl).toHaveBeenCalledWith(101, 'SIGKILL');
+    expect(killImpl).toHaveBeenCalledWith(102, 'SIGKILL');
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
 
   it('retries once on a retryable failure and reports usedFallback', async () => {
     const f = makeFakes([
@@ -288,6 +368,38 @@ describe('runModeLLM fallback retry', () => {
     expect(buildTimeouts).toEqual([80, 80]);
   });
 
+  it('suppresses fallback when a timed-out builder reports incomplete cleanup', async () => {
+    let buildCalls = 0;
+    let spawnCount = 0;
+    const execImpl = () => {
+      buildCalls += 1;
+      return {
+        status: null,
+        signal: 'SIGTERM',
+        stdout: '',
+        stderr: '[SUR9E_PROVIDER_CLEANUP_FAILED] provider process group did not terminate',
+        error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+      };
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 80,
+      execImpl,
+      spawnImpl: () => {
+        spawnCount += 1;
+        throw new Error('provider must not spawn after failed builder cleanup');
+      },
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.cleanupFailed).toBe(true);
+    expect(r.stderr).toContain('[SUR9E_PROVIDER_CLEANUP_FAILED]');
+    expect(buildCalls).toBe(1);
+    expect(spawnCount).toBe(0);
+  });
+
   it('reports both provider/model pairs when fallback fails after a primary timeout', async () => {
     const f = makeFakes([{ code: 0 }]);
     let spawnCount = 0;
@@ -351,7 +463,9 @@ describe('runModeLLM fallback retry', () => {
 
     expect(r.ok).toBe(false);
     expect(spawnCount).toBe(2);
-    expect(Date.now() - startedAt).toBeLessThan(350);
+    // This proves the operation is bounded while allowing CI scheduling and
+    // process-settlement slack beyond the two 100ms provider budgets.
+    expect(Date.now() - startedAt).toBeLessThan(1000);
     expect(r.error).toContain('fallback codex/gpt-5-codex: timeout');
   });
 
@@ -385,7 +499,7 @@ describe('runModeLLM fallback retry', () => {
     expect(r.ok).toBe(false);
     expect(spawnCount).toBe(2);
     expect(r.error).toContain('fallback codex/gpt-5-codex: timeout 50ms');
-    expect(Date.now() - startedAt).toBeLessThan(150);
+    expect(Date.now() - startedAt).toBeLessThan(600);
   });
 
   it('does not treat a child error during timeout cleanup as process closure', async () => {
@@ -407,6 +521,41 @@ describe('runModeLLM fallback retry', () => {
       logsDir,
       runtime: RUNTIME,
       timeoutMs: 20,
+      execImpl: f.execImpl,
+      spawnImpl,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.cleanupFailed).toBe(true);
+    expect(r.error).toContain('provider process tree did not terminate');
+    expect(spawnCount).toBe(1);
+  });
+
+  it('does not start fallback when the supervisor reports incomplete process cleanup', async () => {
+    const f = makeFakes([{ code: 0 }]);
+    let spawnCount = 0;
+    const spawnImpl = () => {
+      spawnCount += 1;
+      const child = new EventEmitter() as any;
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {
+        setImmediate(() => child.emit('close', 1));
+        return true;
+      };
+      setImmediate(() => {
+        child.stderr.emit(
+          'data',
+          Buffer.from('[SUR9E_PROVIDER_CLEANUP_FAILED] Provider is overloaded'),
+        );
+      });
+      return child;
+    };
+
+    const r = await runModeLLM(process.cwd(), 'evaluate', 'prompt', {
+      logsDir,
+      runtime: RUNTIME,
+      timeoutMs: 100,
       execImpl: f.execImpl,
       spawnImpl,
     });
@@ -471,7 +620,7 @@ describe('runModeLLM fallback retry', () => {
   it.runIf(process.platform !== 'win32')(
     'kills an orphaned primary process group before fallback after wrapper exit',
     async () => {
-      const root = mkdtempSync(join(tmpdir(), 'llm-fallback-orphan-'));
+      const root = trackedTempRoot('llm-fallback-orphan-');
       const descendantPidFile = join(root, 'descendant.pid');
       const primaryScript = `
         const { spawn } = require('node:child_process');
@@ -538,7 +687,7 @@ describe('runModeLLM fallback retry', () => {
   it.runIf(process.platform !== 'win32')(
     'preserves a successful provider exit while cleaning its lingering descendant',
     async () => {
-      const root = mkdtempSync(join(tmpdir(), 'llm-provider-success-orphan-'));
+      const root = trackedTempRoot('llm-provider-success-orphan-');
       const descendantPidFile = join(root, 'descendant.pid');
       const primaryScript = `
         const { spawn } = require('node:child_process');
@@ -589,7 +738,7 @@ describe('runModeLLM fallback retry', () => {
   it.runIf(process.platform !== 'win32')(
     'cleans an isolated provider group after an uncatchable worker kill without fallback',
     async () => {
-      const root = mkdtempSync(join(tmpdir(), 'llm-fallback-signal-'));
+      const root = trackedTempRoot('llm-fallback-signal-');
       const descendantPidFile = join(root, 'descendant.pid');
       const workerPath = join(process.cwd(), 'test/fixtures/fallback-timeout-worker.mjs');
       const worker = nodeSpawn(

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -863,7 +863,7 @@ describe('runModeLLM fallback retry', () => {
       const workerPath = join(process.cwd(), 'test/fixtures/fallback-timeout-worker.mjs');
       const worker = nodeSpawn(
         process.execPath,
-        [workerPath, root, descendantPidFile, '200', '0'],
+        [workerPath, root, descendantPidFile, '5000', '0'],
         { stdio: ['ignore', 'pipe', 'pipe'] },
       );
       let output = '';
@@ -891,7 +891,7 @@ describe('runModeLLM fallback retry', () => {
             );
             expect(supervisorPid).toBeGreaterThan(1);
           },
-          { timeout: 1000, interval: 20 },
+          { timeout: 5000, interval: 20 },
         );
         supervisorGroupNeedsCleanup = true;
 
@@ -927,6 +927,7 @@ describe('runModeLLM fallback retry', () => {
         }
       }
     },
+    15_000,
   );
 
   it('detects a retryable signature split across bounded stderr-tail chunks', async () => {


### PR DESCRIPTION
Closes #33

## What changed
- classify streamed quota, rate-limit, overload, auth, installation, and model diagnostics while a provider CLI is still running
- treat a primary timeout or silent hang as fallback-eligible when a fallback is configured
- supervise separate provider process groups and verify every live primary member is gone before fallback
- preserve successful provider exit codes while cleaning lingering helpers
- cap execution at one primary plus one fallback attempt within a bounded total deadline
- never invoke fallback after explicit cancellation or incomplete process cleanup
- surface the [FALLBACK] marker with the actual source and fallback provider/model pairs
- preserve both provider/model pairs and diagnostics when fallback is exhausted

## Verification
- Claude Code, Codex, and OpenCode matrices for streamed failures and timeout/hang recovery
- fallback success, fallback failure, no configured fallback, primary cancellation, and fallback cancellation
- real descendant cleanup for timeout, wrapper exit, successful exit, and uncatchable worker termination
- Windows already-exited tree handling and POSIX builder/provider cleanup-failure guards
- real background-job runner coverage for output and fallback attribution
- focused fallback/job suites: 59 passed
- npm run test:quick: 100 passed
- npm run build: passed
