### PR TITLE
fix(agent): give get_tracker server-side filters, compact rows, and pagination

### DIFF
--- a/cli/mcp-app-server.mjs
+++ b/cli/mcp-app-server.mjs
@@ -29,6 +29,20 @@ const TURN_ID = process.env.SUR9E_CHAT_TURN_ID ?? '';
 const PROTOCOL_VERSION = '2025-06-18';
 const SERVER_INFO = { name: 'sur9e-app', version: '1.0.0' };
 
+// Keep in sync with CANONICAL_STATUSES in src/lib/server/applications.ts.
+const CANONICAL_STATUSES = [
+  'screened',
+  'evaluated',
+  'applied',
+  'responded',
+  'interview',
+  'offer',
+  'rejected',
+  'discarded',
+];
+
+const DATE_PATTERN = '^\\d{4}-\\d{2}-\\d{2}$';
+
 const READ_TOOLS = [
   {
     name: 'list_modes',
@@ -52,8 +66,60 @@ const READ_TOOLS = [
   {
     name: 'get_tracker',
     description:
-      'List every tracked application: num, date, company, role, score, status, source URL, and report summary. Read-only.',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      'List tracked applications as compact rows: num, date, company, role, score, status, url, ' +
+      'location, work_mode, seniority, posted. The tracker can hold thousands of rows — ALWAYS ' +
+      'filter server-side with the arguments below instead of fetching everything and filtering ' +
+      'yourself. Returns { entries, total, count, next_offset }; pages default to 200 rows — when ' +
+      'next_offset is not null, call again with offset set to it for the next page. For full ' +
+      'detail on one application (report markdown etc.), use get_report. Read-only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'array',
+          minItems: 1,
+          items: { type: 'string', enum: CANONICAL_STATUSES },
+          description: 'Keep only rows whose canonical status is one of these',
+        },
+        location: {
+          type: 'string',
+          description: 'Case-insensitive substring match on the offer location',
+        },
+        work_mode: {
+          type: 'string',
+          description: 'Exact work mode (case-insensitive), e.g. Remote, Hybrid, On-site',
+        },
+        company: { type: 'string', description: 'Case-insensitive substring match on company' },
+        role: { type: 'string', description: 'Case-insensitive substring match on role title' },
+        min_score: {
+          type: 'number',
+          description:
+            'Keep only rows scoring at least this (e.g. 4 keeps 4.0/5 and up); rows without a numeric score are dropped',
+        },
+        since: {
+          type: 'string',
+          pattern: DATE_PATTERN,
+          description: 'Keep rows added on or after this date (YYYY-MM-DD)',
+        },
+        until: {
+          type: 'string',
+          pattern: DATE_PATTERN,
+          description: 'Keep rows added on or before this date (YYYY-MM-DD)',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 1000,
+          description: 'Page size (default 200)',
+        },
+        offset: {
+          type: 'integer',
+          minimum: 0,
+          description: 'Pagination offset — pass the previous call’s next_offset',
+        },
+      },
+      additionalProperties: false,
+    },
   },
   {
     name: 'get_report',
@@ -269,20 +335,7 @@ const ACTION_TOOLS = [
       type: 'object',
       properties: {
         num: { type: 'integer', minimum: 1 },
-        status: {
-          type: 'string',
-          // Keep in sync with CANONICAL_STATUSES in src/lib/server/applications.ts.
-          enum: [
-            'screened',
-            'evaluated',
-            'applied',
-            'responded',
-            'interview',
-            'offer',
-            'rejected',
-            'discarded',
-          ],
-        },
+        status: { type: 'string', enum: CANONICAL_STATUSES },
         terminalApproved: { type: 'boolean', description: TERMINAL_APPROVED_DESC },
       },
       required: ['num', 'status'],
@@ -461,7 +514,21 @@ async function callTool(name, args) {
       return textResult(body);
     }
     case 'get_tracker': {
-      const { status, body } = await appFetch('/api/applications');
+      // Always request the compact server-side-filtered projection — the
+      // full-summary payload blows the tool-output limit on large trackers.
+      const params = new URLSearchParams({ fields: 'compact' });
+      if (Array.isArray(args?.status) && args.status.length > 0) {
+        params.set('status', args.status.join(','));
+      }
+      for (const key of ['location', 'work_mode', 'company', 'role', 'since', 'until']) {
+        const value = args?.[key];
+        if (typeof value === 'string' && value.trim()) params.set(key, value.trim());
+      }
+      for (const key of ['min_score', 'limit', 'offset']) {
+        const value = args?.[key];
+        if (typeof value === 'number' && Number.isFinite(value)) params.set(key, String(value));
+      }
+      const { status, body } = await appFetch(`/api/applications?${params}`);
       if (status !== 200) {
         return errorResult(
           `Failed to load the tracker (HTTP ${status}): ${body?.error ?? 'unknown error'}`,

--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -3,11 +3,33 @@ export const runtime = 'nodejs';
 import { jsonError } from '@/lib/http-errors';
 import { ROOT } from '@/lib/root';
 import { loadApplicationsWithSummary } from '@/lib/server/applications';
+import {
+  queryApplications,
+  TRACKER_QUERY_PARAM_KEYS,
+  TrackerQueryParams,
+  toTrackerFilters,
+} from '@/lib/server/tracker-query';
 
-export function GET() {
+export function GET(request: Request) {
   try {
-    const entries = loadApplicationsWithSummary(ROOT);
-    return Response.json({ entries, count: entries.length });
+    const { searchParams } = new URL(request.url);
+    const recognized = TRACKER_QUERY_PARAM_KEYS.filter(key => searchParams.has(key));
+
+    // Back-compat: with no recognized params the payload stays byte-identical
+    // to the legacy full-summary shape — the web UI's TanStack hook consumes it.
+    if (recognized.length === 0) {
+      const entries = loadApplicationsWithSummary(ROOT);
+      return Response.json({ entries, count: entries.length });
+    }
+
+    const params = TrackerQueryParams.safeParse(
+      Object.fromEntries(recognized.map(key => [key, searchParams.get(key)])),
+    );
+    if (!params.success) {
+      const issue = params.error.issues[0];
+      return jsonError(`Invalid query param ${issue.path.join('.')}: ${issue.message}`, 400);
+    }
+    return Response.json(queryApplications(ROOT, toTrackerFilters(params.data)));
   } catch (error) {
     return jsonError(error instanceof Error ? error.message : 'Failed to load applications');
   }

--- a/src/lib/server/tracker-query.ts
+++ b/src/lib/server/tracker-query.ts
@@ -14,6 +14,18 @@ import { loadApplicationsWithSummary, normalizeStatus } from './applications';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/** YYYY-MM-DD that is also a real calendar date — the regex alone admits
+ * impossible values like 2026-02-30, which would then silently filter as
+ * plain string comparisons. The UTC round-trip rejects anything Date had
+ * to normalize. */
+const isoDate = z
+  .string()
+  .regex(DATE_RE, 'expected YYYY-MM-DD')
+  .refine(value => {
+    const parsed = new Date(`${value}T00:00:00Z`);
+    return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+  }, 'not a real calendar date');
+
 /**
  * URL query params recognized by GET /api/applications. Presence of ANY of
  * these keys switches the route from the legacy full-summary payload to the
@@ -45,8 +57,8 @@ export const TrackerQueryParams = z.object({
   company: z.string().optional(),
   role: z.string().optional(),
   min_score: z.coerce.number().optional(),
-  since: z.string().regex(DATE_RE, 'expected YYYY-MM-DD').optional(),
-  until: z.string().regex(DATE_RE, 'expected YYYY-MM-DD').optional(),
+  since: isoDate.optional(),
+  until: isoDate.optional(),
   limit: z.coerce.number().int().optional(),
   offset: z.coerce.number().int().optional(),
   fields: z.literal('compact').optional(),

--- a/src/lib/server/tracker-query.ts
+++ b/src/lib/server/tracker-query.ts
@@ -1,0 +1,234 @@
+// Server-side tracker querying: filters + compact projection + pagination
+// over loadApplicationsWithSummary. Powers GET /api/applications with query
+// params (fields=compact) and, through it, the MCP get_tracker tool — so an
+// agent can ask for exactly the rows it needs instead of pulling the whole
+// tracker (1.7 MB at ~2.5k rows) through a tool-output limit (#104/#107).
+
+import 'server-only';
+import { z } from 'zod';
+import type { ApplicationWithSummary } from '../schemas/applications';
+import { ApplicationStatus } from '../schemas/applications';
+import { loadApplicationsWithSummary, normalizeStatus } from './applications';
+
+// ── Query params (wire format, snake_case) ────────────────────────────────────
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * URL query params recognized by GET /api/applications. Presence of ANY of
+ * these keys switches the route from the legacy full-summary payload to the
+ * compact paginated payload — keep the route's back-compat check in sync by
+ * always deriving it from this schema's keys.
+ */
+export const TrackerQueryParams = z.object({
+  // Comma-separated canonical statuses (legacy 'skip' folds into discarded
+  // via the ApplicationStatus preprocess).
+  status: z
+    .string()
+    .transform((s, ctx) => {
+      const statuses: ApplicationStatus[] = [];
+      for (const part of s.split(',')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const parsed = ApplicationStatus.safeParse(trimmed);
+        if (!parsed.success) {
+          ctx.addIssue({ code: 'custom', message: `unknown status: ${trimmed}` });
+          return z.NEVER;
+        }
+        statuses.push(parsed.data);
+      }
+      return statuses;
+    })
+    .optional(),
+  location: z.string().optional(),
+  work_mode: z.string().optional(),
+  company: z.string().optional(),
+  role: z.string().optional(),
+  min_score: z.coerce.number().optional(),
+  since: z.string().regex(DATE_RE, 'expected YYYY-MM-DD').optional(),
+  until: z.string().regex(DATE_RE, 'expected YYYY-MM-DD').optional(),
+  limit: z.coerce.number().int().optional(),
+  offset: z.coerce.number().int().optional(),
+  fields: z.literal('compact').optional(),
+});
+export type TrackerQueryParams = z.infer<typeof TrackerQueryParams>;
+
+export const TRACKER_QUERY_PARAM_KEYS = Object.freeze(
+  Object.keys(TrackerQueryParams.shape),
+) as readonly string[];
+
+// ── Filters (lib format, camelCase) ───────────────────────────────────────────
+
+export interface TrackerQueryFilters {
+  status?: ApplicationStatus[];
+  /** Case-insensitive substring on summary.location (fallback summary.loc). */
+  location?: string;
+  /** Case-insensitive equality on summary.work_mode. */
+  workMode?: string;
+  /** Case-insensitive substring on the row's company. */
+  company?: string;
+  /** Case-insensitive substring on the row's role. */
+  role?: string;
+  /** Rows whose score parses to a number >= this; non-numeric rows drop. */
+  minScore?: number;
+  /** YYYY-MM-DD; rows with date >= since. */
+  since?: string;
+  /** YYYY-MM-DD; rows with date <= until. */
+  until?: string;
+  /** Page size, default 200, clamped to 1..1000. */
+  limit?: number;
+  /** Pagination offset, default 0. */
+  offset?: number;
+}
+
+/** Map validated wire params onto lib filters. */
+export function toTrackerFilters(params: TrackerQueryParams): TrackerQueryFilters {
+  return {
+    status: params.status,
+    location: params.location,
+    workMode: params.work_mode,
+    company: params.company,
+    role: params.role,
+    minScore: params.min_score,
+    since: params.since,
+    until: params.until,
+    limit: params.limit,
+    offset: params.offset,
+  };
+}
+
+// ── Result shape ──────────────────────────────────────────────────────────────
+
+/**
+ * Compact row projection: only scalar identity + summary fields the agent
+ * needs to pick an application; full detail stays behind get_report. Absent
+ * values are omitted rather than emitted as null/undefined keys.
+ */
+export interface CompactApplication {
+  num: number;
+  date: string;
+  company: string;
+  role: string;
+  score: string;
+  /** Canonical lowercase status ('skip' rows surface as 'discarded'). */
+  status: string;
+  url?: string;
+  location?: string;
+  work_mode?: string;
+  seniority?: string;
+  posted?: string;
+}
+
+export interface TrackerQueryResult {
+  entries: CompactApplication[];
+  /** Filtered row count before pagination. */
+  total: number;
+  /** entries.length — the page size actually returned. */
+  count: number;
+  /** Offset for the next page, or null when this page is the last. */
+  next_offset: number | null;
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 1000;
+
+/** Canonical lowercase status for a raw tracker cell ('**Skip**' → 'discarded'). */
+function canonicalStatus(raw: string): string {
+  const normalized = normalizeStatus(raw);
+  const parsed = ApplicationStatus.safeParse(normalized);
+  return parsed.success ? parsed.data : normalized;
+}
+
+/** First argument that is a non-empty string, else undefined. */
+function firstNonEmpty(...values: Array<string | null | undefined>): string | undefined {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) return v;
+  }
+  return undefined;
+}
+
+function rowLocation(row: ApplicationWithSummary): string | undefined {
+  return firstNonEmpty(row.summary?.location, row.summary?.loc);
+}
+
+function matches(row: ApplicationWithSummary, filters: TrackerQueryFilters): boolean {
+  // An empty status list (e.g. `?status=`) means "no status filter".
+  if (
+    filters.status &&
+    filters.status.length > 0 &&
+    !(filters.status as string[]).includes(canonicalStatus(row.status))
+  ) {
+    return false;
+  }
+  if (filters.location) {
+    const location = rowLocation(row);
+    if (!location || !location.toLowerCase().includes(filters.location.toLowerCase())) {
+      return false;
+    }
+  }
+  if (filters.workMode) {
+    const workMode = firstNonEmpty(row.summary?.work_mode);
+    if (!workMode || workMode.toLowerCase() !== filters.workMode.toLowerCase()) return false;
+  }
+  if (filters.company && !row.company.toLowerCase().includes(filters.company.toLowerCase())) {
+    return false;
+  }
+  if (filters.role && !row.role.toLowerCase().includes(filters.role.toLowerCase())) {
+    return false;
+  }
+  if (filters.minScore !== undefined) {
+    const score = Number.parseFloat(row.score);
+    if (!Number.isFinite(score) || score < filters.minScore) return false;
+  }
+  if (filters.since && row.date < filters.since) return false;
+  if (filters.until && row.date > filters.until) return false;
+  return true;
+}
+
+function project(row: ApplicationWithSummary): CompactApplication {
+  const entry: CompactApplication = {
+    num: row.num,
+    date: row.date,
+    company: row.company,
+    role: row.role,
+    score: row.score,
+    status: canonicalStatus(row.status),
+  };
+  const url = firstNonEmpty(row.summary?.url);
+  if (url) entry.url = url;
+  const location = rowLocation(row);
+  if (location) entry.location = location;
+  const workMode = firstNonEmpty(row.summary?.work_mode);
+  if (workMode) entry.work_mode = workMode;
+  const seniority = firstNonEmpty(row.summary?.seniority);
+  if (seniority) entry.seniority = seniority;
+  const posted = firstNonEmpty(row.posted, row.summary?.posted);
+  if (posted) entry.posted = posted;
+  return entry;
+}
+
+/**
+ * Filter, project, and paginate the tracker. All filters are conjunctive and
+ * optional; with none given this is simply "first page of the tracker,
+ * compact rows".
+ */
+export function queryApplications(
+  rootPath: string,
+  filters: TrackerQueryFilters,
+): TrackerQueryResult {
+  const limit = Math.min(Math.max(Math.trunc(filters.limit ?? DEFAULT_LIMIT), 1), MAX_LIMIT);
+  const offset = Math.max(Math.trunc(filters.offset ?? 0), 0);
+
+  const filtered = loadApplicationsWithSummary(rootPath).filter(row => matches(row, filters));
+  const entries = filtered.slice(offset, offset + limit).map(project);
+  const nextOffset = offset + entries.length;
+
+  return {
+    entries,
+    total: filtered.length,
+    count: entries.length,
+    next_offset: nextOffset < filtered.length ? nextOffset : null,
+  };
+}

--- a/test/applications-route.test.ts
+++ b/test/applications-route.test.ts
@@ -128,6 +128,9 @@ describe('GET /api/applications — filtered compact shape', () => {
       '?min_score=abc',
       '?status=bogus',
       '?since=07-01-2026',
+      // Format-valid but calendar-impossible — regex alone would accept it.
+      '?since=2026-02-30',
+      '?until=2026-13-01',
       '?limit=two',
       '?fields=full',
     ]) {

--- a/test/applications-route.test.ts
+++ b/test/applications-route.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+//
+// test/applications-route.test.ts
+//
+// GET /api/applications back-compat contract (issues #104/#107): with no
+// recognized query params the response stays byte-identical to the legacy
+// `{ entries, count }` payload with full summaries (the web UI's TanStack
+// hook consumes it); any recognized filter param — or fields=compact —
+// switches to the paginated compact shape from queryApplications. Pattern B
+// (see turns-route.test.ts): tmpdir + SUR9E_ROOT + vi.resetModules() +
+// dynamic import so the route's module-level ROOT binding points at this
+// test's throwaway root, never the repo.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type ApplicationsRoute = typeof import('@/app/api/applications/route');
+type ApplicationsLib = typeof import('@/lib/server/applications');
+
+let root: string;
+let route: ApplicationsRoute;
+let applications: ApplicationsLib;
+
+async function loadRoot(): Promise<void> {
+  root = mkdtempSync(join(tmpdir(), 'sur9e-apps-route-'));
+  mkdirSync(join(root, 'data'), { recursive: true });
+  mkdirSync(join(root, 'artifacts/reports'), { recursive: true });
+  writeFileSync(
+    join(root, 'data/applications.md'),
+    `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|
+| 1 | 2026-07-01 | Acme | Platform Engineer | 4.2/5 | Evaluated | ✅ | [1](artifacts/reports/001-acme.md) | - |  |
+| 2 | 2026-07-05 | Globex | Sales Engineer | 3.1/5 | Applied | ✅ | - | - |  |
+`,
+  );
+  writeFileSync(
+    join(root, 'artifacts/reports/001-acme.md'),
+    [
+      '---',
+      'num: 1',
+      'company: Acme',
+      'role: Platform Engineer',
+      "date: '2026-07-01'",
+      'state: evaluated',
+      'score: 4.2',
+      'url: https://jobs.acme.dev/platform',
+      'location: Barcelona, Spain',
+      'work_mode: Hybrid',
+      '---',
+      '',
+      '# Report body',
+      '',
+    ].join('\n'),
+  );
+  process.env.SUR9E_ROOT = root;
+  vi.resetModules();
+  route = await import('@/app/api/applications/route');
+  applications = await import('@/lib/server/applications');
+}
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  delete process.env.SUR9E_ROOT;
+});
+
+function get(query = ''): Response {
+  return route.GET(new Request(`http://localhost/api/applications${query}`));
+}
+
+describe('GET /api/applications — legacy back-compat', () => {
+  it('stays byte-identical to the full-summary payload with no params', async () => {
+    await loadRoot();
+    const res = get();
+    expect(res.status).toBe(200);
+    const entries = applications.loadApplicationsWithSummary(root);
+    expect(await res.text()).toBe(JSON.stringify({ entries, count: entries.length }));
+  });
+
+  it('keeps the legacy shape when only unrecognized params are present', async () => {
+    await loadRoot();
+    const res = get('?foo=bar&baz=1');
+    const body = await res.json();
+    expect(body.count).toBe(2);
+    expect(body.total).toBeUndefined();
+    expect(body.next_offset).toBeUndefined();
+    expect(body.entries[0]).toHaveProperty('summary');
+  });
+});
+
+describe('GET /api/applications — filtered compact shape', () => {
+  it('a filter param switches to the paginated compact payload', async () => {
+    await loadRoot();
+    const res = get('?status=applied');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ total: 1, count: 1, next_offset: null });
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0]).toMatchObject({ num: 2, company: 'Globex', status: 'applied' });
+    expect(body.entries[0]).not.toHaveProperty('summary');
+  });
+
+  it('fields=compact alone switches shape without filtering', async () => {
+    await loadRoot();
+    const body = await get('?fields=compact').json();
+    expect(body.total).toBe(2);
+    expect(body.count).toBe(2);
+    expect(body.entries.map((e: { num: number }) => e.num)).toEqual([1, 2]);
+    expect(body.entries[0].url).toBe('https://jobs.acme.dev/platform');
+  });
+
+  it('maps snake_case params onto the lib filters', async () => {
+    await loadRoot();
+    const body = await get('?work_mode=hybrid&min_score=4&role=engineer').json();
+    expect(body.entries.map((e: { num: number }) => e.num)).toEqual([1]);
+    const paged = await get('?fields=compact&limit=1&offset=1').json();
+    expect(paged.entries.map((e: { num: number }) => e.num)).toEqual([2]);
+    expect(paged.next_offset).toBeNull();
+    expect(paged.total).toBe(2);
+  });
+
+  it('rejects invalid param values with a 400', async () => {
+    await loadRoot();
+    for (const query of [
+      '?min_score=abc',
+      '?status=bogus',
+      '?since=07-01-2026',
+      '?limit=two',
+      '?fields=full',
+    ]) {
+      const res = get(query);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBeTruthy();
+    }
+  });
+});

--- a/test/tracker-query.test.ts
+++ b/test/tracker-query.test.ts
@@ -9,7 +9,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { queryApplications } from '@/lib/server/tracker-query';
+import { queryApplications, TrackerQueryParams } from '@/lib/server/tracker-query';
 
 const TRACKER_HEADER = `# Applications Tracker
 
@@ -260,5 +260,20 @@ describe('queryApplications — pagination', () => {
     expect(clamped.count).toBe(1);
     const clampedHigh = queryApplications(root, { limit: 5000 });
     expect(clampedHigh.count).toBe(205);
+  });
+});
+
+describe('TrackerQueryParams — date validation', () => {
+  it('rejects format-valid but calendar-impossible dates', () => {
+    for (const value of ['2026-02-30', '2026-13-01', '2025-04-31', '2026-00-10']) {
+      expect(TrackerQueryParams.safeParse({ since: value }).success, value).toBe(false);
+      expect(TrackerQueryParams.safeParse({ until: value }).success, value).toBe(false);
+    }
+  });
+
+  it('accepts real calendar dates, including leap day', () => {
+    for (const value of ['2026-07-01', '2024-02-29', '2026-12-31']) {
+      expect(TrackerQueryParams.safeParse({ since: value }).success, value).toBe(true);
+    }
   });
 });

--- a/test/tracker-query.test.ts
+++ b/test/tracker-query.test.ts
@@ -1,0 +1,264 @@
+// test/tracker-query.test.ts
+//
+// queryApplications(rootPath, filters) — the server-side filter + compact
+// projection + pagination layer behind GET /api/applications?fields=compact
+// and the MCP get_tracker tool (issues #104 / #107). Fixtures are built in a
+// throwaway mkdtemp root; the real data/ directory is never touched.
+
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { queryApplications } from '@/lib/server/tracker-query';
+
+const TRACKER_HEADER = `# Applications Tracker
+
+| # | Date | Company | Role | Score | Status | PDF | Report | Notes |
+|---|------|---------|------|-------|--------|-----|--------|-------|`;
+
+function makeRoot(trackerRows: string[], reports: Record<string, string> = {}): string {
+  const root = mkdtempSync(join(tmpdir(), 'sur9e-tracker-query-'));
+  mkdirSync(join(root, 'data'), { recursive: true });
+  mkdirSync(join(root, 'artifacts/reports'), { recursive: true });
+  writeFileSync(
+    join(root, 'data/applications.md'),
+    `${TRACKER_HEADER}\n${trackerRows.join('\n')}\n`,
+  );
+  for (const [fileName, content] of Object.entries(reports)) {
+    writeFileSync(join(root, 'artifacts/reports', fileName), content);
+  }
+  return root;
+}
+
+function report(frontmatterLines: string[]): string {
+  return ['---', ...frontmatterLines, '---', '', '# Report body', ''].join('\n');
+}
+
+/**
+ * Standard 4-row fixture:
+ *   1  Acme    Platform Engineer  4.2/5  Evaluated  Barcelona / Hybrid / Senior + url
+ *   2  Globex  Sales Engineer     3.1/5  Applied    loc_short-only summary + posted col
+ *   3  Initech Backend Engineer   N/A    Screened   no report (null summary)
+ *   4  Hooli   Platform Engineer  4.8/5  Skip       posted via report frontmatter
+ */
+function standardRoot(): string {
+  return makeRoot(
+    [
+      '| 1 | 2026-07-01 | Acme | Platform Engineer | 4.2/5 | Evaluated | ✅ | [1](artifacts/reports/001-acme.md) | - |  |',
+      '| 2 | 2026-07-05 | Globex | Sales Engineer | 3.1/5 | Applied | ✅ | [2](artifacts/reports/002-globex.md) | - | 2026-07-02 |',
+      '| 3 | 2026-07-10 | Initech | Backend Engineer | N/A | Screened | ❌ | - | - |  |',
+      '| 4 | 2026-08-01 | Hooli | Platform Engineer | 4.8/5 | Skip | ❌ | [4](artifacts/reports/004-hooli.md) | - |  |',
+    ],
+    {
+      '001-acme.md': report([
+        'num: 1',
+        'company: Acme',
+        'role: Platform Engineer',
+        "date: '2026-07-01'",
+        'state: evaluated',
+        'score: 4.2',
+        'url: https://jobs.acme.dev/platform',
+        'location: Barcelona, Spain',
+        'work_mode: Hybrid',
+        'seniority: Senior',
+      ]),
+      '002-globex.md': report([
+        'num: 2',
+        'company: Globex',
+        'role: Sales Engineer',
+        "date: '2026-07-05'",
+        'state: evaluated',
+        'score: 3.1',
+        'loc_short: Remote EU',
+        'work_mode: Remote',
+      ]),
+      '004-hooli.md': report([
+        'num: 4',
+        'company: Hooli',
+        'role: Platform Engineer',
+        "date: '2026-08-01'",
+        'state: evaluated',
+        'score: 4.8',
+        'location: Palo Alto, US',
+        'work_mode: On-site',
+        "posted: '2026-07-28'",
+      ]),
+    },
+  );
+}
+
+describe('queryApplications — compact projection', () => {
+  it('returns all rows compactly with totals when no filters are given', () => {
+    const result = queryApplications(standardRoot(), {});
+    expect(result.total).toBe(4);
+    expect(result.count).toBe(4);
+    expect(result.next_offset).toBeNull();
+    expect(result.entries).toHaveLength(4);
+    for (const entry of result.entries) {
+      expect(entry).not.toHaveProperty('summary');
+      expect(entry).not.toHaveProperty('pdf');
+      expect(entry).not.toHaveProperty('reportPath');
+      expect(entry).not.toHaveProperty('notes');
+    }
+  });
+
+  it('projects url/location/work_mode/seniority from the report summary', () => {
+    const result = queryApplications(standardRoot(), {});
+    const acme = result.entries.find(e => e.num === 1);
+    expect(acme).toMatchObject({
+      num: 1,
+      date: '2026-07-01',
+      company: 'Acme',
+      role: 'Platform Engineer',
+      score: '4.2/5',
+      status: 'evaluated',
+      url: 'https://jobs.acme.dev/platform',
+      location: 'Barcelona, Spain',
+      work_mode: 'Hybrid',
+      seniority: 'Senior',
+    });
+  });
+
+  it('omits absent keys entirely on a null-summary row', () => {
+    const result = queryApplications(standardRoot(), {});
+    const initech = result.entries.find(e => e.num === 3);
+    expect(initech).toEqual({
+      num: 3,
+      date: '2026-07-10',
+      company: 'Initech',
+      role: 'Backend Engineer',
+      score: 'N/A',
+      status: 'screened',
+    });
+  });
+
+  it('falls back to summary.loc when summary.location is empty', () => {
+    const result = queryApplications(standardRoot(), {});
+    const globex = result.entries.find(e => e.num === 2);
+    expect(globex?.location).toBe('Remote EU');
+  });
+
+  it('takes posted from the row column first, then the report summary', () => {
+    const result = queryApplications(standardRoot(), {});
+    expect(result.entries.find(e => e.num === 2)?.posted).toBe('2026-07-02');
+    expect(result.entries.find(e => e.num === 4)?.posted).toBe('2026-07-28');
+    expect(result.entries.find(e => e.num === 1)).not.toHaveProperty('posted');
+  });
+
+  it('canonicalizes legacy Skip status to discarded in the projection', () => {
+    const result = queryApplications(standardRoot(), {});
+    expect(result.entries.find(e => e.num === 4)?.status).toBe('discarded');
+  });
+});
+
+describe('queryApplications — filters', () => {
+  it('filters by canonical status, matching legacy Skip rows as discarded', () => {
+    const root = standardRoot();
+    const applied = queryApplications(root, { status: ['applied'] });
+    expect(applied.entries.map(e => e.num)).toEqual([2]);
+    expect(applied.total).toBe(1);
+    const discarded = queryApplications(root, { status: ['discarded'] });
+    expect(discarded.entries.map(e => e.num)).toEqual([4]);
+    const multi = queryApplications(root, { status: ['evaluated', 'screened'] });
+    expect(multi.entries.map(e => e.num)).toEqual([1, 3]);
+  });
+
+  it('treats an empty status list as no status filter', () => {
+    expect(queryApplications(standardRoot(), { status: [] }).total).toBe(4);
+  });
+
+  it('filters by location as a case-insensitive substring with loc fallback', () => {
+    const root = standardRoot();
+    expect(queryApplications(root, { location: 'barcelona' }).entries.map(e => e.num)).toEqual([1]);
+    expect(queryApplications(root, { location: 'remote' }).entries.map(e => e.num)).toEqual([2]);
+    // Rows with no location at all never match a location filter.
+    expect(queryApplications(root, { location: '' }).total).toBe(4);
+  });
+
+  it('filters by work_mode as case-insensitive equality, not substring', () => {
+    const root = standardRoot();
+    expect(queryApplications(root, { workMode: 'hybrid' }).entries.map(e => e.num)).toEqual([1]);
+    expect(queryApplications(root, { workMode: 'Hyb' }).total).toBe(0);
+    expect(queryApplications(root, { workMode: 'ON-SITE' }).entries.map(e => e.num)).toEqual([4]);
+  });
+
+  it('filters company and role by case-insensitive substring', () => {
+    const root = standardRoot();
+    expect(queryApplications(root, { company: 'glo' }).entries.map(e => e.num)).toEqual([2]);
+    expect(queryApplications(root, { role: 'platform' }).entries.map(e => e.num)).toEqual([1, 4]);
+  });
+
+  it('min_score keeps numeric scores >= the bound and drops non-numeric rows', () => {
+    const root = standardRoot();
+    const result = queryApplications(root, { minScore: 4 });
+    // Row 3 (score N/A) must be excluded, not treated as 0 or kept.
+    expect(result.entries.map(e => e.num)).toEqual([1, 4]);
+    expect(queryApplications(root, { minScore: 4.5 }).entries.map(e => e.num)).toEqual([4]);
+  });
+
+  it('filters by since/until on the tracker date', () => {
+    const root = standardRoot();
+    expect(queryApplications(root, { since: '2026-07-05' }).entries.map(e => e.num)).toEqual([
+      2, 3, 4,
+    ]);
+    expect(queryApplications(root, { until: '2026-07-05' }).entries.map(e => e.num)).toEqual([
+      1, 2,
+    ]);
+    expect(
+      queryApplications(root, { since: '2026-07-02', until: '2026-07-31' }).entries.map(e => e.num),
+    ).toEqual([2, 3]);
+  });
+
+  it('combines filters conjunctively', () => {
+    const root = standardRoot();
+    const result = queryApplications(root, { role: 'engineer', minScore: 4, workMode: 'on-site' });
+    expect(result.entries.map(e => e.num)).toEqual([4]);
+    expect(result.total).toBe(1);
+  });
+});
+
+describe('queryApplications — pagination', () => {
+  it('paginates with limit/offset and reports next_offset', () => {
+    const root = standardRoot();
+    const page1 = queryApplications(root, { limit: 2 });
+    expect(page1.entries.map(e => e.num)).toEqual([1, 2]);
+    expect(page1.total).toBe(4);
+    expect(page1.count).toBe(2);
+    expect(page1.next_offset).toBe(2);
+    const page2 = queryApplications(root, { limit: 2, offset: 2 });
+    expect(page2.entries.map(e => e.num)).toEqual([3, 4]);
+    expect(page2.next_offset).toBeNull();
+  });
+
+  it('totals count the filtered set, not the whole tracker', () => {
+    const result = queryApplications(standardRoot(), { role: 'engineer', limit: 1 });
+    expect(result.total).toBe(4);
+    expect(result.count).toBe(1);
+    expect(result.next_offset).toBe(1);
+  });
+
+  it('returns an empty page past the end', () => {
+    const result = queryApplications(standardRoot(), { offset: 10 });
+    expect(result.entries).toEqual([]);
+    expect(result.count).toBe(0);
+    expect(result.total).toBe(4);
+    expect(result.next_offset).toBeNull();
+  });
+
+  it('clamps limit to at least 1 and defaults it to 200', () => {
+    const rows = Array.from(
+      { length: 205 },
+      (_, i) =>
+        `| ${i + 1} | 2026-07-01 | Co${i + 1} | Engineer | 4.0/5 | Screened | ❌ | - | - |  |`,
+    );
+    const root = makeRoot(rows);
+    const defaulted = queryApplications(root, {});
+    expect(defaulted.count).toBe(200);
+    expect(defaulted.total).toBe(205);
+    expect(defaulted.next_offset).toBe(200);
+    const clamped = queryApplications(root, { limit: 0 });
+    expect(clamped.count).toBe(1);
+    const clampedHigh = queryApplications(root, { limit: 5000 });
+    expect(clampedHigh.count).toBe(205);
+  });
+});

--- a/test/unit/chat/mcp-tracker-tool.test.ts
+++ b/test/unit/chat/mcp-tracker-tool.test.ts
@@ -1,0 +1,149 @@
+// test/unit/chat/mcp-tracker-tool.test.ts
+//
+// get_tracker server-side filtering (issues #104/#107): the tool declares
+// filter/pagination arguments, always requests the compact projection
+// (fields=compact), and relays the paginated payload — so the model never
+// pulls the full 1.7 MB tracker through the tool-output limit again.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { McpTestClient, type MockApp, startMockApp } from './mcp-test-utils';
+
+const CANONICAL_STATUSES = [
+  'screened',
+  'evaluated',
+  'applied',
+  'responded',
+  'interview',
+  'offer',
+  'rejected',
+  'discarded',
+];
+
+describe('mcp-app-server — get_tracker filters', () => {
+  let client: McpTestClient;
+  let app: MockApp | undefined;
+
+  afterEach(async () => {
+    client?.kill();
+    await app?.close();
+    app = undefined;
+  });
+
+  async function callGetTracker(args: Record<string, unknown> = {}) {
+    client = new McpTestClient({ SUR9E_APP_URL: app?.url ?? 'http://127.0.0.1:9' });
+    await client.initialize();
+    return client.request(2, 'tools/call', { name: 'get_tracker', arguments: args });
+  }
+
+  function requestedParams(): URLSearchParams {
+    expect(app?.requests).toHaveLength(1);
+    return new URL(app?.requests[0].url ?? '', 'http://localhost').searchParams;
+  }
+
+  it('declares the filter and pagination arguments on its input schema', async () => {
+    client = new McpTestClient({ SUR9E_APP_URL: 'http://127.0.0.1:9' });
+    await client.initialize();
+    const res = await client.request(2, 'tools/list');
+    const tool = res.result.tools.find((t: { name: string }) => t.name === 'get_tracker');
+    expect(tool).toBeTruthy();
+    expect(tool.inputSchema.additionalProperties).toBe(false);
+    const props = tool.inputSchema.properties;
+    for (const key of [
+      'status',
+      'location',
+      'work_mode',
+      'company',
+      'role',
+      'min_score',
+      'since',
+      'until',
+      'limit',
+      'offset',
+    ]) {
+      expect(props, `missing inputSchema property ${key}`).toHaveProperty(key);
+    }
+    expect(props.status.items.enum).toEqual(CANONICAL_STATUSES);
+    expect(tool.inputSchema.required).toBeUndefined();
+    // The description must steer the model toward server-side filtering
+    // and pagination instead of dumping the whole tracker.
+    expect(tool.description).toContain('next_offset');
+    expect(tool.description).toContain('get_report');
+  });
+
+  it('requests the compact projection even with no arguments', async () => {
+    app = await startMockApp({
+      'GET /api/applications': {
+        status: 200,
+        body: { entries: [], total: 0, count: 0, next_offset: null },
+      },
+    });
+    const res = await callGetTracker();
+    expect(res.result.isError).toBeUndefined();
+    expect(requestedParams().get('fields')).toBe('compact');
+  });
+
+  it('passes every filter through as snake_case query params', async () => {
+    app = await startMockApp({
+      'GET /api/applications': {
+        status: 200,
+        body: { entries: [], total: 0, count: 0, next_offset: null },
+      },
+    });
+    await callGetTracker({
+      status: ['applied', 'interview'],
+      location: 'Barcelona',
+      work_mode: 'Hybrid',
+      company: 'Acme',
+      role: 'engineer',
+      min_score: 4,
+      since: '2026-07-01',
+      until: '2026-08-01',
+      limit: 50,
+      offset: 100,
+    });
+    const params = requestedParams();
+    expect(params.get('fields')).toBe('compact');
+    expect(params.get('status')).toBe('applied,interview');
+    expect(params.get('location')).toBe('Barcelona');
+    expect(params.get('work_mode')).toBe('Hybrid');
+    expect(params.get('company')).toBe('Acme');
+    expect(params.get('role')).toBe('engineer');
+    expect(params.get('min_score')).toBe('4');
+    expect(params.get('since')).toBe('2026-07-01');
+    expect(params.get('until')).toBe('2026-08-01');
+    expect(params.get('limit')).toBe('50');
+    expect(params.get('offset')).toBe('100');
+  });
+
+  it('relays the paginated compact payload verbatim', async () => {
+    const payload = {
+      entries: [
+        {
+          num: 7,
+          date: '2026-07-01',
+          company: 'Acme',
+          role: 'Eng',
+          score: '4.2/5',
+          status: 'applied',
+          url: 'https://jobs.acme.dev/x',
+        },
+      ],
+      total: 251,
+      count: 1,
+      next_offset: 201,
+    };
+    app = await startMockApp({ 'GET /api/applications': { status: 200, body: payload } });
+    const res = await callGetTracker({ status: ['applied'], limit: 1, offset: 200 });
+    expect(res.result.isError).toBeUndefined();
+    expect(JSON.parse(res.result.content[0].text)).toEqual(payload);
+  });
+
+  it('surfaces an app-side validation error as a tool error', async () => {
+    app = await startMockApp({
+      'GET /api/applications': { status: 400, body: { error: 'Invalid query param min_score' } },
+    });
+    const res = await callGetTracker({ min_score: 4 });
+    expect(res.result.isError).toBe(true);
+    expect(res.result.content[0].text).toContain('Invalid query param min_score');
+  });
+});


### PR DESCRIPTION
## Outcome

The MCP `get_tracker` tool returned the full tracker with per-row summaries (~1.77 MB at 2,579 rows), blowing tool-output limits and pushing the model into per-offer `get_report` fan-out that burned provider spend.

`get_tracker` now takes optional metadata filters (status/location/work_mode/company/role/min_score/since/until), always requests a compact projection (no summary objects), and paginates (default limit 200, `total`/`next_offset` in the response). Worst-case unfiltered page is ~25 KB.

## Changes

- **New `src/lib/server/tracker-query.ts`** — `queryApplications(root, filters)`: conjunctive filters over `loadApplicationsWithSummary` (status matched on the canonical normalized value, so legacy `Skip` rows match `discarded`; location falls back `summary.location` → `summary.loc` treating empty strings as absent), compact projection `{num, date, company, role, score, status, url, location, work_mode, seniority, posted}`, clamped pagination. Zod wire schema exported so the route stays thin.
- **`GET /api/applications`** — accepts the snake_case query params. **With zero recognized params the response is byte-identical to today** (pinned by a test asserting the exact serialized legacy body), so the web UI is untouched. Invalid values → 400.
- **`cli/mcp-app-server.mjs`** — `get_tracker` input schema (`additionalProperties: false`, status enum), handler always sends `fields=compact`, description rewritten to steer the model: filter server-side, page via `next_offset`, use `get_report` for detail.

## Testing

TDD throughout (every test watched fail before implementation): 18 lib tests (each filter, combined, pagination, projection edges, non-numeric scores), 6 route tests (incl. the byte-identical back-compat pin), 5 MCP tests (`McpTestClient`). Regression sweep across the neighboring MCP suites: 43/43 on this branch; `tsc` clean.

No UI changes.

Fixes #104
Fixes #107

## AI disclosure

Substantially AI-authored (Claude Code, TDD workflow), reviewed against the approved design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)