### PR TITLE
fix(followups): exclude interview-stage offers from the follow-up tracker

### DIFF
--- a/cli/followup-cadence.mjs
+++ b/cli/followup-cadence.mjs
@@ -53,7 +53,10 @@ const ALIASES = {
   'geo blocker': 'skip',
 };
 
-const ACTIONABLE_STATUSES = ['applied', 'responded', 'interview'];
+// Interview and later stages are past the point of a meaningful follow-up
+// push, so they're excluded from the cadence tracker (#69). Kept in sync with
+// src/lib/server/followups.ts (the web port).
+const ACTIONABLE_STATUSES = ['applied', 'responded'];
 
 function normalizeStatus(raw) {
   const clean = raw

--- a/src/lib/server/followups.ts
+++ b/src/lib/server/followups.ts
@@ -21,7 +21,12 @@ export const CADENCE = {
   interview_thankyou: 1,
 } as const;
 
-const ACTIONABLE_STATUSES = new Set(['applied', 'responded', 'interview']);
+// Only earlier-funnel stages get follow-up nudges. Once an offer reaches
+// Interview (or later: offer/rejected/closed) the ball is no longer in the
+// user's court for a cadence push, so those rows are excluded from the tracker
+// counts and lists (#69). computeUrgency/computeNextFollowupDate keep their
+// `interview` branch for CLI parity + direct unit tests; this set is the gate.
+const ACTIONABLE_STATUSES = new Set(['applied', 'responded']);
 
 export type Urgency = 'urgent' | 'overdue' | 'waiting' | 'cold';
 

--- a/test/followups-lib.test.ts
+++ b/test/followups-lib.test.ts
@@ -120,6 +120,25 @@ describe('loadFollowupState', () => {
     expect(state.entries[1].daysSinceApplication).toBe(2);
   });
 
+  it('excludes Interview-stage and later rows from follow-up counts and lists', () => {
+    // Once an offer reaches Interview (or Offer/Rejected/etc.) it's past the
+    // point where a follow-up push is meaningful — it must not appear in the
+    // "follow-up due" counts or the FOLLOW-UPS DUE list (#69).
+    const root = makeRoot(
+      [
+        `| 1 | ${isoDaysAgo(40)} | ZipRecruiter | Sales Engineer | 4.1/5 | Applied | ✅ | - | - |`,
+        `| 2 | ${isoDaysAgo(40)} | Customer.io | Technical Operations Manager | 4.0/5 | Interview | ✅ | - | - |`,
+        `| 3 | ${isoDaysAgo(40)} | Acme | SE | 3.9/5 | Offer | ✅ | - | - |`,
+      ],
+      undefined,
+      [transition(1, 'applied', 9), transition(2, 'interview', 3), transition(3, 'offer', 1)],
+    );
+    const state = loadFollowupState(root);
+    expect(state.actionable).toBe(1); // only the Applied row
+    expect(state.entries.map(e => e.company)).toEqual(['ZipRecruiter']);
+    expect(state.entries.some(e => e.status === 'interview')).toBe(false);
+  });
+
   it('leaves a row waiting when nothing recorded when it was applied', () => {
     const root = makeRoot([
       `| 1 | ${isoDaysAgo(40)} | ZipRecruiter | Sales Engineer | 4.1/5 | Applied | ✅ | - | - |`,


### PR DESCRIPTION
Offers at Interview and later are past the point of a meaningful follow-up push, so drop `interview` from `ACTIONABLE_STATUSES` in both the web module and the CLI (kept in sync). `computeUrgency`/`computeNextFollowupDate` keep their interview branch for direct unit tests and CLI parity.

Closes #69

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)