### PR TITLE
ci: raise node heap for the quick quality gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,13 @@ jobs:
 
       - name: Run quick quality gate
         run: npm run test:quick
+        env:
+          # The jsdom + ProseMirror vitest suites intermittently OOM-kill a
+          # fork on the default heap even with the fork pool capped at 2
+          # (vitest.config.ts) — the killed worker surfaces as a gate failure
+          # whose log truncates mid-test with no assertion. Give each fork
+          # explicit headroom (runner has 16 GB; 2 forks × 6 GB fits).
+          NODE_OPTIONS: --max-old-space-size=6144
 
   build:
     name: Production build

--- a/test/github-actions-policy.test.mjs
+++ b/test/github-actions-policy.test.mjs
@@ -164,6 +164,9 @@ function coreJobPolicyViolations(jobName, job) {
         {
           name: 'Run quick quality gate',
           run: 'npm run test:quick',
+          // Explicit heap headroom: the jsdom + ProseMirror suites can OOM-kill
+          // a vitest fork on the runner's default heap (see vitest.config.ts).
+          env: { NODE_OPTIONS: '--max-old-space-size=6144' },
         },
       ],
     },


### PR DESCRIPTION
Follow-up to #85: the fork-pool cap reduced but did not eliminate the OOM — the push-to-main gate on `2fdd8afa` was killed mid-run again (log truncates inside the editor suite, no assertion). Gives the gate step explicit heap headroom (`NODE_OPTIONS: --max-old-space-size=6144`; 2 forks × 6 GB fits the 16 GB runner) and updates the workflow policy test's approved job object to match.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)