### PR TITLE
fix(editor): strip editor internals from copied report HTML

### DIFF
--- a/src/components/editor/__tests__/clean-clipboard-html.test.ts
+++ b/src/components/editor/__tests__/clean-clipboard-html.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { cleanClipboardHtml } from '../clean-clipboard-html';
+
+// The raw serialization ProseMirror puts on the clipboard when a report-body
+// table cell is copied (issue #67). Rich-text targets (Gmail, Docs, Notion)
+// read text/html first, so this markup is what the user actually pastes.
+const RAW_TABLE = `<table class="be-table" style="min-width: 25px;">
+<colgroup><col style="min-width: 25px;"></colgroup>
+<tbody><tr><td colspan="1" rowspan="1" data-node-id="a1b2"><p>Arsenii Peskovatskov</p></td></tr></tbody>
+</table>`;
+
+describe('cleanClipboardHtml', () => {
+  it('strips editor-internal table chrome but keeps the content', () => {
+    const out = cleanClipboardHtml(RAW_TABLE);
+    expect(out).toContain('Arsenii Peskovatskov');
+    expect(out).toContain('<table>');
+    expect(out).toContain('<td>');
+    // Editor internals must be gone.
+    expect(out).not.toContain('colgroup');
+    expect(out).not.toContain('<col');
+    expect(out).not.toContain('be-table');
+    expect(out).not.toContain('min-width');
+    expect(out).not.toContain('data-node-id');
+    // Redundant single-cell spans are noise.
+    expect(out).not.toContain('colspan="1"');
+    expect(out).not.toContain('rowspan="1"');
+  });
+
+  it('preserves real merged-cell spans', () => {
+    const out = cleanClipboardHtml(
+      '<table><tbody><tr><td colspan="2" rowspan="3"><p>merged</p></td></tr></tbody></table>',
+    );
+    expect(out).toContain('colspan="2"');
+    expect(out).toContain('rowspan="3"');
+  });
+
+  it('drops resize handles, editor handles, and contenteditable/draggable attrs', () => {
+    const out = cleanClipboardHtml(
+      '<p contenteditable="true" draggable="true">hi<span class="column-resize-handle"></span><span class="be-handle"></span></p>',
+    );
+    expect(out).toContain('hi');
+    expect(out).not.toContain('contenteditable');
+    expect(out).not.toContain('draggable');
+    expect(out).not.toContain('column-resize-handle');
+    expect(out).not.toContain('be-handle');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(cleanClipboardHtml('')).toBe('');
+  });
+});

--- a/src/components/editor/clean-clipboard-html.ts
+++ b/src/components/editor/clean-clipboard-html.ts
@@ -1,0 +1,43 @@
+// Cleans the `text/html` ProseMirror puts on the clipboard so that copying
+// from the report body (especially tables) yields clean, semantic HTML in
+// rich-text targets (Gmail, Google Docs, Notion) instead of editor internals
+// like <colgroup>, resize handles, data-node ids, and be-* chrome (issue #67).
+//
+// Pure + DOM-based so it can be unit-tested directly; the editor wires it into
+// a copy/cut listener (see tiptap-editor.tsx).
+
+// Editor-only nodes that carry no content — dropped entirely.
+const CHROME_SELECTOR = [
+  'colgroup',
+  '.column-resize-handle',
+  '.be-handle',
+  '.ProseMirror-separator',
+  '.ProseMirror-trailingBreak',
+  '.ProseMirror-gapcursor',
+].join(',');
+
+export function cleanClipboardHtml(html: string): string {
+  if (!html) return html;
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const body = doc.body;
+
+  for (const el of body.querySelectorAll(CHROME_SELECTOR)) el.remove();
+
+  for (const el of body.querySelectorAll<HTMLElement>('*')) {
+    // Editor chrome attributes that never belong in pasted content.
+    el.removeAttribute('contenteditable');
+    el.removeAttribute('draggable');
+    el.removeAttribute('spellcheck');
+    el.removeAttribute('class');
+    el.removeAttribute('style');
+    // All data-* attributes are editor internals (node ids, decorations, …).
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.startsWith('data-')) el.removeAttribute(attr.name);
+    }
+    // Drop redundant single-cell spans; keep real merges (>1).
+    if (el.getAttribute('colspan') === '1') el.removeAttribute('colspan');
+    if (el.getAttribute('rowspan') === '1') el.removeAttribute('rowspan');
+  }
+
+  return body.innerHTML;
+}

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -38,6 +38,7 @@ import { useEffect, useImperativeHandle, useRef } from 'react';
 import { Markdown } from 'tiptap-markdown';
 import { makeBubbleColorButton } from './bubble-color-popover';
 import { type CalloutPopoverHandle, mountCalloutPopover } from './callout-popover';
+import { cleanClipboardHtml } from './clean-clipboard-html';
 import { CalloutNode } from './extensions/callout-node';
 import { CodeBlockWithChrome } from './extensions/code-block-view';
 import { DetailsBlock } from './extensions/details-block';
@@ -480,6 +481,30 @@ export function TipTapEditor({
       dom.removeEventListener('error', onError, true);
       dom.removeEventListener('load', onLoad, true);
       clearTimeout(t);
+    };
+  }, [editor]);
+
+  // Clean the text/html ProseMirror writes on copy/cut so pasting a report
+  // table (or any block) into Gmail/Docs/Notion yields semantic HTML instead
+  // of editor internals (<colgroup>, resize handles, data-node ids…) (#67).
+  // ProseMirror's own copy handler runs first (registered at view creation);
+  // this listener runs after and rewrites clipboardData in place.
+  useEffect(() => {
+    if (!editor) return;
+    const dom = editor.view.dom as HTMLElement;
+    const onCopyOrCut = (e: Event) => {
+      const dt = (e as ClipboardEvent).clipboardData;
+      if (!dt) return;
+      const html = dt.getData('text/html');
+      if (!html) return;
+      const cleaned = cleanClipboardHtml(html);
+      if (cleaned && cleaned !== html) dt.setData('text/html', cleaned);
+    };
+    dom.addEventListener('copy', onCopyOrCut);
+    dom.addEventListener('cut', onCopyOrCut);
+    return () => {
+      dom.removeEventListener('copy', onCopyOrCut);
+      dom.removeEventListener('cut', onCopyOrCut);
     };
   }, [editor]);
 


### PR DESCRIPTION
Copying from a report-body table put ProseMirror's raw DOM serialization (colgroup, resize handles, data-node ids, be-* chrome) on the clipboard, so rich-text targets pasted markup. Adds `cleanClipboardHtml`, wired to the editor's copy/cut events to rewrite `text/html` in place.

Closes #67

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)