### PR TITLE
docs: document test:e2e:ci in CONTRIBUTING test commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ npm run lint         # Biome (TS/JS/CSS/JSON) + Prettier (MD/YAML)
 npm run typecheck    # tsc over src/**
 npm run test:unit    # vitest
 npm run test:e2e     # Playwright (needs the dev server running)
+npm run test:e2e:ci  # Playwright, self-contained (starts and stops the dev server)
 npm run test:quick   # the full pre-commit/CI gate
 npm run build        # production build
 ```


### PR DESCRIPTION
## Summary

CONTRIBUTING.md's Quality gates code block documents `npm run test:e2e` but omits `npm run test:e2e:ci`, which is defined in `package.json` and is the self-contained variant (start-server-and-test boots the dev server on port 3000, runs Playwright, and tears it down). This adds one line for it directly under `test:e2e`, matching the block's existing comment style.

Docs-only change; no code touched.

Fixes #61

## AI disclosure

This PR was authored entirely by an AI coding agent (Claude Code), per the AI-assisted contributions policy in CONTRIBUTING.md. The diff has been reviewed against `package.json` to confirm the documented command exists and behaves as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)