### PR TITLE
fix(providers): classify Claude monthly spend limit as quota

### DIFF
--- a/cli/classify-error.mjs
+++ b/cli/classify-error.mjs
@@ -33,7 +33,7 @@ const SHARED = {
 const PROVIDER_SIGNATURES = {
   claude: {
     install: [],
-    quota: ['session limit', 'credit balance is too low'],
+    quota: ['session limit', 'credit balance is too low', 'monthly spend limit', 'usage-credits'],
     auth: ['oauth token revoked', 'not logged in', 'authentication_error'],
     model_not_found: [
       'issue with the selected model',

--- a/test/classify-error.test.ts
+++ b/test/classify-error.test.ts
@@ -15,6 +15,12 @@ describe('classifyProviderError', () => {
     ['{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', 'overloaded'],
     ["You've hit your session limit. It resets at 3pm", 'quota'],
     ['Credit balance is too low', 'quota'],
+    [
+      // Org monthly spend limit (observed on claude-code 2.1.226) — must
+      // fall back to Codex, not classify as unknown. Exact provider wording.
+      "You've hit your org's monthly spend limit · run /usage-credits to ask your admin for a higher limit",
+      'quota',
+    ],
     ['OAuth token revoked. Please run /login', 'auth'],
     ['Not logged in. Please run `claude login`', 'auth'],
     ['claude: command not found', 'install'],


### PR DESCRIPTION
Recognizes the org `monthly spend limit` / `/usage-credits` wording so the job runner falls back to the configured Codex provider instead of exiting as an unknown, non-retryable error. Adds a regression test using the exact observed message.

Closes #75

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)