### PR TITLE
fix(chat): center scroll-to-bottom button icon

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -866,9 +866,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Keep it a perfect circle: equal sides that the flex parent can't stretch,
+     with a 50% radius. */
+  flex: none;
   width: 28px;
   height: 28px;
-  border-radius: var(--radius-pill);
+  aspect-ratio: 1;
+  border-radius: 50%;
   border: 1px solid var(--border);
   background: var(--surface);
   color: var(--text-2);

--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -863,6 +863,9 @@
   position: sticky;
   bottom: 4px;
   align-self: flex-end;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 28px;
   height: 28px;
   border-radius: var(--radius-pill);


### PR DESCRIPTION
The `.chat-jump` button lacked flex centering, so its arrow icon rendered off-center. Adds flex centering and makes the button an explicit, stretch-proof circle. Supersedes #72.

Closes #68

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)