### PR TITLE
fix(update): recover failed updates safely

### DIFF
--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -28,6 +28,7 @@ const POST_ROLLBACK_CHECKPOINTS = new Set([
   'recovery-server-started',
 ]);
 const COMMAND_TIMEOUTS_MS = {
+  preflight: 30_000,
   apply: 15 * 60_000,
   stop: 2 * 60_000,
   build: 15 * 60_000,
@@ -120,7 +121,7 @@ function runCommand(
       ...options,
       detached: true,
       shell: false,
-      stdio: 'ignore',
+      stdio: ['ignore', 'inherit', 'inherit'],
     });
     let settled = false;
     let timedOut = false;
@@ -178,8 +179,27 @@ function runCommand(
     child.once('exit', (code, signal) => {
       if (timedOut) return;
       if (code === 0 && signal === null) finish(resolvePromise)();
-      else finish(reject)(new Error('Command failed'));
+      else {
+        console.error(
+          `[update-worker] command failed (${command}, exit ${code ?? 'none'}, signal ${signal ?? 'none'})`,
+        );
+        const error = new Error('Command failed');
+        error.exitCode = code;
+        error.signal = signal;
+        finish(reject)(error);
+      }
     });
+  });
+}
+
+async function validateRuntime(root) {
+  const major = Number(process.versions.node.split('.')[0]);
+  if (!Number.isInteger(major) || major < 24) {
+    throw new Error(`Node ${process.version} is below the required Node 24 runtime`);
+  }
+  await runCommand('npm', ['--version'], {
+    cwd: root,
+    timeoutMs: COMMAND_TIMEOUTS_MS.preflight,
   });
 }
 
@@ -228,6 +248,7 @@ const defaultDeps = {
   waitForHealth: waitForSur9eHealth,
   readLaunchIdentity,
   readVersion,
+  validateRuntime,
 };
 
 /**
@@ -343,15 +364,25 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps, optio
     return recover(job.error ?? 'Update worker stopped before completion');
   }
 
+  try {
+    await runtime.validateRuntime(root);
+  } catch {
+    transition('failed', 'Update requires Node 24+ and a working npm installation');
+    return { status: 'failed' };
+  }
+
   transition('applying', undefined, 'apply-started');
   try {
     await runPhaseCommand(process.execPath, [join(root, 'update-system.mjs'), 'apply'], {
       cwd: root,
       timeoutMs: COMMAND_TIMEOUTS_MS.apply,
     });
-  } catch {
-    transition('failed', 'Update failed while applying the new version', 'apply-started');
-    return { status: 'failed' };
+  } catch (error) {
+    if (error?.exitCode === 2) {
+      transition('failed', 'Update failed before changing system files', 'apply-started');
+      return { status: 'failed' };
+    }
+    return recover('Update failed while applying the new version');
   }
 
   let failedPhase;

--- a/src/app/api/version/__tests__/route.test.ts
+++ b/src/app/api/version/__tests__/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import packageJson from '../../../../../package.json';
+import { GET } from '../route';
+
+describe('GET /api/version', () => {
+  it('reports the version baked into the running build', async () => {
+    const response = GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ version: packageJson.version });
+  });
+});

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,16 +1,10 @@
 export const runtime = 'nodejs';
 
-import { join } from 'node:path';
-import { jsonError } from '@/lib/http-errors';
-import { ROOT } from '@/lib/root';
-import { readFileOrNull } from '@/lib/server/read-or-null';
+import packageJson from '../../../../package.json';
 
 export function GET() {
-  const versionPath = join(ROOT, 'VERSION');
-  const raw = readFileOrNull(versionPath);
-  if (raw == null) return jsonError('Version file not found', 404);
   return Response.json({
-    version: raw.trim(),
+    version: packageJson.version,
     launchId: process.env.SUR9E_WEB_LAUNCH_ID ?? null,
   });
 }

--- a/src/app/styles/settings-inline.css
+++ b/src/app/styles/settings-inline.css
@@ -288,6 +288,17 @@
   background: var(--surface);
   color: var(--text-2);
 }
+.system-update-panel__changelog ul {
+  margin: var(--space-2) 0;
+  padding-left: var(--space-5);
+}
+.system-update-panel__changelog li + li {
+  margin-top: var(--space-1);
+}
+.system-update-panel__changelog a {
+  color: var(--accent-text);
+  font-weight: 600;
+}
 .system-update-panel__changelog strong,
 .system-update-panel__error strong {
   color: var(--text);
@@ -712,7 +723,7 @@
     grid-template-columns: 1fr;
   }
   .settings-content .form-section[id] {
-    scroll-margin-top: 64px;
+    scroll-margin-top: calc(var(--topbar-h) + var(--space-8));
   }
   /* Rows wrap to two lines: toggle+name+pill / host+actions. */
   .portal-row__meta {

--- a/src/features/settings/sections/__tests__/system-section.test.tsx
+++ b/src/features/settings/sections/__tests__/system-section.test.tsx
@@ -232,6 +232,40 @@ describe('SystemSection update status', () => {
     expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
   });
 
+  it('renders Markdown release notes as a concise date, feature list, and normal link', async () => {
+    mocks.check = {
+      isPending: false,
+      mutateAsync: vi.fn().mockResolvedValue({
+        status: 'update-available',
+        local: '0.3.2',
+        remote: '0.4.0',
+        changelog: [
+          '## [0.4.0](https://github.com/arspesk/sur9e/compare/v0.3.2...v0.4.0) (2026-08-02)',
+          '',
+          '### Features',
+          '',
+          '* add guided status follow-ups ([e458cc4](https://github.com/arspesk/sur9e/commit/e458cc4))',
+          '* **status:** guide interview preparation ([6932308](https://github.com/arspesk/sur9e/commit/6932308))',
+        ].join('\n'),
+        releaseDate: '2026-08-02T12:00:00Z',
+        releaseUrl: 'https://github.com/arspesk/sur9e/releases/tag/v0.4.0',
+      }),
+    };
+    renderSection();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check for updates' }));
+
+    expect(await screen.findByText('What’s new in v0.4.0 · Aug 2, 2026')).toBeTruthy();
+    expect(screen.getByText('add guided status follow-ups')).toBeTruthy();
+    expect(screen.getByText('status: guide interview preparation')).toBeTruthy();
+    expect(screen.queryByText(/compare\/v0\.3\.2/)).toBeNull();
+    expect(screen.queryByText(/e458cc4/)).toBeNull();
+    expect(screen.getByRole('link', { name: 'View release notes' })).toHaveAttribute(
+      'href',
+      'https://github.com/arspesk/sur9e/releases/tag/v0.4.0',
+    );
+  });
+
   it('uses the shared medium Settings button size for update actions', () => {
     renderSection();
 

--- a/src/features/settings/sections/system-section.tsx
+++ b/src/features/settings/sections/system-section.tsx
@@ -15,6 +15,7 @@ import {
   useVersion,
 } from '@/hooks/use-system';
 import { FetchJsonError } from '@/lib/api/fetch-json';
+import { parseReleaseNotes } from '@/lib/release-notes';
 import type { UpdateJob, UpdateJobPhase } from '@/lib/schemas/update-job';
 import type { SettingsFormValues } from '../types';
 
@@ -73,12 +74,6 @@ function getConfirmation(): ((options: ConfirmOptions) => Promise<boolean>) | un
       }
     ).deleteConfirmModal?.confirm ?? useDeleteConfirmStore.getState().confirm
   );
-}
-
-function changelogExcerpt(changelog: string) {
-  const normalized = changelog.replace(/\s+/g, ' ').trim();
-  if (normalized.length <= 180) return normalized;
-  return `${normalized.slice(0, 177).trimEnd()}…`;
 }
 
 function readActiveJobId() {
@@ -364,6 +359,10 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
   }, [checkError, checkResult, isChecking, job, jobRunning, resultNotice, updateJob.isError]);
 
   const phaseLabel = job?.phase ? PHASE_LABEL[job.phase] : 'Starting update…';
+  const releaseNotes =
+    checkResult?.status === 'update-available'
+      ? parseReleaseNotes(checkResult.remote, checkResult.changelog, checkResult.releaseDate)
+      : null;
   const canUpdate = checkResult?.status === 'update-available' && !jobId && !resultNotice;
   const checkLabel = isChecking
     ? 'Checking…'
@@ -391,10 +390,20 @@ export function SystemSection({ navigate = defaultNavigate }: SystemSectionProps
           <span className="system-update-panel__detail">{status.detail}</span>
         </div>
 
-        {checkResult?.status === 'update-available' && checkResult.changelog.trim() ? (
-          <p className="system-update-panel__changelog">
-            <strong>What&rsquo;s new:</strong> {changelogExcerpt(checkResult.changelog)}
-          </p>
+        {checkResult?.status === 'update-available' && releaseNotes?.items.length ? (
+          <div className="system-update-panel__changelog">
+            <strong>What&rsquo;s new in {releaseNotes.title}</strong>
+            <ul>
+              {releaseNotes.items.map(item => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+            {checkResult.releaseUrl?.startsWith('https://github.com/') ? (
+              <a href={checkResult.releaseUrl} target="_blank" rel="noreferrer">
+                View release notes
+              </a>
+            ) : null}
+          </div>
         ) : null}
 
         {job?.phase === 'failed' || checkError ? (

--- a/src/hooks/__tests__/use-system.test.tsx
+++ b/src/hooks/__tests__/use-system.test.tsx
@@ -70,7 +70,14 @@ afterEach(() => {
 describe('UpdateCheckResponse', () => {
   it('models every response shape emitted by the update check route', () => {
     expectTypeOf<UpdateCheckResponse>().toEqualTypeOf<
-      | { status: 'update-available'; local: string; remote: string; changelog: string }
+      | {
+          status: 'update-available';
+          local: string;
+          remote: string;
+          changelog: string;
+          releaseDate?: string;
+          releaseUrl?: string;
+        }
       | { status: 'up-to-date'; local: string; remote: string }
       | { status: 'dismissed' }
       | { status: 'offline'; local: string }
@@ -85,6 +92,8 @@ describe('UpdateCheckResponse', () => {
         local: '0.3.2',
         remote: '0.4.0',
         changelog: 'Faster restart',
+        releaseDate: '2026-08-02T12:00:00Z',
+        releaseUrl: 'https://github.com/arspesk/sur9e/releases/tag/v0.4.0',
       },
     ];
 

--- a/src/hooks/use-system.ts
+++ b/src/hooks/use-system.ts
@@ -22,7 +22,14 @@ export interface VersionResponse {
 }
 
 export type UpdateCheckResponse =
-  | { status: 'update-available'; local: string; remote: string; changelog: string }
+  | {
+      status: 'update-available';
+      local: string;
+      remote: string;
+      changelog: string;
+      releaseDate?: string;
+      releaseUrl?: string;
+    }
   | { status: 'up-to-date'; local: string; remote: string }
   | { status: 'dismissed' }
   | { status: 'offline'; local: string };

--- a/src/lib/__tests__/release-notes.test.ts
+++ b/src/lib/__tests__/release-notes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { parseReleaseNotes } from '@/lib/release-notes';
+
+describe('parseReleaseNotes', () => {
+  it('extracts feature bullets without compare URLs or commit-link markup', () => {
+    const changelog = [
+      '## [0.4.0](https://github.com/arspesk/sur9e/compare/v0.3.2...v0.4.0) (2026-08-02)',
+      '',
+      '### Features',
+      '',
+      '* add guided status follow-ups ([e458cc4](https://github.com/arspesk/sur9e/commit/e458cc4))',
+      '* **status:** guide interview preparation ([6932308](https://github.com/arspesk/sur9e/commit/6932308))',
+      '',
+      '### Bug Fixes',
+      '',
+      '* unrelated later section',
+    ].join('\n');
+
+    expect(parseReleaseNotes('0.4.0', changelog, '2026-08-02T12:00:00Z')).toEqual({
+      title: 'v0.4.0 · Aug 2, 2026',
+      items: ['add guided status follow-ups', 'status: guide interview preparation'],
+    });
+  });
+
+  it('falls back to cleaned prose when release notes have no bullets', () => {
+    expect(
+      parseReleaseNotes(
+        '0.4.1',
+        '## [0.4.1](https://github.com/arspesk/sur9e/releases/tag/v0.4.1)\nSafer updates.',
+      ),
+    ).toEqual({ title: 'v0.4.1', items: ['Safer updates.'] });
+  });
+});

--- a/src/lib/release-notes.ts
+++ b/src/lib/release-notes.ts
@@ -1,0 +1,59 @@
+export interface ReleaseNotesSummary {
+  title: string;
+  items: string[];
+}
+
+function cleanMarkdown(text: string): string {
+  return text
+    .replace(/\s*\(\[[^\]]+\]\(https?:\/\/[^)]+\)\)\s*$/, '')
+    .replace(/\[([^\]]+)\]\(https?:\/\/[^)]+\)/g, '$1')
+    .replace(/[*_`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function formatReleaseDate(value?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+export function parseReleaseNotes(
+  version: string,
+  changelog: string,
+  releaseDate?: string,
+): ReleaseNotesSummary {
+  const lines = changelog.split(/\r?\n/);
+  const featuresHeading = lines.findIndex(line => /^###\s+features\s*$/i.test(line.trim()));
+  const candidateLines = featuresHeading >= 0 ? lines.slice(featuresHeading + 1) : lines;
+  const items: string[] = [];
+
+  for (const rawLine of candidateLines) {
+    const trimmed = rawLine.trim();
+    if (featuresHeading >= 0 && /^#{1,3}\s+/.test(trimmed)) break;
+    const bullet = trimmed.match(/^[-*+]\s+(.+)$/)?.[1];
+    if (!bullet) continue;
+    const cleaned = cleanMarkdown(bullet);
+    if (cleaned && !items.includes(cleaned)) items.push(cleaned);
+    if (items.length === 4) break;
+  }
+
+  if (items.length === 0) {
+    const fallback = cleanMarkdown(
+      lines.find(line => line.trim() && !/^#{1,6}\s+/.test(line.trim())) ?? '',
+    );
+    if (fallback) items.push(fallback);
+  }
+
+  const date = formatReleaseDate(releaseDate);
+  return {
+    title: `v${version}${date ? ` · ${date}` : ''}`,
+    items,
+  };
+}

--- a/test/e2e/settings-update.spec.ts
+++ b/test/e2e/settings-update.spec.ts
@@ -7,7 +7,16 @@ const availableCheck = {
   status: 'update-available',
   local: '0.3.2',
   remote: '0.4.0',
-  changelog: 'Faster restart. Improved update recovery without touching your personal data.',
+  changelog: [
+    '## [0.4.0](https://github.com/arspesk/sur9e/compare/v0.3.2...v0.4.0) (2026-08-02)',
+    '',
+    '### Features',
+    '',
+    '* safer update recovery ([e458cc4](https://github.com/arspesk/sur9e/commit/e458cc4))',
+    '* readable release notes ([6932308](https://github.com/arspesk/sur9e/commit/6932308))',
+  ].join('\n'),
+  releaseDate: '2026-08-02T12:00:00Z',
+  releaseUrl: 'https://github.com/arspesk/sur9e/releases/tag/v0.4.0',
 } as const;
 
 function job(phase: string) {
@@ -179,7 +188,15 @@ test('runs the one-click update flow through restart downtime and restores the e
   await page.waitForLoadState('networkidle');
   const section = page.locator('section#system');
   await expect(section.getByText('v0.4.0 available')).toBeVisible();
-  await expect(section.getByText(availableCheck.changelog)).toBeVisible();
+  await expect(section.getByText('What’s new in v0.4.0 · Aug 2, 2026')).toBeVisible();
+  await expect(section.getByText('safer update recovery')).toBeVisible();
+  await expect(section.getByText('readable release notes')).toBeVisible();
+  await expect(section.getByText(/compare\/v0\.3\.2/)).toHaveCount(0);
+  await expect(section.getByText(/e458cc4/)).toHaveCount(0);
+  await expect(section.getByRole('link', { name: 'View release notes' })).toHaveAttribute(
+    'href',
+    availableCheck.releaseUrl,
+  );
   await expect(section.getByRole('button', { name: 'Update now' })).toBeVisible();
   expect(checkCalls).toBe(1);
 
@@ -267,6 +284,81 @@ test('consumes an automatic rollback notice for one load', async ({ page }) => {
   await expect(page.getByText(/automatically recovered v0\.3\.2/i)).toHaveCount(0);
 });
 
+test('shows failed apply recovery from the durable job and permits a clean retry', async ({
+  page,
+}) => {
+  test.setTimeout(30_000);
+  let statusCalls = 0;
+  let rollbackCalls = 0;
+  const phases = ['applying', 'recovering', 'rolled-back'] as const;
+
+  await page.route('**/api/version', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{"version":"0.3.2"}' }),
+  );
+  await page.route('**/api/update/**', route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === '/api/update/status' && request.method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{"job":null}',
+      });
+    }
+    if (pathname === '/api/update/check' && request.method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(availableCheck),
+      });
+    }
+    if (pathname === '/api/update/apply' && request.method() === 'POST') {
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ jobId: JOB_ID }),
+      });
+    }
+    if (pathname === `/api/update/status/${JOB_ID}` && request.method() === 'POST') {
+      const phase = phases[Math.min(statusCalls, phases.length - 1)];
+      statusCalls += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...job(phase),
+          ...(phase === 'rolled-back'
+            ? { error: 'Update failed while applying the new version' }
+            : {}),
+        }),
+      });
+    }
+    if (pathname === '/api/update/rollback' && request.method() === 'POST') {
+      rollbackCalls += 1;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    }
+    return route.fulfill({ status: 418, body: 'unexpected update request' });
+  });
+
+  await page.goto(SETTINGS_HREF);
+  const section = page.locator('section#system');
+  await expect(section.getByRole('button', { name: 'Update now' })).toBeVisible();
+  await section.getByRole('button', { name: 'Update now' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Update now' }).click();
+
+  await expect(section.getByRole('status')).toContainText('Updating files');
+  await expect(section.getByRole('status')).toContainText('Recovering previous version', {
+    timeout: 8_000,
+  });
+  await expect(page.getByText(/automatically recovered v0\.3\.2/i)).toBeVisible({
+    timeout: 10_000,
+  });
+  expect(rollbackCalls).toBe(0);
+
+  await page.reload();
+  await expect(section.getByRole('button', { name: 'Update now' })).toBeEnabled();
+});
+
 for (const viewport of [
   { name: 'desktop', width: 1280, height: 800 },
   { name: 'tablet', width: 768, height: 1024 },
@@ -295,6 +387,16 @@ for (const viewport of [
     await expect(edit).toHaveAttribute('aria-expanded', 'true');
     await expect(section.getByRole('textbox', { name: 'Update source' })).toBeVisible();
     await expect(section.getByRole('textbox', { name: 'Update branch' })).toBeVisible();
+
+    if (viewport.name === 'mobile') {
+      const [topbarBox, headingBox] = await Promise.all([
+        page.locator('.topbar').boundingBox(),
+        section.getByRole('heading', { name: 'Updates & about' }).boundingBox(),
+      ]);
+      expect(topbarBox).not.toBeNull();
+      expect(headingBox).not.toBeNull();
+      expect(headingBox!.y).toBeGreaterThanOrEqual(topbarBox!.y + topbarBox!.height);
+    }
 
     await page.screenshot({
       path: `test-results/settings-update-panel-${viewport.name}-${viewport.width}x${viewport.height}.png`,

--- a/test/update-system-integration.test.mjs
+++ b/test/update-system-integration.test.mjs
@@ -143,7 +143,21 @@ function createUpdateFixture() {
   ]);
   for (const [path, contents] of privateFiles) writeFixtureFile(installed, path, contents);
 
-  writeFixtureFile(shimDirectory, 'npm', '#!/bin/sh\nexit 0\n');
+  writeFixtureFile(
+    shimDirectory,
+    'npm',
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "--version" ]; then echo "11.0.0"; exit 0; fi',
+      'if [ -n "$SUR9E_TEST_NPM_CALL_LOG" ]; then echo "$*" >> "$SUR9E_TEST_NPM_CALL_LOG"; fi',
+      'if [ "$SUR9E_TEST_NPM_INSTALL_FAIL" = "1" ]; then',
+      '  echo "fixture dependency install failed" >&2',
+      '  exit 42',
+      'fi',
+      'exit 0',
+      '',
+    ].join('\n'),
+  );
   chmodSync(resolve(shimDirectory, 'npm'), 0o755);
   symlinkSync(resolve(ROOT, 'node_modules'), resolve(installed, 'node_modules'), 'dir');
 
@@ -243,6 +257,136 @@ describe('update-system apply and rollback', () => {
     expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
   }, 15_000);
 
+  it('treats dependency installation failure as fatal and restores committed system state', () => {
+    const { environment, installed, privateFiles } = createUpdateFixture();
+    const installedHead = git(installed, ['rev-parse', 'HEAD']);
+    const systemState = captureSystemState(installed);
+    const npmCallLog = resolve(installed, '.fixture-home', 'npm-calls.log');
+
+    const result = runUpdater(
+      installed,
+      {
+        ...environment,
+        SUR9E_TEST_NPM_INSTALL_FAIL: '1',
+        SUR9E_TEST_NPM_CALL_LOG: npmCallLog,
+      },
+      'apply',
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('fixture dependency install failed');
+    expect(result.stderr).toContain('restored the previous committed version');
+    expect(git(installed, ['rev-parse', 'HEAD'])).toBe(installedHead);
+    expectSystemState(installed, systemState);
+    expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
+    expectPrivateFiles(installed, privateFiles);
+    expect(readFileSync(npmCallLog, 'utf8').trim().split('\n')).toEqual([
+      'ci --no-audit --no-fund',
+      'ci --no-audit --no-fund',
+    ]);
+
+    const retry = runUpdater(installed, environment, 'apply');
+    expect(retry.status, retry.stderr).toBe(0);
+    expect(readFileSync(resolve(installed, 'VERSION'), 'utf8')).toBe('0.3.0\n');
+  }, 15_000);
+
+  it('backs up the exact customized HEAD even when the installed version is unchanged', () => {
+    const { environment, installed } = createUpdateFixture();
+    git(installed, ['branch', 'backup-pre-update-0.2.0'], environment);
+    writeFixtureFile(installed, 'content/changed.md', 'customized installation\n');
+    git(installed, ['add', '--', 'content/changed.md'], environment);
+    git(installed, ['commit', '--quiet', '-m', 'customize same version'], environment);
+    const customizedHead = git(installed, ['rev-parse', 'HEAD'], environment);
+    const shortHead = git(installed, ['rev-parse', '--short=12', 'HEAD'], environment);
+
+    const result = runUpdater(installed, environment, 'apply');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(git(installed, ['rev-parse', `backup-pre-update-0.2.0-${shortHead}`], environment)).toBe(
+      customizedHead,
+    );
+  }, 15_000);
+
+  it('reports the committed version and complete release metadata despite a staged VERSION', () => {
+    const { environment, installed } = createUpdateFixture();
+    writeFixtureFile(installed, 'VERSION', '9.9.9\n');
+    git(installed, ['add', '--', 'VERSION'], environment);
+    const fetchMock = resolve(installed, '.fixture-home', 'update-fetch-mock.mjs');
+    writeFileSync(
+      fetchMock,
+      [
+        'globalThis.fetch = async url => {',
+        "  if (String(url).includes('raw.githubusercontent.com')) return new Response('0.3.0\\n');",
+        '  return Response.json({',
+        "    body: '### Features\\n\\n* safe recovery',",
+        "    published_at: '2026-08-02T12:00:00Z',",
+        "    html_url: 'https://github.com/fixture/update/releases/tag/v0.3.0',",
+        '  });',
+        '};',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runUpdater(
+      installed,
+      { ...environment, NODE_OPTIONS: `--import=${fetchMock}` },
+      'check',
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      status: 'update-available',
+      local: '0.2.0',
+      remote: '0.3.0',
+      changelog: '### Features\n\n* safe recovery',
+      releaseDate: '2026-08-02T12:00:00Z',
+      releaseUrl: 'https://github.com/fixture/update/releases/tag/v0.3.0',
+    });
+  });
+
+  it('restores committed state when the update commit hook fails after checkout', () => {
+    const { environment, installed, privateFiles } = createUpdateFixture();
+    const hooks = resolve(installed, '.fixture-home', 'failing-hooks');
+    mkdirSync(hooks, { recursive: true });
+    writeFixtureFile(
+      installed,
+      '.fixture-home/failing-hooks/pre-commit',
+      '#!/bin/sh\necho "fixture pre-commit failed" >&2\nexit 33\n',
+    );
+    chmodSync(resolve(hooks, 'pre-commit'), 0o755);
+    git(installed, ['config', 'core.hooksPath', hooks], environment);
+    const installedHead = git(installed, ['rev-parse', 'HEAD'], environment);
+    const systemState = captureSystemState(installed);
+
+    const result = runUpdater(installed, environment, 'apply');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('fixture pre-commit failed');
+    expect(result.stderr).toContain('restored the previous committed version');
+    expect(git(installed, ['rev-parse', 'HEAD'], environment)).toBe(installedHead);
+    expectSystemState(installed, systemState);
+    expect(git(installed, ['status', '--short', '--untracked-files=no'], environment)).toBe('');
+    expectPrivateFiles(installed, privateFiles);
+
+    const rollback = runUpdater(installed, environment, 'rollback');
+    expect(rollback.status, rollback.stderr).toBe(0);
+    expect(rollback.stdout).toContain('already matches');
+  }, 15_000);
+
+  it('makes rollback idempotent when the backup already matches the checkout', () => {
+    const { environment, installed } = createUpdateFixture();
+    expect(runUpdater(installed, environment, 'apply').status).toBe(0);
+    expect(runUpdater(installed, environment, 'rollback').status).toBe(0);
+    const headAfterFirstRollback = git(installed, ['rev-parse', 'HEAD']);
+
+    const repeated = runUpdater(installed, environment, 'rollback');
+
+    expect(repeated.status, repeated.stderr).toBe(0);
+    expect(repeated.stdout).toContain('already matches');
+    expect(git(installed, ['rev-parse', 'HEAD'])).toBe(headAfterFirstRollback);
+    expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
+  }, 15_000);
+
   it('refuses dirty system paths with newlines and rename source records', () => {
     const { environment, installed } = createUpdateFixture();
     mkdirSync(resolve(installed, 'tmp'), { recursive: true });
@@ -250,7 +394,7 @@ describe('update-system apply and rollback', () => {
 
     const result = runUpdater(installed, environment, 'apply');
 
-    expect(result.status).toBe(1);
+    expect(result.status).toBe(2);
     expect(result.stderr).toContain('Uncommitted changes in system files');
     expect(result.stderr).toContain('content/line\nbreak.md');
     expect(git(installed, ['branch', '--list', 'backup-pre-update-*'])).toBe('');
@@ -280,7 +424,7 @@ describe('update-system apply and rollback', () => {
 
     const result = runUpdater(installed, environment, 'apply');
 
-    expect(result.status).toBe(1);
+    expect(result.status).toBe(2);
     expect(result.stderr).toContain('Upstream update contains protected user paths');
     expect(result.stderr).toContain('.claude/skills/custom/SKILL.md');
     expect(result.stderr).toContain('content/private.yml.bak');

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -54,15 +54,18 @@ function harness(root, overrides = {}) {
   const states = [];
   const runCommand = vi.fn().mockResolvedValue(undefined);
   const waitForHealth = vi.fn().mockResolvedValue(undefined);
+  const validateRuntime = vi.fn().mockResolvedValue(undefined);
   return {
     states,
     runCommand,
     waitForHealth,
+    validateRuntime,
     deps: {
       pid: 4242,
       clock: () => NOW,
       runCommand,
       waitForHealth,
+      validateRuntime,
       claimPid: vi.fn(),
       readLaunchIdentity: vi.fn(() => ({ launchId: 'launch-123' })),
       readVersion: vi.fn(() => '0.4.0'),
@@ -180,10 +183,36 @@ describe('runUpdateRestartJob', () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
-  it('marks apply failure failed without stopping or attempting rollback', async () => {
+  it('routes apply failure through automatic rollback and recovery', async () => {
     const root = makeRoot();
     const { states, runCommand, deps } = harness(root);
     runCommand.mockRejectedValueOnce(new Error('token=do-not-persist command details'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'rolled-back' });
+    expect(states.map(job => job.phase)).toEqual([
+      'applying',
+      'recovering',
+      'recovering',
+      'recovering',
+      'recovering',
+      'rolled-back',
+    ]);
+    expect(runCommand.mock.calls[0][1]).toEqual([join(root, 'update-system.mjs'), 'apply']);
+    expect(runCommand.mock.calls.map(([, args]) => args)).toContainEqual([
+      join(root, 'update-system.mjs'),
+      'rollback',
+    ]);
+    expect(states.at(-1).error).toBe('Update failed while applying the new version');
+  });
+
+  it('does not roll back a stale backup when apply fails before checkout', async () => {
+    const root = makeRoot();
+    const { states, runCommand, deps } = harness(root);
+    runCommand.mockRejectedValueOnce(
+      Object.assign(new Error('fetch failed before checkout'), { exitCode: 2 }),
+    );
 
     const result = await runUpdateRestartJob(root, JOB_ID, deps);
 
@@ -191,7 +220,21 @@ describe('runUpdateRestartJob', () => {
     expect(states.map(job => job.phase)).toEqual(['applying', 'failed']);
     expect(runCommand).toHaveBeenCalledTimes(1);
     expect(runCommand.mock.calls[0][1]).toEqual([join(root, 'update-system.mjs'), 'apply']);
-    expect(states.at(-1).error).toBe('Update failed while applying the new version');
+    expect(states.at(-1).error).toBe('Update failed before changing system files');
+  });
+
+  it('fails before apply without rollback when the worker runtime is unsupported', async () => {
+    const root = makeRoot();
+    const { states, runCommand, waitForHealth, validateRuntime, deps } = harness(root);
+    validateRuntime.mockRejectedValueOnce(new Error('npm is unavailable'));
+
+    const result = await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(result).toEqual({ status: 'failed' });
+    expect(states.map(job => job.phase)).toEqual(['failed']);
+    expect(states.at(-1).error).toBe('Update requires Node 24+ and a working npm installation');
+    expect(runCommand).not.toHaveBeenCalled();
+    expect(waitForHealth).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -375,6 +418,7 @@ describe('runUpdateRestartJob', () => {
       clock: () => NOW,
       runCommand,
       waitForHealth,
+      validateRuntime: vi.fn().mockResolvedValue(undefined),
       readLaunchIdentity: () => ({ launchId: 'launch-123' }),
     });
 
@@ -569,9 +613,15 @@ describe('owned command timeout', () => {
         persistJob: (_root, job) => states.push(structuredClone(job)),
         waitForHealth: vi.fn().mockResolvedValue(undefined),
         readLaunchIdentity: vi.fn(() => ({ launchId: 'launch-123' })),
+        validateRuntime: vi.fn().mockResolvedValue(undefined),
       });
 
+      await Promise.resolve();
+      await Promise.resolve();
       expect(spawnProcess).toHaveBeenCalledTimes(1);
+      expect(spawnProcess.mock.calls[0][2]).toMatchObject({
+        stdio: ['ignore', 'inherit', 'inherit'],
+      });
       children[0].emit('exit', 0, null);
       await Promise.resolve();
       await Promise.resolve();

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -16,8 +16,8 @@
  * See docs/data-contract.md for the full system/user layer definitions.
  */
 
-import { execFileSync, execSync } from 'child_process';
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'fs';
 import yaml from 'js-yaml';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -26,6 +26,10 @@ import { isSystemPath, isUserPath, SYSTEM_PATHS } from './src/lib/repo-path-poli
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = __dirname;
+const MIN_NODE_MAJOR = 24;
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const INSTALL_TIMEOUT_MS = 10 * 60_000;
+const COMMIT_TIMEOUT_MS = 15 * 60_000;
 
 // Update source repo (GitHub "<owner>/<repo>" slug). Defaults to the public
 // repo. Maintainers / fork users can override with the UPDATE_REPO env var
@@ -100,9 +104,21 @@ function resolveUpdateRemote() {
 }
 const REMOTE = resolveUpdateRemote();
 
-function localVersion() {
+function workingVersion() {
   const vPath = join(ROOT, 'VERSION');
   return existsSync(vPath) ? readFileSync(vPath, 'utf-8').trim() : '0.0.0';
+}
+
+function committedVersion() {
+  try {
+    return execFileSync('git', ['show', 'HEAD:VERSION'], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      timeout: DEFAULT_COMMAND_TIMEOUT_MS,
+    }).trim();
+  } catch {
+    return workingVersion();
+  }
 }
 
 function compareVersions(a, b) {
@@ -115,8 +131,33 @@ function compareVersions(a, b) {
   return 0;
 }
 
+function gitWithTimeout(timeout, ...args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout }).trim();
+}
+
 function git(...args) {
-  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf-8', timeout: 30000 }).trim();
+  return gitWithTimeout(DEFAULT_COMMAND_TIMEOUT_MS, ...args);
+}
+
+function validateRuntime() {
+  const major = Number(process.versions.node.split('.')[0]);
+  if (!Number.isInteger(major) || major < MIN_NODE_MAJOR) {
+    throw new Error(`sur9e updates require Node ${MIN_NODE_MAJOR}+; found ${process.version}`);
+  }
+  execFileSync('npm', ['--version'], {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: DEFAULT_COMMAND_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+function installDependencies() {
+  execFileSync('npm', ['ci', '--no-audit', '--no-fund'], {
+    cwd: ROOT,
+    timeout: INSTALL_TIMEOUT_MS,
+    stdio: 'inherit',
+  });
 }
 
 function gitStatusEntries() {
@@ -133,6 +174,25 @@ function revertPaths(paths) {
   // deletion by the sync step (plain `git checkout --` can't, since `git rm`
   // removed them from the index too).
   git('checkout', 'HEAD', '--', ...paths);
+}
+
+function restoreCommittedSystemState() {
+  const changedSystemPaths = [
+    ...new Set(
+      gitStatusEntries()
+        .map(entry => entry.path)
+        .filter(isSystemPath),
+    ),
+  ];
+  for (const path of changedSystemPaths) {
+    try {
+      git('checkout', 'HEAD', '--', path);
+    } catch {
+      // The path was added by the fetched tree and does not exist in HEAD.
+      git('rm', '-f', '--ignore-unmatch', '--', path);
+      rmSync(join(ROOT, path), { recursive: true, force: true });
+    }
+  }
 }
 
 // True sync for one system path: `git checkout <ref> -- <path>` only
@@ -189,7 +249,7 @@ async function check() {
     return;
   }
 
-  const local = localVersion();
+  const local = committedVersion();
   let remote;
 
   try {
@@ -208,6 +268,8 @@ async function check() {
 
   // Fetch changelog from GitHub releases
   let changelog = '';
+  let releaseDate = '';
+  let releaseUrl = '';
   try {
     const res = await fetch(REMOTE.releasesApi, {
       headers: { Accept: 'application/vnd.github.v3+json' },
@@ -215,6 +277,8 @@ async function check() {
     if (res.ok) {
       const release = await res.json();
       changelog = release.body || '';
+      releaseDate = release.published_at || release.created_at || '';
+      releaseUrl = release.html_url || '';
     }
   } catch {
     // No changelog available, that's OK
@@ -225,7 +289,9 @@ async function check() {
       status: 'update-available',
       local,
       remote,
-      changelog: changelog.slice(0, 500),
+      changelog: changelog.slice(0, 10_000),
+      ...(releaseDate ? { releaseDate } : {}),
+      ...(releaseUrl ? { releaseUrl } : {}),
     }),
   );
 }
@@ -233,7 +299,15 @@ async function check() {
 // ── APPLY ───────────────────────────────────────────────────────
 
 async function apply() {
-  const local = localVersion();
+  try {
+    validateRuntime();
+  } catch (error) {
+    console.error(`Update runtime check failed: ${error.message}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const local = committedVersion();
   const initialStatusEntries = gitStatusEntries();
   const initialStatusPaths = new Set(initialStatusEntries.map(entry => entry.path));
 
@@ -244,7 +318,7 @@ async function apply() {
   if (dirtySystem.length > 0) {
     console.error('Uncommitted changes in system files — commit or stash them first:');
     for (const entry of dirtySystem) console.error(`  ${entry.code} ${entry.path}`);
-    process.exit(1);
+    process.exit(2);
   }
 
   // Check for lock
@@ -253,12 +327,14 @@ async function apply() {
     console.error(
       'Update already in progress (.update-lock exists). If stuck, delete it manually.',
     );
-    process.exit(1);
+    process.exit(2);
   }
 
   // Create lock
   writeFileSync(lockFile, new Date().toISOString());
 
+  let checkoutStarted = false;
+  let dependencyInstallStarted = false;
   try {
     // 1. Fetch from canonical repo
     console.log('Fetching latest from upstream...');
@@ -272,12 +348,12 @@ async function apply() {
     if (upstreamPrivatePaths.length > 0) {
       console.error('Upstream update contains protected user paths — aborting before checkout:');
       for (const path of upstreamPrivatePaths) console.error(`  ${path}`);
-      process.exitCode = 1;
+      process.exitCode = 2;
       return;
     }
 
     // 3. Backup: create branch only after the fetched tree passes preflight.
-    const backupBranch = `backup-pre-update-${local}`;
+    const backupBranch = `backup-pre-update-${local}-${git('rev-parse', '--short=12', 'HEAD')}`;
     try {
       git('branch', backupBranch);
       console.log(`Backup branch created: ${backupBranch}`);
@@ -289,6 +365,7 @@ async function apply() {
     // never removes files, so anything deleted/renamed upstream must be
     // explicitly removed or it lingers (stale routes break the build).
     console.log('Updating system files...');
+    checkoutStarted = true;
     const updated = [];
     const removed = [];
     for (const path of SYSTEM_PATHS) {
@@ -326,32 +403,56 @@ async function apply() {
       process.exit(1);
     }
 
-    // 6. Install any new dependencies
-    try {
-      execSync('npm install --silent', { cwd: ROOT, timeout: 60000 });
-    } catch {
-      console.log('npm install skipped (may need manual run)');
-    }
+    // 6. Install the exact dependency tree. Failure is fatal because an
+    // incomplete node_modules cannot safely build or run the fetched version.
+    dependencyInstallStarted = true;
+    installDependencies();
 
     // 7. Commit the update
-    const remote = localVersion(); // Re-read after checkout updated VERSION
+    const remote = workingVersion(); // Re-read after checkout updated VERSION
     const dismissFile = join(ROOT, '.update-dismissed');
     if (existsSync(dismissFile)) unlinkSync(dismissFile); // gitignored — never staged
     addPaths(updated);
     if (git('diff', '--cached', '--name-only')) {
       try {
-        git('commit', '-m', `chore: auto-update system files to v${remote}`);
+        gitWithTimeout(
+          COMMIT_TIMEOUT_MS,
+          'commit',
+          '-m',
+          `chore: auto-update system files to v${remote}`,
+        );
       } catch (err) {
-        console.error(`Commit failed — update is staged but NOT committed: ${err.message}`);
-        console.error('Resolve the failure (e.g. pre-commit gate) and commit manually.');
-        unlinkSync(lockFile); // process.exit skips the finally block
-        process.exit(1);
+        throw new Error(`commit failed: ${err.message}`);
       }
     }
 
     console.log(`\nUpdate complete: v${local} → v${remote}`);
     console.log(`Updated ${updated.length} system paths.`);
     console.log(`Rollback available: node update-system.mjs rollback`);
+  } catch (error) {
+    if (checkoutStarted) {
+      let filesRestored = false;
+      try {
+        restoreCommittedSystemState();
+        filesRestored = true;
+        console.error('Update failed; restored the previous committed version.');
+      } catch (restoreError) {
+        console.error(`Update failed and automatic file recovery failed: ${restoreError.message}`);
+      }
+      if (filesRestored && dependencyInstallStarted) {
+        try {
+          installDependencies();
+        } catch (dependencyError) {
+          console.error(
+            `Previous system files were restored, but dependency recovery failed: ${dependencyError.message}`,
+          );
+        }
+      }
+      process.exitCode = 1;
+    } else {
+      console.error(`Update failed before changing system files: ${error.message}`);
+      process.exitCode = 2;
+    }
   } finally {
     // Remove lock
     if (existsSync(lockFile)) unlinkSync(lockFile);
@@ -405,7 +506,20 @@ function rollback() {
 
     // removeFilesAbsentInTarget uses `git rm`, so deletions are already staged.
     addPaths([...new Set(updated)]);
-    git('commit', '-m', `chore: rollback system files from ${latest}`);
+    if (!git('diff', '--cached', '--name-only')) {
+      console.log(`Checkout already matches ${latest}; no rollback commit needed.`);
+      return;
+    }
+    // A rollback restores an already committed tree. Skip the full pre-commit
+    // gate here so recovery cannot exceed the wrapper timeout before npm ci
+    // and the worker's health verification run.
+    gitWithTimeout(
+      COMMIT_TIMEOUT_MS,
+      'commit',
+      '--no-verify',
+      '-m',
+      `chore: rollback system files from ${latest}`,
+    );
 
     console.log(`Rollback complete. System files restored from ${latest}.`);
     console.log('Your data (CV, profile, tracker, reports) was not affected.');


### PR DESCRIPTION
## Summary

- make UI-driven updates fail safely and automatically restore the exact committed backup
- keep committed, API, and running-version state consistent while preserving updater subprocess diagnostics
- render concise release notes and make manual rollback idempotent
- add unit, integration, and Playwright coverage for failure, recovery, retry, and responsive Settings behavior

## Root cause

The updater continued after dependency-install failures, did not route every apply-phase failure through recovery, derived version state from mutable worktree files, and discarded subprocess output. Manual rollback also always committed, allowing the pre-commit gate to exceed the wrapper timeout even after files were restored.

## Validation

- `npm run test:quick` — 100 passed
- `npm run build` — passed
- `test/e2e/settings-update.spec.ts` — 7 passed at desktop, tablet, and mobile widths
- local browser verification of `/settings?view=system#system`

Closes #49

## AI assistance

Substantial implementation and test work was completed with Codex and reviewed against the repository quality gates.
