### PR TITLE
fix(update): install build dependencies in production

### DIFF
--- a/scripts/update-worker.mjs
+++ b/scripts/update-worker.mjs
@@ -333,7 +333,7 @@ export async function runUpdateRestartJob(root, jobId, deps = defaultDeps, optio
       }
       transition('recovering', originalError, 'rollback-complete');
       recoveryStage = 'install';
-      await runPhaseCommand('npm', ['ci', '--no-audit', '--no-fund'], {
+      await runPhaseCommand('npm', ['ci', '--include=dev', '--no-audit', '--no-fund'], {
         cwd: root,
         timeoutMs: COMMAND_TIMEOUTS_MS.install,
       });

--- a/test/update-system-integration.test.mjs
+++ b/test/update-system-integration.test.mjs
@@ -150,6 +150,12 @@ function createUpdateFixture() {
       '#!/bin/sh',
       'if [ "$1" = "--version" ]; then echo "11.0.0"; exit 0; fi',
       'if [ -n "$SUR9E_TEST_NPM_CALL_LOG" ]; then echo "$*" >> "$SUR9E_TEST_NPM_CALL_LOG"; fi',
+      'if [ "$SUR9E_TEST_NPM_REQUIRE_DEV" = "1" ]; then',
+      '  case " $* " in',
+      '    *" --include=dev "*) ;;',
+      '    *) echo "fixture development dependencies were omitted" >&2; exit 43 ;;',
+      '  esac',
+      'fi',
       'if [ "$SUR9E_TEST_NPM_INSTALL_FAIL" = "1" ]; then',
       '  echo "fixture dependency install failed" >&2',
       '  exit 42',
@@ -281,12 +287,32 @@ describe('update-system apply and rollback', () => {
     expect(git(installed, ['status', '--short', '--untracked-files=no'])).toBe('');
     expectPrivateFiles(installed, privateFiles);
     expect(readFileSync(npmCallLog, 'utf8').trim().split('\n')).toEqual([
-      'ci --no-audit --no-fund',
-      'ci --no-audit --no-fund',
+      'ci --include=dev --no-audit --no-fund',
+      'ci --include=dev --no-audit --no-fund',
     ]);
 
     const retry = runUpdater(installed, environment, 'apply');
     expect(retry.status, retry.stderr).toBe(0);
+    expect(readFileSync(resolve(installed, 'VERSION'), 'utf8')).toBe('0.3.0\n');
+  }, 15_000);
+
+  it('installs build dependencies when launched from a production server', () => {
+    const { environment, installed } = createUpdateFixture();
+    const npmCallLog = resolve(installed, '.fixture-home', 'npm-calls.log');
+
+    const result = runUpdater(
+      installed,
+      {
+        ...environment,
+        NODE_ENV: 'production',
+        SUR9E_TEST_NPM_REQUIRE_DEV: '1',
+        SUR9E_TEST_NPM_CALL_LOG: npmCallLog,
+      },
+      'apply',
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(npmCallLog, 'utf8').trim()).toBe('ci --include=dev --no-audit --no-fund');
     expect(readFileSync(resolve(installed, 'VERSION'), 'utf8')).toBe('0.3.0\n');
   }, 15_000);
 

--- a/test/update-worker.test.mjs
+++ b/test/update-worker.test.mjs
@@ -207,6 +207,19 @@ describe('runUpdateRestartJob', () => {
     expect(states.at(-1).error).toBe('Update failed while applying the new version');
   });
 
+  it('restores build dependencies during production-server recovery', async () => {
+    const root = makeRoot({ prod: true, tailscale: true });
+    const { runCommand, deps } = harness(root);
+    runCommand.mockRejectedValueOnce(new Error('apply failed'));
+
+    await runUpdateRestartJob(root, JOB_ID, deps);
+
+    expect(runCommand.mock.calls.map(([command, args]) => [command, args])).toContainEqual([
+      'npm',
+      ['ci', '--include=dev', '--no-audit', '--no-fund'],
+    ]);
+  });
+
   it('does not roll back a stale backup when apply fails before checkout', async () => {
     const root = makeRoot();
     const { states, runCommand, deps } = harness(root);
@@ -274,7 +287,7 @@ describe('runUpdateRestartJob', () => {
     ]);
     expect(runCommand.mock.calls.map(([command, args]) => [command, args])).toContainEqual([
       'npm',
-      ['ci', '--no-audit', '--no-fund'],
+      ['ci', '--include=dev', '--no-audit', '--no-fund'],
     ]);
     const finalStart = runCommand.mock.calls
       .filter(([, args]) => args[0] === join(root, 'scripts/web.mjs') && args[1] !== 'stop')
@@ -361,7 +374,7 @@ describe('runUpdateRestartJob', () => {
     {
       recoveryStage: 'install',
       mode: { prod: false, tailscale: false },
-      failCommand: 'ci --no-audit --no-fund',
+      failCommand: 'ci --include=dev --no-audit --no-fund',
     },
     {
       recoveryStage: 'rebuild',
@@ -387,7 +400,8 @@ describe('runUpdateRestartJob', () => {
         if (args[0] === join(root, 'scripts/web.mjs') && args[1] !== 'stop') startCount += 1;
         const recoveryFailure =
           (failCommand === 'rollback' && args[1] === 'rollback') ||
-          (failCommand === 'ci --no-audit --no-fund' && label === 'ci --no-audit --no-fund') ||
+          (failCommand === 'ci --include=dev --no-audit --no-fund' &&
+            label === 'ci --include=dev --no-audit --no-fund') ||
           (failCommand === 'second build' && label === 'run build' && buildCount === 2) ||
           (failCommand === 'web start' && startCount === 2);
         if (recoveryFailure) throw new Error('recovery secret with command details');
@@ -467,7 +481,7 @@ describe('runUpdateRestartJob', () => {
       expect(result).toEqual({ status: 'rolled-back' });
       const calls = runCommand.mock.calls.map(([, args]) => args);
       expect(calls).not.toContainEqual([join(root, 'update-system.mjs'), 'apply']);
-      expect(calls).toContainEqual(['ci', '--no-audit', '--no-fund']);
+      expect(calls).toContainEqual(['ci', '--include=dev', '--no-audit', '--no-fund']);
       expect(calls).toContainEqual([join(root, 'scripts/web.mjs'), '--detach']);
       const rollbackCalls = calls.filter(
         args => args[0] === join(root, 'update-system.mjs') && args[1] === 'rollback',

--- a/update-system.mjs
+++ b/update-system.mjs
@@ -153,7 +153,7 @@ function validateRuntime() {
 }
 
 function installDependencies() {
-  execFileSync('npm', ['ci', '--no-audit', '--no-fund'], {
+  execFileSync('npm', ['ci', '--include=dev', '--no-audit', '--no-fund'], {
     cwd: ROOT,
     timeout: INSTALL_TIMEOUT_MS,
     stdio: 'inherit',


### PR DESCRIPTION
## Summary

- install build-time dependencies during updates launched from production servers
- restore those dependencies during automatic rollback and recovery
- cover production-mode update and Tailscale recovery behavior with regression tests

## Root cause

The update worker inherits `NODE_ENV=production` from `next start`. npm consequently defaults to omitting development dependencies, but Sur9e builds locally before starting production and requires build-time packages such as `@next/bundle-analyzer` and the Tailwind PostCSS plugin. The next `web:tailscale` launch therefore failed while loading `next.config.ts`.

The updater and recovery path now explicitly run `npm ci --include=dev` so production-server updates retain the complete build toolchain.

## Validation

- reproduced the regression tests failing before the implementation change
- focused updater and worker suite: 46 passed
- `npm run test:quick`: 100 passed, 0 failed, 0 warnings
- `npm run build`: passed
- production-mode dependency install followed by the real detached Tailscale launcher: passed
- local and Tailnet `/api/version` health checks returned the same launch identity

## AI assistance

Substantial diagnosis, implementation, and test work was completed with Codex and reviewed against the repository quality gates.
