### PR TITLE
feat(chat): preserve stopped-reply history and add Send now for queued messages

### DIFF
--- a/src/app/api/chat/turns/[id]/cancel/route.ts
+++ b/src/app/api/chat/turns/[id]/cancel/route.ts
@@ -2,7 +2,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { jsonError } from '@/lib/http-errors';
-import { cancelTurn, getTurn } from '@/lib/server/chat/turn-runner';
+import { cancelTurnAndWait, getTurn } from '@/lib/server/chat/turn-runner';
 import { rejectCrossOrigin } from '@/lib/server/same-origin';
 
 interface Params {
@@ -18,5 +18,7 @@ export async function POST(request: Request, { params }: Params) {
   if (!UUID_RE.test(id)) return jsonError('Invalid turn id', 400);
   if (!getTurn(id)) return jsonError('Turn not found', 404);
   // false = the turn had already settled; still a 200 — cancel is idempotent.
-  return Response.json({ cancelled: cancelTurn(id) });
+  // The bounded wait means a 200 also guarantees the conversation lock is
+  // free (or the grace window elapsed), so a follow-up send won't bounce.
+  return Response.json({ cancelled: await cancelTurnAndWait(id) });
 }

--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -671,6 +671,25 @@
 .chat-composer__queued .chat-attach-chips {
   padding: 0;
 }
+.chat-composer__queued-send {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 0;
+}
+.chat-composer__queued-send:hover {
+  text-decoration: underline;
+}
+.chat-composer__queued-send:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .chat-composer__queued-clear {
   display: inline-flex;
   align-items: center;

--- a/src/features/chat/chat-card.tsx
+++ b/src/features/chat/chat-card.tsx
@@ -77,6 +77,7 @@ export function ChatCard() {
         onFilesChange={convo.setDraftFiles}
         onSend={(text, refs) => void convo.send(text, refs)}
         onStop={() => void convo.stop()}
+        onSendNow={() => void convo.sendNow()}
       />
     </div>
   );

--- a/src/features/chat/chat-composer.tsx
+++ b/src/features/chat/chat-composer.tsx
@@ -43,6 +43,7 @@ export function ChatComposer({
   onFilesChange,
   onSend,
   onStop,
+  onSendNow,
 }: {
   streaming: boolean;
   /** Keep the draft editable while preventing it from being sent to a thread
@@ -53,6 +54,9 @@ export function ChatComposer({
   onFilesChange: (files: File[]) => void;
   onSend: (text: string, referencedOffers: number[]) => void;
   onStop: () => void;
+  /** Stop the in-flight reply and dispatch the queued content immediately
+   * (issue #105). Only rendered while a reply is actually streaming. */
+  onSendNow?: () => void;
 }) {
   const [value, setValue] = useState('');
   const pushToast = useToastStore(s => s.push);
@@ -298,6 +302,17 @@ export function ChatComposer({
         <div className="chat-composer__queued">
           <div className="chat-composer__queued-row">
             <span>Queued — sends when the reply finishes</span>
+            {streaming && onSendNow && (
+              <button
+                type="button"
+                className="chat-composer__queued-send"
+                aria-label="Send now"
+                title="Stop the current reply and send this now"
+                onClick={onSendNow}
+              >
+                Send now
+              </button>
+            )}
             <button
               type="button"
               className="chat-composer__queued-clear"

--- a/src/features/chat/chat-page.tsx
+++ b/src/features/chat/chat-page.tsx
@@ -103,6 +103,7 @@ export function ChatPage({ conversationId }: { conversationId?: string }) {
             onFilesChange={convo.setDraftFiles}
             onSend={(text, refs) => void convo.send(text, refs)}
             onStop={() => void convo.stop()}
+            onSendNow={() => void convo.sendNow()}
           />
         </div>
       </section>

--- a/src/features/chat/use-conversation.ts
+++ b/src/features/chat/use-conversation.ts
@@ -56,8 +56,12 @@ export interface ConversationApi {
   draftFiles: File[];
   setDraftFiles: React.Dispatch<React.SetStateAction<File[]>>;
   showEmpty: boolean;
-  send: (text: string, referencedOffers?: number[], files?: File[]) => Promise<void>;
+  /** Resolves true when the message actually went out — sendNow uses the
+   * flag to restore taken queue slots on failure. */
+  send: (text: string, referencedOffers?: number[], files?: File[]) => Promise<boolean>;
   stop: () => Promise<void>;
+  /** Stop the in-flight reply, then dispatch the queued content (issue #105). */
+  sendNow: () => Promise<void>;
   retry: () => void;
   retryConversation: () => void;
   regenerate: () => Promise<void>;
@@ -114,8 +118,8 @@ export function useConversation(opts?: {
   // not (accepted limitation; the mention text itself still tells the model
   // what to read).
   const sendRef = useRef<
-    (text: string, referencedOffers?: number[], files?: File[]) => Promise<void>
-  >(async () => {});
+    (text: string, referencedOffers?: number[], files?: File[]) => Promise<boolean>
+  >(async () => false);
 
   // opts is a fresh object literal on most renders — read the callback through
   // a ref so send()'s useCallback identity doesn't churn every render.
@@ -180,7 +184,13 @@ export function useConversation(opts?: {
   }
 
   const send = useCallback(
-    async (text: string, referencedOffers: number[] = [], filesOverride?: File[]) => {
+    // Returns whether the message actually went out — sendNow restores the
+    // taken queue slots on false so queued content is never lost.
+    async (
+      text: string,
+      referencedOffers: number[] = [],
+      filesOverride?: File[],
+    ): Promise<boolean> => {
       // filesOverride carries the queued-attachments slot on the post-'done'
       // flush; a normal send consumes the live draft chips instead.
       const files = filesOverride ?? draftFiles;
@@ -244,7 +254,7 @@ export function useConversation(opts?: {
             adoptDraftOverride(createdConversationId);
             queryClient.invalidateQueries({ queryKey: CHAT_SESSIONS_KEY });
           }
-          return;
+          return false;
         }
         setPendingUserMessageId(res.userMessageId);
         setStreamingTurnId(res.turnId);
@@ -289,14 +299,16 @@ export function useConversation(opts?: {
         // Host hook: Home navigates to /chat once the turn is live. Runs after
         // the turn exists so the destination reattaches to a real stream.
         onAfterSendRef.current?.();
+        return true;
       } catch (err) {
         setPendingUserMessage(null);
         setPendingUserMessageId(null);
         if (err instanceof ChatApiError && err.setupRequired) {
           setSetupRequired(true);
-          return;
+          return false;
         }
         setSendError(err instanceof Error ? err.message : 'Message failed to send.');
+        return false;
       }
     },
     [
@@ -479,6 +491,28 @@ export function useConversation(opts?: {
     turn.reset();
   }
 
+  /** "Send now" on a queued message (issue #105): consume the queue slots
+   * FIRST (the post-'done' auto-flush uses the same consume-once slots, so a
+   * racing natural finish can't double-send), stop the in-flight reply (the
+   * cancel POST returns only once the conversation lock is free — see
+   * cancelTurnAndWait), then dispatch. A failed dispatch puts the content
+   * back in the slots; the composer's restore effect (not streaming any
+   * more) turns it into an editable draft — never lost. */
+  async function handleSendNow() {
+    const store = useChatStore.getState();
+    const key = conversationKey(store.activeConversationId);
+    const queuedText = store.takeQueuedMessage(key);
+    const queuedFiles = store.takeQueuedAttachments(key);
+    if (queuedText == null && queuedFiles.length === 0) return;
+    await handleStop();
+    const ok = await send(queuedText ?? '', [], queuedFiles);
+    if (!ok) {
+      const s = useChatStore.getState();
+      if (queuedText != null) s.setQueuedMessage(key, queuedText);
+      if (queuedFiles.length > 0) s.setQueuedAttachments(key, queuedFiles);
+    }
+  }
+
   function handleRetry() {
     const s = useChatStore.getState();
     const last = s.lastUserMessages[conversationKey(s.activeConversationId)];
@@ -558,6 +592,7 @@ export function useConversation(opts?: {
     showEmpty,
     send,
     stop: handleStop,
+    sendNow: handleSendNow,
     retry: handleRetry,
     retryConversation: () => {
       void sessionQuery.refetch();

--- a/src/features/chat/use-conversation.ts
+++ b/src/features/chat/use-conversation.ts
@@ -444,17 +444,39 @@ export function useConversation(opts?: {
   const streaming = turn.status === 'streaming' && streamingTurnId != null;
 
   async function handleStop() {
-    const turnId = useChatStore.getState().streamingTurnId;
-    turn.detach();
-    setStreamingTurnId(null);
-    if (turnId) {
-      clearActiveTurn(turnId);
-      try {
-        await fetch(`/api/chat/turns/${encodeURIComponent(turnId)}/cancel`, { method: 'POST' });
-      } catch {
-        // the turn may already be finished — nothing to surface
-      }
+    const store = useChatStore.getState();
+    const turnId = store.streamingTurnId;
+    const conversationId = store.activeConversationId;
+    if (!turnId) {
+      turn.detach();
+      setStreamingTurnId(null);
+      return;
     }
+    // Stay ATTACHED while cancelling (issue #106): the server emits the
+    // terminal 'cancelled' event through the stream and persists the partial
+    // assistant message synchronously before this POST returns — detaching
+    // first (the old behavior) cut off the terminal event and left the
+    // transcript looking wiped.
+    try {
+      await fetch(`/api/chat/turns/${encodeURIComponent(turnId)}/cancel`, { method: 'POST' });
+    } catch {
+      // Cancel unreachable (server down, or a race with a turn that already
+      // finished) — degrade to detach-only so the composer never sticks.
+      turn.detach();
+      setStreamingTurnId(null);
+      clearActiveTurn(turnId);
+      return;
+    }
+    setStreamingTurnId(null);
+    clearActiveTurn(turnId); // idempotent with the hook's own error-path clear
+    if (conversationId) {
+      // The partial is provably persisted by now — pull it into the message
+      // list, then retire the live copy so it renders exactly once.
+      await queryClient.invalidateQueries({ queryKey: chatSessionKey(conversationId) });
+    }
+    setPendingUserMessage(null);
+    setPendingUserMessageId(null);
+    turn.reset();
   }
 
   function handleRetry() {

--- a/src/lib/server/chat/turn-runner.ts
+++ b/src/lib/server/chat/turn-runner.ts
@@ -967,3 +967,24 @@ export function cancelTurn(turnId: string): boolean {
   }
   return true;
 }
+
+/**
+ * cancelTurn, then wait (bounded) for the cancelled child to truly exit —
+ * i.e. for the FR-5 conversation lock to be released. "Send now" (issue
+ * #105) stops the current reply and immediately starts a new turn; without
+ * this wait the new startTurn would bounce off the lock the dying child
+ * still holds. Waits only when THIS call did the cancelling: a false return
+ * means the turn already settled, whose terminal path released its own lock
+ * (and the lock may already belong to a newer turn we must not wait on).
+ * The cap is CANCEL_GRACE_MS plus a beat for the SIGKILL to land.
+ */
+export async function cancelTurnAndWait(turnId: string): Promise<boolean> {
+  const turn = turns.get(turnId);
+  const cancelled = cancelTurn(turnId);
+  if (!cancelled || !turn) return cancelled;
+  const deadline = Date.now() + CANCEL_GRACE_MS + 1000;
+  while (inFlightConversations.has(turn.conversationId) && Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 50));
+  }
+  return cancelled;
+}

--- a/src/lib/server/chat/turn-runner.ts
+++ b/src/lib/server/chat/turn-runner.ts
@@ -65,6 +65,11 @@ export type TurnRecord = {
   startedAt: number;
   child: ChildProcess | null;
   subscribers: Set<(e: ChatTurnEvent) => void>;
+  /** Persists whatever assistant text has streamed so far (no-op when empty,
+   * self-guarded against double writes). Assigned by runAttempt so cancelTurn
+   * can persist the partial SYNCHRONOUSLY at cancel time — the client
+   * refetches on the terminal event, which must not race the child's exit. */
+  persistPartial?: () => void;
 };
 
 /** A ChatTurnEvent minus seq — emitTurnEvent assigns the seq. */
@@ -759,9 +764,12 @@ function runAttempt(ctx: AttemptCtx): void {
     }
   }, TURN_TIMEOUT_MS);
 
+  let partialPersisted = false;
   const persistPartial = (): void => {
+    if (partialPersisted) return;
     const partial = resultText ?? assistantText;
     if (partial.trim()) {
+      partialPersisted = true;
       appendMessage(root, {
         conversationId: opts.conversationId,
         role: 'assistant',
@@ -771,6 +779,9 @@ function runAttempt(ctx: AttemptCtx): void {
       });
     }
   };
+  // cancelTurn persists through this handle; a reseed's second runAttempt
+  // reassigns it so the freshest attempt's text is what gets saved.
+  turn.persistPartial = persistPartial;
 
   child.on('close', (code: number | null) => {
     clearTimeout(killTimer);
@@ -933,6 +944,11 @@ export function cancelTurn(turnId: string): boolean {
   const turn = turns.get(turnId);
   if (!turn || turn.status !== 'running') return false;
   const child = turn.child;
+  // Persist the partial BEFORE the terminal event goes out: the client
+  // refetches the session on that event, and the child may take up to
+  // CANCEL_GRACE_MS to die — persisting from its close handler would race
+  // the refetch and the partial would look wiped (issue #106).
+  turn.persistPartial?.();
   finishError(turn, 'cancelled', { releaseLock: !child });
   if (child) {
     try {

--- a/test/components/chat-send-now.test.tsx
+++ b/test/components/chat-send-now.test.tsx
@@ -1,0 +1,169 @@
+// test/components/chat-send-now.test.tsx
+//
+// Issue #105: the queued-message row gains a "Send now" action — stop the
+// in-flight reply (the cancel POST only returns once the conversation lock
+// is free, see cancelTurnAndWait), then dispatch the queued text + files
+// immediately. On a failed dispatch the taken content is restored to the
+// queue slots, which the composer's existing restore effect turns back into
+// an editable draft — queued content is never lost. Same FakeEventSource +
+// route-keyed fetch doubles as chat-card.test.tsx.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatCard } from '@/features/chat/chat-card';
+import { useChatStore } from '@/stores/chat-store';
+
+const pushSpy = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushSpy, refresh: () => {}, replace: () => {} }),
+}));
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(event: object) {
+    act(() => this.onmessage?.({ data: JSON.stringify(event) }));
+  }
+}
+
+function fakeSession(id: string) {
+  return { id, title: 'New chat', mode: null, archived: false, createdAt: '', updatedAt: '' };
+}
+
+function okResponse(body: unknown, status = 200) {
+  return { ok: status < 300, status, json: async () => body } as Response;
+}
+
+/** turnResponses: one entry per POST .../turns call — a turnId, or
+ * { fail: true } to answer 500 (chatFetch throws → send() reports failure). */
+function stubFetch(turnResponses: Array<{ turnId: string } | { fail: true }>) {
+  let turnCall = 0;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === '/api/providers') return okResponse({ providers: {} });
+    if (url === '/api/settings') return okResponse({});
+    if (url === '/api/applications') return okResponse({ entries: [], count: 0 });
+    if (url === '/api/chat/sessions' && method === 'POST') {
+      return okResponse({ session: fakeSession('c1') }, 201);
+    }
+    if (/^\/api\/chat\/sessions\/[^/]+$/.test(url) && method === 'GET') {
+      const id = url.split('/').pop() as string;
+      return okResponse({ session: fakeSession(id), messages: [] });
+    }
+    if (/^\/api\/chat\/turns\/[^/]+$/.test(url) && method === 'GET') {
+      return okResponse({ status: 'running', conversationId: 'c1' });
+    }
+    if (/\/turns$/.test(url) && method === 'POST') {
+      const body = turnResponses[Math.min(turnCall, turnResponses.length - 1)];
+      turnCall += 1;
+      if ('fail' in body) return okResponse({ error: 'boom' }, 500);
+      return okResponse({ turnId: body.turnId, userMessageId: `u-${body.turnId}` }, 202);
+    }
+    if (/\/cancel$/.test(url) && method === 'POST') return okResponse({ cancelled: true });
+    throw new Error(`unexpected fetch: ${method} ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function renderCard() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<ChatCard />, { wrapper });
+}
+
+function textarea() {
+  return screen.getByLabelText('Message') as HTMLTextAreaElement;
+}
+
+function typeAndEnter(text: string) {
+  fireEvent.change(textarea(), { target: { value: text } });
+  fireEvent.keyDown(textarea(), { key: 'Enter' });
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  vi.stubGlobal('EventSource', FakeEventSource);
+  window.sessionStorage.clear();
+  pushSpy.mockClear();
+  useChatStore.setState({
+    open: true,
+    activeConversationId: null,
+    streamingTurnId: null,
+    queuedMessages: {},
+    queuedAttachments: {},
+    lastUserMessages: {},
+    setupRequired: false,
+    modelOverride: {},
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function streamFirstTurnAndQueue() {
+  renderCard();
+  await waitFor(() => expect(screen.getByLabelText('Message')).toBeTruthy());
+  typeAndEnter('first message');
+  await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+  FakeEventSource.instances[0].emit({ seq: 1, type: 'text-delta', text: 'streaming reply' });
+  typeAndEnter('queued text');
+  await screen.findByText('Queued — sends when the reply finishes');
+}
+
+describe('Send now on queued messages (#105)', () => {
+  it('stops the current reply and dispatches the queued text immediately', async () => {
+    const fetchMock = stubFetch([{ turnId: 't1' }, { turnId: 't2' }]);
+    await streamFirstTurnAndQueue();
+
+    fireEvent.click(screen.getByLabelText('Send now'));
+
+    // The in-flight reply is cancelled…
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(
+          c => String(c[0]) === '/api/chat/turns/t1/cancel' && c[1]?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+    // …then the queued text goes out as its own turn…
+    await waitFor(() => {
+      const turnPosts = fetchMock.mock.calls.filter(
+        c => /\/turns$/.test(String(c[0])) && c[1]?.method === 'POST',
+      );
+      expect(turnPosts).toHaveLength(2);
+      expect(JSON.parse(String(turnPosts[1][1]?.body)).message).toBe('queued text');
+    });
+    // …the queue row is gone, and the new turn's stream is attached.
+    expect(screen.queryByText('Queued — sends when the reply finishes')).toBeNull();
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(2));
+    expect(FakeEventSource.instances[1].url).toBe('/api/chat/turns/t2/events?after=0');
+  });
+
+  it('restores the queued text as an editable draft when the dispatch fails', async () => {
+    stubFetch([{ turnId: 't1' }, { fail: true }]);
+    await streamFirstTurnAndQueue();
+
+    fireEvent.click(screen.getByLabelText('Send now'));
+
+    // The send failed — the taken content lands back as the composer draft
+    // (via the queue slots + the composer's restore effect), never lost.
+    await waitFor(() => expect(textarea().value).toBe('queued text'));
+  });
+});

--- a/test/components/chat-stop-preserves-history.test.tsx
+++ b/test/components/chat-stop-preserves-history.test.tsx
@@ -1,0 +1,205 @@
+// test/components/chat-stop-preserves-history.test.tsx
+//
+// Issue #106: pressing Stop must not wipe the transcript. The designed flow:
+// handleStop stays ATTACHED to the SSE stream (the server emits the terminal
+// 'cancelled' event synchronously and persists the partial before answering
+// the cancel POST), then invalidates the session query so the persisted
+// partial replaces the live view — rendered exactly once, never zero times.
+// FakeEventSource + a route-keyed fetch double, same doubles as
+// chat-card.test.tsx.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatCard } from '@/features/chat/chat-card';
+import { useChatStore } from '@/stores/chat-store';
+
+const pushSpy = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushSpy, refresh: () => {}, replace: () => {} }),
+}));
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(event: object) {
+    act(() => this.onmessage?.({ data: JSON.stringify(event) }));
+  }
+}
+
+function fakeSession(id: string) {
+  return { id, title: 'New chat', mode: null, archived: false, createdAt: '', updatedAt: '' };
+}
+
+function okResponse(body: unknown, status = 200) {
+  return { ok: status < 300, status, json: async () => body } as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+/** Stateful double: after the cancel POST resolves, the session GET starts
+ * returning the server-persisted rows (user + partial assistant) — exactly
+ * what the real cancel path guarantees, since cancelTurn persists the
+ * partial synchronously before the POST handler returns. */
+function stubFetch(opts: {
+  cancel: { promise: Promise<Response> };
+  persistedAfterCancel: Array<{ id: string; role: string; content: string }>;
+}) {
+  let cancelled = false;
+  const sessionGets: string[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+    if (url === '/api/providers') return okResponse({ providers: {} });
+    if (url === '/api/settings') return okResponse({});
+    if (url === '/api/applications') return okResponse({ entries: [], count: 0 });
+    if (url === '/api/chat/sessions' && method === 'POST') {
+      return okResponse({ session: fakeSession('c1') }, 201);
+    }
+    if (/^\/api\/chat\/sessions\/[^/]+$/.test(url) && method === 'GET') {
+      sessionGets.push(url);
+      const id = url.split('/').pop() as string;
+      return okResponse({
+        session: fakeSession(id),
+        messages: cancelled ? opts.persistedAfterCancel : [],
+      });
+    }
+    if (/^\/api\/chat\/turns\/[^/]+$/.test(url) && method === 'GET') {
+      return okResponse({ status: 'running', conversationId: 'c1' });
+    }
+    if (/\/turns$/.test(url) && method === 'POST') {
+      return okResponse({ turnId: 't1', userMessageId: 'u1' }, 202);
+    }
+    if (/\/cancel$/.test(url) && method === 'POST') {
+      return opts.cancel.promise.then(res => {
+        cancelled = true;
+        return res;
+      });
+    }
+    throw new Error(`unexpected fetch: ${method} ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return { fetchMock, sessionGets };
+}
+
+function renderCard() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<ChatCard />, { wrapper });
+}
+
+function typeAndEnter(text: string) {
+  const box = screen.getByLabelText('Message') as HTMLTextAreaElement;
+  fireEvent.change(box, { target: { value: text } });
+  fireEvent.keyDown(box, { key: 'Enter' });
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  vi.stubGlobal('EventSource', FakeEventSource);
+  window.sessionStorage.clear();
+  pushSpy.mockClear();
+  useChatStore.setState({
+    open: true,
+    activeConversationId: null,
+    streamingTurnId: null,
+    queuedMessages: {},
+    queuedAttachments: {},
+    lastUserMessages: {},
+    setupRequired: false,
+    modelOverride: {},
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Stop preserves history (#106)', () => {
+  it('stays attached through cancel, then swaps to the persisted partial exactly once', async () => {
+    const cancel = deferred<Response>();
+    const { fetchMock, sessionGets } = stubFetch({
+      cancel,
+      persistedAfterCancel: [
+        { id: 'u1', role: 'user', content: 'hello' },
+        { id: 'a1', role: 'assistant', content: 'partial answer' },
+      ],
+    });
+    renderCard();
+    await waitFor(() => expect(screen.getByLabelText('Message')).toBeTruthy());
+    typeAndEnter('hello');
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    const es = FakeEventSource.instances[0];
+    es.emit({ seq: 1, type: 'text-delta', text: 'partial answer' });
+    await screen.findByText('partial answer');
+
+    fireEvent.click(screen.getByLabelText('Stop reply'));
+
+    // The cancel POST went out…
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(
+          c => String(c[0]) === '/api/chat/turns/t1/cancel' && c[1]?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+    // …and the stream is still attached: the terminal event must arrive
+    // through it, not be cut off by an eager detach (the old bug).
+    expect(es.closed).toBe(false);
+    // The server emits the terminal 'cancelled' error synchronously.
+    es.emit({ seq: 2, type: 'error', message: 'cancelled' });
+    // The partial never disappears while the cancel settles.
+    expect(screen.getByText('partial answer')).toBeTruthy();
+
+    const sessionGetsBefore = sessionGets.length;
+    act(() => cancel.resolve(okResponse({ cancelled: true })));
+
+    // The session query refetches (the persisted rows are guaranteed to
+    // exist by now) and the partial renders exactly once — the live copy
+    // retired, the persisted copy in its place.
+    await waitFor(() => expect(sessionGets.length).toBeGreaterThan(sessionGetsBefore));
+    await waitFor(() => expect(screen.getAllByText('partial answer')).toHaveLength(1));
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+  });
+
+  it('falls back to detaching when the cancel POST fails', async () => {
+    const cancel = deferred<Response>();
+    stubFetch({ cancel, persistedAfterCancel: [] });
+    renderCard();
+    await waitFor(() => expect(screen.getByLabelText('Message')).toBeTruthy());
+    typeAndEnter('hello');
+    await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    FakeEventSource.instances[0].emit({ seq: 1, type: 'text-delta', text: 'partial answer' });
+    await screen.findByText('partial answer');
+
+    fireEvent.click(screen.getByLabelText('Stop reply'));
+    await act(async () => {
+      cancel.resolve(Promise.reject(new Error('network down')) as never);
+      await Promise.resolve();
+    });
+
+    // Streaming UI ends (composer back to send mode) and the streamed text
+    // is still on screen — degraded, but never a wipe.
+    await waitFor(() => expect(screen.queryByLabelText('Stop reply')).toBeNull());
+    expect(screen.getByText('partial answer')).toBeTruthy();
+  });
+});

--- a/test/unit/chat/turn-runner.test.ts
+++ b/test/unit/chat/turn-runner.test.ts
@@ -17,6 +17,7 @@ import {
   _setProbeImpl,
   _setSpawnImpl,
   cancelTurn,
+  cancelTurnAndWait,
   getTurn,
   mapChatLine,
   startTurn,
@@ -843,6 +844,43 @@ describe('cancelTurn', () => {
     // The dying child's close handler must not persist a second copy.
     child!.emit('close', null);
     expect(listMessages(root, conv.id).filter(m => m.role === 'assistant')).toHaveLength(1);
+  });
+
+  it('cancelTurnAndWait resolves only after the cancelled child exits, with the lock free', async () => {
+    let child: FakeChild | null = null;
+    _setSpawnImpl(() => {
+      child = fakeChild(); // hangs — SIGTERM takes a while to be honored
+      return child as never;
+    });
+    const conv = createConversation(root);
+    const { turnId } = await startTurn(root, { conversationId: conv.id, userMessage: 'hello' });
+
+    let settled = false;
+    const wait = cancelTurnAndWait(turnId).then(v => {
+      settled = true;
+      return v;
+    });
+    // The child hasn't exited — the wait must still be pending (this is what
+    // lets "Send now" fire a new turn without bouncing off the FR-5 lock).
+    await new Promise(r => setTimeout(r, 150));
+    expect(settled).toBe(false);
+
+    child!.emit('close', null);
+    await expect(wait).resolves.toBe(true);
+
+    // Lock is provably free: a new startTurn succeeds with no retry.
+    _setSpawnImpl(() => fakeChild(c => happyStream(c, 'sess-1', 'next reply')) as never);
+    const t2 = await startTurn(root, { conversationId: conv.id, userMessage: 'queued text' });
+    await waitForTerminal(t2.turnId);
+    expect(getTurn(t2.turnId)?.status).toBe('done');
+  });
+
+  it('cancelTurnAndWait returns immediately for an already-settled turn', async () => {
+    _setSpawnImpl(() => fakeChild(c => happyStream(c, 'sess-1', 'done already')) as never);
+    const conv = createConversation(root);
+    const { turnId } = await startTurn(root, { conversationId: conv.id, userMessage: 'hello' });
+    await waitForTerminal(turnId);
+    await expect(cancelTurnAndWait(turnId)).resolves.toBe(false);
   });
 
   it('cancel before any streamed output persists no assistant message', async () => {

--- a/test/unit/chat/turn-runner.test.ts
+++ b/test/unit/chat/turn-runner.test.ts
@@ -813,6 +813,50 @@ describe('cancelTurn', () => {
     expect(spawnCount).toBe(2);
     expect(getTurn(t2.turnId)?.status).toBe('done');
   });
+
+  it('persists the streamed partial as an assistant message at cancel time, exactly once', async () => {
+    let child: FakeChild | null = null;
+    _setSpawnImpl(() => {
+      child = fakeChild(c => {
+        // Streams init + some text, then hangs — the user hits Stop mid-reply.
+        c.stdout.emit(
+          'data',
+          Buffer.from(`${initLine('sess-1')}\n${textLine('partial answer so far')}\n`),
+        );
+      });
+      return child as never;
+    });
+    const conv = createConversation(root);
+    const { turnId } = await startTurn(root, { conversationId: conv.id, userMessage: 'hello' });
+    await vi.waitFor(() => {
+      expect(getTurn(turnId)!.events.some(e => e.type === 'text-delta')).toBe(true);
+    });
+
+    expect(cancelTurn(turnId)).toBe(true);
+
+    // Persisted synchronously at cancel — BEFORE the child exits — so the
+    // client's post-cancel refetch provably sees it.
+    const afterCancel = listMessages(root, conv.id).filter(m => m.role === 'assistant');
+    expect(afterCancel).toHaveLength(1);
+    expect(afterCancel[0].content).toBe('partial answer so far');
+
+    // The dying child's close handler must not persist a second copy.
+    child!.emit('close', null);
+    expect(listMessages(root, conv.id).filter(m => m.role === 'assistant')).toHaveLength(1);
+  });
+
+  it('cancel before any streamed output persists no assistant message', async () => {
+    let child: FakeChild | null = null;
+    _setSpawnImpl(() => {
+      child = fakeChild(); // hangs silently — nothing streamed yet
+      return child as never;
+    });
+    const conv = createConversation(root);
+    const { turnId } = await startTurn(root, { conversationId: conv.id, userMessage: 'hello' });
+    expect(cancelTurn(turnId)).toBe(true);
+    child!.emit('close', null);
+    expect(listMessages(root, conv.id).filter(m => m.role === 'assistant')).toHaveLength(0);
+  });
 });
 
 describe('subscribeTurn', () => {


### PR DESCRIPTION
## Outcome

Two coupled fixes to the chat turn lifecycle — shipped together because Send now is built directly on the reworked stop path (it stops the in-flight reply, then dispatches), and separating them would land a stop rework whose main consumer follows minutes later.

**Stop no longer wipes the transcript (#106).** The cancel path was the only terminal path that never persisted the partial assistant message (the close handler's cancelled branch returned before `persistPartial`), and the client detached from the SSE stream before the terminal event — the streamed reply and its tool activity vanished.

**Queued messages get a Send now action (#105).** Previously queued content could only wait for the current reply to finish.

## Changes

- `cancelTurn` persists the partial **synchronously** before emitting the terminal 'cancelled' event, via a `persistPartial` handle on the turn record (self-guarded against the close handler double-writing; a reseed reassigns it). By the time the client refetches, the partial provably exists.
- `handleStop` stays attached through the cancel POST, lets the terminal event drive the render, invalidates the session query, then retires the live copy so the persisted row renders exactly once. A failed cancel POST degrades to the old detach-only behavior.
- New `cancelTurnAndWait`: the cancel route now waits (bounded by the SIGTERM grace window) for the cancelled child to truly exit, i.e. for the per-conversation FR-5 lock to be free — so the follow-up send can't bounce off it. Perceived stop latency is unchanged (the terminal event is still emitted synchronously).
- `sendNow()` consumes the queue slots FIRST (the post-'done' auto-flush uses the same consume-once slots, so a racing natural finish can't double-send), stops, dispatches. A failed dispatch restores the content to the slots, which the composer's restore effect turns back into an editable draft — never lost.
- Composer's queued row gains a **Send now** text button (rendered only while a reply is actually streaming); clear behavior unchanged. `send()` now returns a success boolean.

## Testing

TDD (each watched fail first): turn-runner unit tests for synchronous persist / no double-persist / empty-cancel / `cancelTurnAndWait` pending-until-child-exit + lock-free assertion; component tests for stay-attached-through-cancel, exactly-once render of the persisted partial, cancel-POST-failure fallback, stop-and-dispatch flow, and failed-dispatch draft restore. Full chat suites green (521 tests at commit time); quick gate green on the follow-up commit.

**Visual note:** the Send now button is a one-line addition to the existing queued row (text button, tokens only). It renders only mid-stream, which a static fixture can't reach — covered by component tests; 3-width verification of the surrounding chat page shipped with the activity-stream PR.

Fixes #105
Fixes #106

## AI disclosure

Substantially AI-authored (Claude Code, TDD workflow), reviewed against the approved design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)