### PR TITLE
fix(batch): accept screen JSON when stream-formatter trailers follow the fence

### DIFF
--- a/batch/lib/output-parser.mjs
+++ b/batch/lib/output-parser.mjs
@@ -137,8 +137,35 @@ export function extractSentinelPayload(responseText, options = {}) {
   throw new Error(`no ${END_MARK} sentinel after ${OUTPUT_MARK} (or payload empty)`);
 }
 
+// Stream-formatter trailer lines cli/stream-claude-parser.mjs emits AFTER the
+// model's final text on a successful claude-routed run: the human status line
+// ("✓ claude done — 1 turns, $0.02, 41s") and the structured usage marker
+// ("[USAGE] {…}"). They land in captured stdout because the claude spawn is
+// piped through that formatter (see buildSpawnArgsForMode), so a trailing-
+// fence contract can never match end-of-string on those runs (issue #91).
+const FORMATTER_TRAILER_RE = /^(?:✓ \S+ done — .*|\[USAGE\] .*)$/;
+
+// Drop formatter trailers (and blank lines) from the END of the text only —
+// identical-looking content INSIDE the model's payload is untouched, and a
+// trailer line anywhere before the final fence is irrelevant to matching.
+export function stripFormatterTrailers(text) {
+  const lines = String(text ?? "").split("\n");
+  let end = lines.length;
+  while (end > 0) {
+    const line = lines[end - 1].trim();
+    if (line !== "" && !FORMATTER_TRAILER_RE.test(line)) break;
+    end--;
+  }
+  return lines.slice(0, end).join("\n");
+}
+
 export function extractTrailingFence(responseText) {
-  const text = stripTerminalNoise(responseText);
+  const text = stripFormatterTrailers(stripTerminalNoise(responseText));
+  // Deliberately end-anchored (after trailer stripping) rather than "last
+  // fence anywhere": if the model echoes a fenced profile/JD from the prompt
+  // but never emits the contract block, matching an arbitrary earlier fence
+  // would record junk fields as a real screen. Throwing here keeps that case
+  // a loud "unreadable" instead.
   const fenceRe = /```[a-zA-Z]*\s*\n([\s\S]*?)\n```\s*$/;
   const m = text.match(fenceRe);
   if (!m) throw new Error("no trailing fenced block in response");

--- a/batch/screen.mjs
+++ b/batch/screen.mjs
@@ -28,6 +28,7 @@ import { getUsageSummary } from '../cli/usage-tracker.mjs';
 import { buildScreeningPolicy, metadataPrefilter } from './screening-policy.mjs';
 import { fetchJobDescription } from './jd-fetcher.mjs';
 import { resolveRuntimeForMode, runModeLLM } from './lib/llm.mjs';
+import { extractTrailingFence } from './lib/output-parser.mjs';
 import { isValidIsoDate } from './lib/posted-date.mjs';
 import { stripFrontMatter } from './lib/report-file.mjs';
 import { trackModeUsage } from './lib/usage.mjs';
@@ -315,17 +316,12 @@ ${jdBlock}
 // of the response"; we tolerate trailing whitespace and any language
 // annotation on the fence ('```json', '```yaml', or bare '```'), and we
 // parse with yaml.load — a strict superset of JSON — so a model that
-// emits YAML keys instead of JSON still lands.
+// emits YAML keys instead of JSON still lands. Delegates to the shared
+// portable-contract parser, which also strips terminal noise and the
+// stream-formatter trailer lines ("✓ claude done — …", "[USAGE] {…}") that
+// claude-routed runs append after the fence (issue #91).
 export function parseScreenResponse(responseText) {
-  const text = String(responseText || '');
-  const fenceRe = /```[a-zA-Z]*\s*\n([\s\S]*?)\n```\s*$/;
-  const m = text.match(fenceRe);
-  if (!m) throw new Error('no trailing fenced block in response');
-  const parsed = yaml.load(m[1]);
-  if (!parsed || typeof parsed !== 'object') {
-    throw new Error('trailing fenced block did not yield an object');
-  }
-  return parsed;
+  return extractTrailingFence(responseText);
 }
 
 // Deterministically assemble the markdown-native screener report + tracker TSV

--- a/test/mode-runner-output-parser.test.mjs
+++ b/test/mode-runner-output-parser.test.mjs
@@ -157,6 +157,48 @@ describe('extractTrailingFence', () => {
   it('throws when there is no trailing fence', () => {
     expect(() => extractTrailingFence('nothing')).toThrow(/fenced/i);
   });
+
+  it('parses the fence when stream-formatter trailer lines follow it (issue #91)', () => {
+    // A claude-routed run pipes through cli/stream-claude-parser.mjs, whose
+    // re-emitted stdout ends with "✓ claude done — …" and "[USAGE] {…}" AFTER
+    // the model's fenced payload. A fallback run also prepends "[FALLBACK]".
+    const text = [
+      '[FALLBACK] {"from":{"provider":"opencode"},"to":{"provider":"claude"},"reason":"quota"}',
+      'Screening the posting now.',
+      '```json',
+      '{"readable": true, "company": "Acme", "score": 7.5}',
+      '```',
+      '✓ claude done — 1 turns, $0.02, 41s',
+      '[USAGE] {"cost_usd":0.02,"input_tokens":900,"output_tokens":80,"model":"claude-haiku-4-5-20251001"}',
+      '',
+    ].join('\n');
+    expect(extractTrailingFence(text)).toEqual({ readable: true, company: 'Acme', score: 7.5 });
+  });
+
+  it('still throws when only trailer lines exist and no fence at all', () => {
+    const text = [
+      'some chatter, no fenced block',
+      '✓ claude done — 2 turns, $0.10, 1m02s',
+      '[USAGE] {"cost_usd":0.1}',
+    ].join('\n');
+    expect(() => extractTrailingFence(text)).toThrow(/fenced/i);
+  });
+
+  it('does not strip trailer-shaped lines inside the fenced payload', () => {
+    // Only lines AFTER the closing fence are formatter noise; identical-looking
+    // content inside the payload must survive.
+    const text = [
+      '```yaml',
+      'company: Acme',
+      'note: "[USAGE] is a formatter marker"',
+      '```',
+      '✓ claude done — 1 turns, $0.01, 12s',
+    ].join('\n');
+    expect(extractTrailingFence(text)).toEqual({
+      company: 'Acme',
+      note: '[USAGE] is a formatter marker',
+    });
+  });
 });
 
 describe('stripTerminalNoise', () => {

--- a/test/screen-parse-response.test.mjs
+++ b/test/screen-parse-response.test.mjs
@@ -1,0 +1,49 @@
+// test/screen-parse-response.test.mjs
+//
+// parseScreenResponse must accept the screen contract's trailing fenced block
+// even when provider-infrastructure noise surrounds it. Issue #91: a claude
+// run (primary or opencode→claude fallback) is piped through
+// cli/stream-claude-parser.mjs, so the captured stdout carries formatter
+// trailer lines ("✓ claude done — …", "[USAGE] {…}") AFTER the model's fence —
+// the old end-of-string regex rejected those responses as unreadable.
+import { describe, expect, it } from 'vitest';
+import { parseScreenResponse } from '../batch/screen.mjs';
+
+describe('parseScreenResponse', () => {
+  it('parses a plain trailing fenced JSON block', () => {
+    const text = 'Assessment complete.\n```json\n{"readable": true, "score": 6.0}\n```\n';
+    expect(parseScreenResponse(text)).toEqual({ readable: true, score: 6.0 });
+  });
+
+  it('parses the opencode→claude fallback shape with formatter trailers (issue #91)', () => {
+    const text = [
+      '[FALLBACK] {"from":{"provider":"opencode","model":"deepseek-v4-flash-free"},"to":{"provider":"claude","model":"claude-haiku-4-5-20251001"},"reason":"quota"}',
+      'Here is the screen result:',
+      '```json',
+      '{',
+      '  "readable": true,',
+      '  "company": "Acme",',
+      '  "role": "Platform Engineer",',
+      '  "score": 7.5,',
+      '  "tldr": "Strong platform fit."',
+      '}',
+      '```',
+      '✓ claude done — 1 turns, $0.02, 41s',
+      '[USAGE] {"cost_usd":0.02,"input_tokens":900,"output_tokens":80,"model":"claude-haiku-4-5-20251001"}',
+      '',
+    ].join('\n');
+    expect(parseScreenResponse(text)).toEqual({
+      readable: true,
+      company: 'Acme',
+      role: 'Platform Engineer',
+      score: 7.5,
+      tldr: 'Strong platform fit.',
+    });
+  });
+
+  it('throws on a response with no fenced block so the offer records as unreadable', () => {
+    expect(() => parseScreenResponse('no fence here\n✓ claude done — 1 turns, $0.01, 9s')).toThrow(
+      /fenced/i,
+    );
+  });
+});


### PR DESCRIPTION
## Outcome

Batch screens routed through Claude (primary or `opencode → claude` fallback) no longer get marked unreadable when the response is valid. Claude spawns are piped through `cli/stream-claude-parser.mjs` (see `buildSpawnArgsForMode` in `batch/lib/llm.mjs`), so captured stdout always ends with formatter trailer lines — `✓ claude done — …` and `[USAGE] {…}` — after the model's fenced JSON. The end-of-string regex in `parseScreenResponse` then failed with `no trailing fenced block in response`, and a perfectly good screen was recorded as unreadable/Discarded.

Fixes #91

## The fix

- `extractTrailingFence` in `batch/lib/output-parser.mjs` now strips formatter trailer lines (and blank lines) from the **end** of the text — after the existing terminal-noise strip, before the strict trailing-fence match. Trailer-shaped content inside the payload is untouched.
- `parseScreenResponse` in `batch/screen.mjs` delegates to `extractTrailingFence` instead of duplicating the same regex, so the contract is parsed in one place (the screen path also gains ANSI/OSC noise stripping for free). Exported name and error messages are unchanged.
- The match deliberately stays end-anchored rather than "last fence anywhere": if a model echoes the fenced profile/JD from the prompt but never emits the contract block, matching an arbitrary earlier fence would record junk fields as a real screen. Throwing keeps that case a loud unreadable.

## Testing

- New failing-first test reproducing the issue's exact log shape (`[FALLBACK]` marker → fenced JSON → `✓ claude done` → `[USAGE]`) at both levels: `extractTrailingFence` and `parseScreenResponse` (new `test/screen-parse-response.test.mjs`)
- Guard tests: no fence + trailers still throws (stripping can't fabricate a match); trailer-shaped lines inside the payload survive
- Existing sentinel/recovery/screen suites pass unchanged; `npm run test:quick` 100/100

No UI changes — batch worker parsing only — so no screenshots.

## AI disclosure

Implemented by an AI coding agent (Claude Code) per the repo's agent workflow; diff reviewed in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)