### PR TITLE
fix(web): stop hiding ChatGPT-only models from the Codex model picker

### DIFF
--- a/src/lib/server/providers/__tests__/codex.test.ts
+++ b/src/lib/server/providers/__tests__/codex.test.ts
@@ -238,21 +238,29 @@ describe('codex provider', () => {
     // The model list comes from `~/.codex/models_cache.json`, a file Codex
     // maintains itself. We stub HOME per-test to a tmpdir so a dev's real
     // cache doesn't bleed into assertions and tests can construct the
-    // exact cache shape they want to assert against.
+    // exact cache shape they want to assert against. CODEX_API_KEY is
+    // cleared too — it forces API-key auth mode, which changes which cache
+    // entries qualify (see the auth-mode tests below).
     let originalHome: string | undefined;
+    let originalCodexApiKey: string | undefined;
 
     beforeEach(() => {
       originalHome = process.env.HOME;
+      originalCodexApiKey = process.env.CODEX_API_KEY;
+      delete process.env.CODEX_API_KEY;
     });
     afterEach(() => {
       if (originalHome === undefined) delete process.env.HOME;
       else process.env.HOME = originalHome;
+      if (originalCodexApiKey === undefined) delete process.env.CODEX_API_KEY;
+      else process.env.CODEX_API_KEY = originalCodexApiKey;
     });
 
     it('reads models from ~/.codex/models_cache.json filtered to picker-visible + API-supported entries', async () => {
       // Mirrors the real cache file shape: a mix of picker-shown,
-      // hidden, and not-yet-API-available entries. Only the
-      // visibility=list + supported_in_api=true ones should surface.
+      // hidden, and not-yet-API-available entries. With no auth.json in
+      // the fake HOME the auth mode is unknown, so the strict filter
+      // applies: only visibility=list + supported_in_api=true surface.
       const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
       mkdirSync(join(fakeHome, '.codex'), { recursive: true });
       writeFileSync(
@@ -287,7 +295,9 @@ describe('codex provider', () => {
               supported_in_api: true,
             },
             {
-              // visibility=list but not API-supported — must be filtered out.
+              // visibility=list but not API-supported — filtered out in
+              // API-key/unknown auth mode (kept under ChatGPT auth; see
+              // the ChatGPT-auth test below).
               slug: 'preview-only-model',
               display_name: 'Preview Only',
               visibility: 'list',
@@ -304,6 +314,128 @@ describe('codex provider', () => {
         { id: 'gpt-5.4', label: 'GPT-5.4' },
         { id: 'gpt-5.4-mini', label: 'GPT-5.4-Mini' },
       ]);
+    });
+
+    it('keeps supported_in_api=false models under ChatGPT auth, matching the codex /model picker', async () => {
+      // Issue #89: `gpt-5.3-codex-spark` is `visibility: list` but
+      // `supported_in_api: false`. Codex's own picker filter
+      // (ModelPreset::filter_by_auth) only applies `supported_in_api` in
+      // API-key mode; under ChatGPT login (`codex login` → auth.json with
+      // `tokens`) all picker-visible models show and run fine.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(
+        join(fakeHome, '.codex/auth.json'),
+        JSON.stringify({
+          OPENAI_API_KEY: null,
+          tokens: { id_token: 'x', access_token: 'y', refresh_token: 'z', account_id: 'a' },
+          last_refresh: '2026-08-14T00:00:00Z',
+        }),
+      );
+      writeFileSync(
+        join(fakeHome, '.codex/models_cache.json'),
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+            {
+              slug: 'gpt-5.3-codex-spark',
+              display_name: 'GPT-5.3-Codex-Spark',
+              visibility: 'list',
+              supported_in_api: false,
+            },
+            {
+              // Hidden entries stay excluded regardless of auth mode.
+              slug: 'codex-auto-review',
+              display_name: 'Codex Auto Review',
+              visibility: 'hide',
+              supported_in_api: true,
+            },
+          ],
+        }),
+      );
+      process.env.HOME = fakeHome;
+
+      const models = await codex.listModels();
+      expect(models).toEqual([
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3-Codex-Spark' },
+      ]);
+    });
+
+    it('filters supported_in_api=false models when auth.json holds a stored API key', async () => {
+      // `codex login --api-key` stores the key in auth.json without ChatGPT
+      // tokens → API-key mode: `supported_in_api: false` models are genuinely
+      // not callable, so codex (and we) drop them from the picker. Would
+      // fail if the supported_in_api condition were removed outright.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(
+        join(fakeHome, '.codex/auth.json'),
+        JSON.stringify({ OPENAI_API_KEY: 'sk-test-123', last_refresh: null }),
+      );
+      writeFileSync(
+        join(fakeHome, '.codex/models_cache.json'),
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+            {
+              slug: 'gpt-5.3-codex-spark',
+              display_name: 'GPT-5.3-Codex-Spark',
+              visibility: 'list',
+              supported_in_api: false,
+            },
+          ],
+        }),
+      );
+      process.env.HOME = fakeHome;
+
+      const models = await codex.listModels();
+      expect(models).toEqual([{ id: 'gpt-5.5', label: 'GPT-5.5' }]);
+    });
+
+    it('lets CODEX_API_KEY env force API-key mode even when ChatGPT tokens exist', async () => {
+      // Codex gives the CODEX_API_KEY env var top precedence over auth.json,
+      // so its presence flips the picker to the API-supported subset.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(
+        join(fakeHome, '.codex/auth.json'),
+        JSON.stringify({ OPENAI_API_KEY: null, tokens: { access_token: 'y' } }),
+      );
+      writeFileSync(
+        join(fakeHome, '.codex/models_cache.json'),
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+            {
+              slug: 'gpt-5.3-codex-spark',
+              display_name: 'GPT-5.3-Codex-Spark',
+              visibility: 'list',
+              supported_in_api: false,
+            },
+          ],
+        }),
+      );
+      process.env.HOME = fakeHome;
+      process.env.CODEX_API_KEY = 'sk-env-key';
+
+      const models = await codex.listModels();
+      expect(models).toEqual([{ id: 'gpt-5.5', label: 'GPT-5.5' }]);
     });
 
     it('uses the slug as the label when display_name is missing or empty', async () => {

--- a/src/lib/server/providers/__tests__/codex.test.ts
+++ b/src/lib/server/providers/__tests__/codex.test.ts
@@ -367,6 +367,86 @@ describe('codex provider', () => {
       ]);
     });
 
+    it('honors an explicit auth_mode: "chatgpt" even when a stored API key is also present', async () => {
+      // AuthDotJson::resolved_mode gives the explicit `auth_mode` field top
+      // priority over stored credentials, so a leftover stored key must not
+      // flip a declared-ChatGPT auth.json into API-key mode.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(
+        join(fakeHome, '.codex/auth.json'),
+        JSON.stringify({
+          auth_mode: 'chatgpt',
+          OPENAI_API_KEY: 'sk-stale-leftover',
+          tokens: { access_token: 'y' },
+        }),
+      );
+      writeFileSync(
+        join(fakeHome, '.codex/models_cache.json'),
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+            {
+              slug: 'gpt-5.3-codex-spark',
+              display_name: 'GPT-5.3-Codex-Spark',
+              visibility: 'list',
+              supported_in_api: false,
+            },
+          ],
+        }),
+      );
+      process.env.HOME = fakeHome;
+
+      const models = await codex.listModels();
+      expect(models).toEqual([
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3-Codex-Spark' },
+      ]);
+    });
+
+    it('honors an explicit auth_mode: "apikey" even when ChatGPT tokens are also present', async () => {
+      // The inverse mixed-credential state: declared API-key mode wins over
+      // leftover ChatGPT tokens, so the API-supported subset applies.
+      const fakeHome = mkdtempSync(join(tmpdir(), 'sur9e-codex-cache-'));
+      mkdirSync(join(fakeHome, '.codex'), { recursive: true });
+      writeFileSync(
+        join(fakeHome, '.codex/auth.json'),
+        JSON.stringify({
+          auth_mode: 'apikey',
+          OPENAI_API_KEY: null,
+          tokens: { access_token: 'y' },
+        }),
+      );
+      writeFileSync(
+        join(fakeHome, '.codex/models_cache.json'),
+        JSON.stringify({
+          models: [
+            {
+              slug: 'gpt-5.5',
+              display_name: 'GPT-5.5',
+              visibility: 'list',
+              supported_in_api: true,
+            },
+            {
+              slug: 'gpt-5.3-codex-spark',
+              display_name: 'GPT-5.3-Codex-Spark',
+              visibility: 'list',
+              supported_in_api: false,
+            },
+          ],
+        }),
+      );
+      process.env.HOME = fakeHome;
+
+      const models = await codex.listModels();
+      expect(models).toEqual([{ id: 'gpt-5.5', label: 'GPT-5.5' }]);
+    });
+
     it('filters supported_in_api=false models when auth.json holds a stored API key', async () => {
       // `codex login --api-key` stores the key in auth.json without ChatGPT
       // tokens → API-key mode: `supported_in_api: false` models are genuinely

--- a/src/lib/server/providers/codex.ts
+++ b/src/lib/server/providers/codex.ts
@@ -452,20 +452,41 @@ const codex: Provider = {
         // Mirror of Codex's own picker filter (ModelPreset::filter_by_auth):
         // `supported_in_api` only excludes a model under API-key auth — the
         // ChatGPT backend runs `supported_in_api: false` slugs fine (e.g.
-        // gpt-5.3-codex-spark, issue #89). ChatGPT mode = `codex login`
-        // tokens in ~/.codex/auth.json, no stored API key, and no
-        // CODEX_API_KEY env (which codex gives top precedence). Unknown /
-        // unreadable auth state keeps the strict filter — the conservative
-        // list is never wrong to RUN, just possibly shorter.
+        // gpt-5.3-codex-spark, issue #89). Auth mode follows codex's
+        // AuthDotJson::resolved_mode over ~/.codex/auth.json: an explicit
+        // `auth_mode` field wins, then stored credentials decide — except
+        // a CODEX_API_KEY env var beats stored auth entirely (top
+        // precedence in codex's load_auth). One deliberate divergence:
+        // with no explicit mode we require ChatGPT `tokens` to be present,
+        // where codex defaults to ChatGPT mode even without them —
+        // unknown/unreadable auth keeps the strict filter, whose shorter
+        // list is never wrong to RUN, just possibly shorter than the
+        // picker's.
         let chatgptAuth = false;
         if (!(process.env.CODEX_API_KEY ?? '').trim()) {
           try {
             const authPath = join(homedir(), '.codex/auth.json');
             if (existsSync(authPath)) {
               const auth = JSON.parse(readFileSync(authPath, 'utf-8'));
-              const hasStoredApiKey =
-                typeof auth?.OPENAI_API_KEY === 'string' && auth.OPENAI_API_KEY.trim().length > 0;
-              chatgptAuth = !hasStoredApiKey && Boolean(auth?.tokens);
+              // AuthMode variants that ride the ChatGPT/codex backend
+              // (AuthMode::uses_codex_backend in codex-rs/protocol) —
+              // everything except `apikey` and `bedrockApiKey`.
+              const codexBackendModes = [
+                'chatgpt',
+                'chatgptAuthTokens',
+                'headers',
+                'agentIdentity',
+                'personalAccessToken',
+              ];
+              if (typeof auth?.auth_mode === 'string') {
+                chatgptAuth = codexBackendModes.includes(auth.auth_mode);
+              } else if (auth?.personal_access_token) {
+                chatgptAuth = true;
+              } else {
+                const hasStoredApiKey =
+                  typeof auth?.OPENAI_API_KEY === 'string' && auth.OPENAI_API_KEY.trim().length > 0;
+                chatgptAuth = !hasStoredApiKey && !auth?.bedrock_api_key && Boolean(auth?.tokens);
+              }
             }
           } catch {
             // Corrupt/unreadable auth.json → treat as API-key mode. Must not

--- a/src/lib/server/providers/codex.ts
+++ b/src/lib/server/providers/codex.ts
@@ -25,9 +25,13 @@
 //     file that Codex itself maintains at `~/.codex/models_cache.json`
 //     (auto-fetched by the CLI via ETag against OpenAI's internal model
 //     metadata endpoint). We READ this file and filter to entries the
-//     `codex /model` picker actually shows — `visibility === "list"` AND
-//     `supported_in_api === true`. This is the SAME list users see when
-//     they run `codex /model` interactively. If the cache file is missing
+//     `codex /model` picker actually shows — `visibility === "list"`, plus
+//     `supported_in_api === true` only under API-key auth. That matches
+//     Codex's own ModelPreset::filter_by_auth: the ChatGPT backend runs
+//     models the public API doesn't expose (e.g. gpt-5.3-codex-spark), so
+//     under `codex login` (ChatGPT tokens) the API flag is ignored. This is
+//     the SAME list users see when they run `codex /model` interactively.
+//     If the cache file is missing
 //     (fresh install, never run `codex`) or yields zero qualifying entries,
 //     we fall back to FALLBACK_MODELS so the Settings picker never renders
 //     empty. The cache file is owned/refreshed by Codex itself; we treat
@@ -430,8 +434,8 @@ const codex: Provider = {
     // Source of truth: `~/.codex/models_cache.json`. Codex maintains this
     // file itself (auto-refreshes via ETag on each run) and uses it to power
     // its own `/model` interactive picker. Filtering to `visibility: "list"`
-    // + `supported_in_api: true` gives us the EXACT same list the picker
-    // displays — no guessing, no API mismatches.
+    // — plus `supported_in_api: true` only under API-key auth — gives us the
+    // EXACT same list the picker displays — no guessing, no API mismatches.
     //
     // The file is owned by Codex; we treat it as read-only. If it's missing
     // (fresh install before first `codex` invocation), malformed, or yields
@@ -445,11 +449,35 @@ const codex: Provider = {
       if (existsSync(cachePath)) {
         const cache = JSON.parse(readFileSync(cachePath, 'utf-8'));
         const models: any[] = Array.isArray(cache?.models) ? cache.models : [];
+        // Mirror of Codex's own picker filter (ModelPreset::filter_by_auth):
+        // `supported_in_api` only excludes a model under API-key auth — the
+        // ChatGPT backend runs `supported_in_api: false` slugs fine (e.g.
+        // gpt-5.3-codex-spark, issue #89). ChatGPT mode = `codex login`
+        // tokens in ~/.codex/auth.json, no stored API key, and no
+        // CODEX_API_KEY env (which codex gives top precedence). Unknown /
+        // unreadable auth state keeps the strict filter — the conservative
+        // list is never wrong to RUN, just possibly shorter.
+        let chatgptAuth = false;
+        if (!(process.env.CODEX_API_KEY ?? '').trim()) {
+          try {
+            const authPath = join(homedir(), '.codex/auth.json');
+            if (existsSync(authPath)) {
+              const auth = JSON.parse(readFileSync(authPath, 'utf-8'));
+              const hasStoredApiKey =
+                typeof auth?.OPENAI_API_KEY === 'string' && auth.OPENAI_API_KEY.trim().length > 0;
+              chatgptAuth = !hasStoredApiKey && Boolean(auth?.tokens);
+            }
+          } catch {
+            // Corrupt/unreadable auth.json → treat as API-key mode. Must not
+            // bubble to the outer catch: a broken auth file shouldn't wipe
+            // out the whole cache-derived model list.
+          }
+        }
         const filtered = models
           .filter(
             m =>
               m?.visibility === 'list' &&
-              m?.supported_in_api === true &&
+              (chatgptAuth || m?.supported_in_api === true) &&
               typeof m?.slug === 'string' &&
               m.slug.length > 0,
           )


### PR DESCRIPTION
## Outcome

The Settings → Codex model picker now shows the same models as the interactive `codex /model` picker. Previously `listModels()` required `supported_in_api === true` for every `~/.codex/models_cache.json` entry, which hid `gpt-5.3-codex-spark` (`visibility: list`, `supported_in_api: false`) even though the Codex CLI lists and runs it under ChatGPT auth.

Fixes #89

## Why the auth-aware fix (not dropping the condition)

Codex's own picker filter (`ModelPreset::filter_by_auth` in `codex-rs/protocol/src/openai_models.rs`) keeps every picker-visible model under ChatGPT auth and applies `supported_in_api` **only in API-key mode** — resolving the issue's open question. This PR mirrors that exactly:

- keep `visibility === 'list'`
- require `supported_in_api === true` only when auth is API-key mode: `CODEX_API_KEY` env set (top precedence in codex), or a stored API key in `~/.codex/auth.json` without ChatGPT tokens
- unknown/unreadable auth state keeps the strict filter, so behavior is unchanged for cache-only setups; a corrupt `auth.json` cannot wipe out the model list

Also rewrites the two comment blocks that claimed `visibility + supported_in_api` alone reproduces the `codex /model` list.

## Testing

- New vitest: ChatGPT auth (`auth.json` with `tokens`) keeps `supported_in_api: false` models; written first and watched fail against the old filter
- New guard vitests: stored-API-key auth.json filters them out; `CODEX_API_KEY` env overrides ChatGPT tokens
- Existing tests (no auth.json in fake HOME) pass unchanged as the strict-mode path; comments updated to say so
- `npm run test:quick`: 100/100 passing
- Verified read-only against a real ChatGPT-auth `~/.codex` (tokens present, no stored key, spark in cache as `list`/`false`) that the environment matches the ChatGPT branch

No UI markup/CSS changes — this only changes which options the picker receives — so no screenshots.

## AI disclosure

Implemented by an AI coding agent (Claude Code) per the repo's agent workflow; diff reviewed in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)