### PR TITLE
feat(chat): render thought bodies as markdown with a lightbulb glyph

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -174,9 +174,9 @@ button.chat-activity__think-toggle:focus-visible {
 .chat-activity__think-toggle[aria-expanded="true"] {
   color: var(--text-2);
 }
-/* …and the bulb literally lights up while its thought is open. */
+/* …and the bulb lifts with it — same tone as the expanded label. */
 .chat-activity__glyph[data-open] .chat-activity__dot {
-  color: var(--accent);
+  color: var(--text-2);
 }
 .chat-activity__think-body {
   grid-column: 1 / 4;

--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -174,6 +174,10 @@ button.chat-activity__think-toggle:focus-visible {
 .chat-activity__think-toggle[aria-expanded="true"] {
   color: var(--text-2);
 }
+/* …and the bulb literally lights up while its thought is open. */
+.chat-activity__glyph[data-open] .chat-activity__dot {
+  color: var(--accent);
+}
 .chat-activity__think-body {
   grid-column: 1 / 4;
   font-family: var(--font-sans);

--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -169,6 +169,11 @@ button.chat-activity__think-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+/* Open state lifts the label tone — same signal as the activity line's
+   expanded caret. */
+.chat-activity__think-toggle[aria-expanded="true"] {
+  color: var(--text-2);
+}
 .chat-activity__think-body {
   grid-column: 1 / 4;
   font-family: var(--font-sans);
@@ -176,8 +181,20 @@ button.chat-activity__think-toggle:focus-visible {
   color: var(--text-3);
   border-left: 2px solid var(--border);
   padding-left: var(--space-2);
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+/* Thought bodies render through the shared chat markdown renderer — keep
+   them at timeline scale, not reply scale. */
+.chat-activity__think-body .chat-md {
+  font-size: 12px;
+  line-height: 1.5;
+  color: inherit;
+}
+.chat-activity__think-body .chat-md p {
+  margin: 0 0 var(--space-2);
+}
+.chat-activity__think-body .chat-md p:last-child {
+  margin-bottom: 0;
 }
 
 /* ── 8: confirm card ── */

--- a/src/features/chat/activity-stream.tsx
+++ b/src/features/chat/activity-stream.tsx
@@ -96,7 +96,7 @@ function ThinkingRow({ entry, followTs }: { entry: ActivityEntry; followTs?: num
   const hasText = entry.text.trim().length > 0;
   return (
     <>
-      <span className="chat-activity__glyph" aria-hidden="true">
+      <span className="chat-activity__glyph" aria-hidden="true" data-open={open || undefined}>
         <Lightbulb className="chat-activity__dot" />
       </span>
       {hasText ? (

--- a/src/features/chat/activity-stream.tsx
+++ b/src/features/chat/activity-stream.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import { ArrowRight, Check, Circle, ListChevronsUpDown, LoaderCircle, X } from 'lucide-react';
+import {
+  ArrowRight,
+  Check,
+  Circle,
+  Lightbulb,
+  ListChevronsUpDown,
+  LoaderCircle,
+  X,
+} from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
+import { renderChatMarkdown } from './chat-markdown';
 import type { ActivityEntry, FoldedItem } from './fold-events';
 
 type Activity = Extract<FoldedItem, { kind: 'activity' }>;
@@ -88,7 +97,7 @@ function ThinkingRow({ entry, followTs }: { entry: ActivityEntry; followTs?: num
   return (
     <>
       <span className="chat-activity__glyph" aria-hidden="true">
-        <Circle className="chat-activity__dot" />
+        <Lightbulb className="chat-activity__dot" />
       </span>
       {hasText ? (
         <button
@@ -108,7 +117,15 @@ function ThinkingRow({ entry, followTs }: { entry: ActivityEntry; followTs?: num
       <span />
       {open && hasText && (
         <div className="chat-activity__think-body" id={bodyId}>
-          {entry.text}
+          {/* Same safety contract as ChatMarkdownView (message-view.tsx):
+              renderChatMarkdown escapes raw HTML tokens. Rendered here
+              directly (not via ChatMarkdownView) to avoid a module cycle
+              with message-view and the code-copy delegation it carries. */}
+          <div
+            className="chat-md"
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: renderer escapes raw HTML
+            dangerouslySetInnerHTML={{ __html: renderChatMarkdown(entry.text) }}
+          />
         </div>
       )}
     </>

--- a/test/chat-ui-style-contract.test.ts
+++ b/test/chat-ui-style-contract.test.ts
@@ -58,11 +58,11 @@ describe('chat UI style contract', () => {
     );
   });
 
-  it('lights the thought bulb in accent while expanded', () => {
+  it('lifts the expanded thought bulb to the same tone as its label', () => {
     const chatCss = readFileSync(join(root, 'src/app/styles/chat.css'), 'utf8');
 
     expect(chatCss).toMatch(
-      /\.chat-activity__glyph\[data-open\] \.chat-activity__dot\s*\{[\s\S]*?color:\s*var\(--accent\)/,
+      /\.chat-activity__glyph\[data-open\] \.chat-activity__dot\s*\{[\s\S]*?color:\s*var\(--text-2\)/,
     );
   });
 });

--- a/test/chat-ui-style-contract.test.ts
+++ b/test/chat-ui-style-contract.test.ts
@@ -49,4 +49,12 @@ describe('chat UI style contract', () => {
       /body:has\(\.filter-panel\.open\) \.chat-bubble\s*\{[\s\S]*?visibility:\s*hidden;[\s\S]*?pointer-events:\s*none/,
     );
   });
+
+  it('lifts the expanded Thought toggle like the activity line does', () => {
+    const chatCss = readFileSync(join(root, 'src/app/styles/chat.css'), 'utf8');
+
+    expect(chatCss).toMatch(
+      /\.chat-activity__think-toggle\[aria-expanded="true"\]\s*\{[\s\S]*?color:\s*var\(--text-2\)/,
+    );
+  });
 });

--- a/test/chat-ui-style-contract.test.ts
+++ b/test/chat-ui-style-contract.test.ts
@@ -57,4 +57,12 @@ describe('chat UI style contract', () => {
       /\.chat-activity__think-toggle\[aria-expanded="true"\]\s*\{[\s\S]*?color:\s*var\(--text-2\)/,
     );
   });
+
+  it('lights the thought bulb in accent while expanded', () => {
+    const chatCss = readFileSync(join(root, 'src/app/styles/chat.css'), 'utf8');
+
+    expect(chatCss).toMatch(
+      /\.chat-activity__glyph\[data-open\] \.chat-activity__dot\s*\{[\s\S]*?color:\s*var\(--accent\)/,
+    );
+  });
 });

--- a/test/components/activity-stream.test.tsx
+++ b/test/components/activity-stream.test.tsx
@@ -147,6 +147,45 @@ describe('ActivityStream', () => {
     expect(screen.getByText('the actual reasoning')).toBeTruthy();
   });
 
+  it('renders thinking text as markdown, not literal asterisks', () => {
+    const { container } = render(
+      <ActivityStream
+        streaming={false}
+        activity={activity({
+          status: 'done',
+          steps: 1,
+          entries: [
+            { type: 'thinking', text: '**2 active interviews** need prep' },
+            { type: 'tool', name: 'get_tracker', status: 'done' },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Thought/ }));
+    const strong = container.querySelector('.chat-activity__think-body strong');
+    expect(strong?.textContent).toBe('2 active interviews');
+    expect(screen.queryByText(/\*\*/)).toBeNull();
+  });
+
+  it('marks thinking rows with the Lightbulb icon', () => {
+    const { container } = render(
+      <ActivityStream
+        streaming={false}
+        activity={activity({
+          status: 'done',
+          steps: 1,
+          entries: [
+            { type: 'thinking', text: 'reasoning' },
+            { type: 'tool', name: 'get_tracker', status: 'done' },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    expect(container.querySelector('svg.lucide-lightbulb')).toBeTruthy();
+  });
+
   it('renders nothing for a settled burst with no steps and no thinking text', () => {
     const { container } = render(
       <ActivityStream

--- a/test/components/activity-stream.test.tsx
+++ b/test/components/activity-stream.test.tsx
@@ -186,6 +186,30 @@ describe('ActivityStream', () => {
     expect(container.querySelector('svg.lucide-lightbulb')).toBeTruthy();
   });
 
+  it('lights the bulb while its thought is expanded', () => {
+    const { container } = render(
+      <ActivityStream
+        streaming={false}
+        activity={activity({
+          status: 'done',
+          steps: 1,
+          entries: [
+            { type: 'thinking', text: 'reasoning' },
+            { type: 'tool', name: 'get_tracker', status: 'done' },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    const lit = () =>
+      container.querySelector('.chat-activity__glyph[data-open] svg.lucide-lightbulb');
+    expect(lit()).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Thought/ }));
+    expect(lit()).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Thought/ }));
+    expect(lit()).toBeNull();
+  });
+
   it('renders nothing for a settled burst with no steps and no thinking text', () => {
     const { container } = render(
       <ActivityStream


### PR DESCRIPTION
## Outcome

Three polish items on the activity stream (follow-ups to #110, maintainer-requested):

- **Thought bodies render as markdown.** Providers stream thinking text with markdown (bold findings, numbered lists), but the timeline body showed it raw — literal `**` asterisks. It now goes through the shared `renderChatMarkdown` (same escaping contract as reply bodies), scoped to timeline scale (12px, compact paragraph rhythm).
- **Thinking rows get the Lucide `Lightbulb` glyph** instead of the neutral circle.
- **The Thought toggle lifts its tone when expanded** (`--text-2`), matching the activity line's own open-state signal.

## Testing

TDD (all watched fail first): markdown renders a `<strong>` and no literal asterisks; `svg.lucide-lightbulb` present on thought rows; style contract asserts the `[aria-expanded="true"]` tone rule. Full activity/fold/message-view suites green (50 tests); quick gate green at commit.

## AI disclosure

AI-authored (Claude Code) from maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)