### PR TITLE
fix: [Bug]: AI chat "go down" (scroll-to-bottom) button icon not centered

### DIFF
--- a/src/components/chat/scroll-to-bottom.tsx
+++ b/src/components/chat/scroll-to-bottom.tsx
@@ -1,0 +1,13 @@
+import { ArrowDown } from 'lucide-react';
+
+export function ScrollToBottom({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label="Scroll to bottom"
+      className="flex items-center justify-center size-10 rounded-full bg-slate-900/80 hover:bg-slate-900 text-white shadow-lg transition-opacity"
+    >
+      <ArrowDown className="size-5" />
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #68