### PR TITLE
test: cap vitest fork pool to prevent CI OOM flakes

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,15 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'test/**/*.{test,spec}.{ts,tsx,mjs}'],
     exclude: ['node_modules', 'test/e2e/**'],
+    // The jsdom + ProseMirror editor suites are memory-heavy. Vitest's default
+    // one-fork-per-CPU parallelism OOM-kills a worker non-deterministically on
+    // CI's memory-constrained runners — a killed worker surfaces as a spurious
+    // "Quick quality gate" failure that truncates mid-test with no assertion.
+    // Cap the fork pool to keep peak memory bounded and CI deterministic.
+    pool: 'forks',
+    poolOptions: {
+      forks: { minForks: 1, maxForks: 2 },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Why

CI's `Quick quality gate` fails intermittently with **no assertion error** — the log truncates mid-test inside the memory-heavy `test/editor-turn-into-heading.test.ts` (22 ProseMirror editor instances). That's a **worker being OOM-killed**, not a real test failure. It's non-deterministic (re-runs pass) and a one-line CSS PR was enough to trip it.

## Root cause

The full jsdom + ProseMirror suite runs under vitest's **default parallelism** (`forks` pool, ~1 worker per CPU → ~4 on `ubuntu-latest`) with **no heap tuning**. Four parallel workers each holding ProseMirror editors in jsdom race the runner's memory; one gets killed.

## Fix

Cap the fork pool to `maxForks: 2` so peak memory stays bounded and CI is deterministic. Local `test:quick` still passes 100/0.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)