### PR TITLE
fix(web): unify page widths on shared tokens and calm the caps

### DIFF
--- a/src/app/styles/analytics-inline.css
+++ b/src/app/styles/analytics-inline.css
@@ -7,17 +7,17 @@
  * this file is analytics-only.
  */
 
-/* Head shares the 960px column of .analytics-content so the h1's left
+/* Head shares the --page-w column of .analytics-content so the h1's left
    edge lines up with the KPI grid (see .page-head--constrained). */
 .analytics-head {
-  --page-col: 960px;
+  --page-col: var(--page-w);
 }
 .analytics-content {
   padding: var(--space-4) var(--space-6) var(--space-6);
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
-  max-width: 960px;
+  max-width: var(--page-w);
   margin: 0 auto;
   width: 100%;
 }

--- a/src/app/styles/chat-page.css
+++ b/src/app/styles/chat-page.css
@@ -77,7 +77,7 @@
 .chat-page__body > * {
   /* Reading column, widened for desktop (issue #93) — the loading shell's
      children share this cap, so skeleton and loaded content stay in step. */
-  max-width: 820px;
+  max-width: var(--reading-w);
   margin-inline: auto;
 }
 /* Capping the scroller itself is harmless, but the auto inline margins above
@@ -182,7 +182,7 @@
 }
 
 .chat-page__composer > * {
-  max-width: 820px; /* keep in step with .chat-page__body > * above */
+  max-width: var(--reading-w); /* keep in step with .chat-page__body > * above */
   margin-inline: auto;
 }
 

--- a/src/app/styles/chrome.css
+++ b/src/app/styles/chrome.css
@@ -1360,12 +1360,12 @@ html:not(.boot-ready) .rail-scrim {
 }
 /* Pages whose content is a centered max-width column (Settings, Profile,
    Analytics) constrain the head to the same column so the h1's left edge
-   lines up with the container below it. --page-col defaults to the 880px
+   lines up with the container below it. --page-col defaults to the --page-w
    form column; pages with a wider column override it (see .analytics-head).
    Full-bleed pages (Offers table, Pipeline board) keep the plain .page-head. */
 .page-head--constrained {
   width: 100%;
-  max-width: var(--page-col, 880px);
+  max-width: var(--page-col, var(--page-w));
   margin: 0 auto;
 }
 

--- a/src/app/styles/home-inline.css
+++ b/src/app/styles/home-inline.css
@@ -6,7 +6,7 @@
   /* Desktop-first cap (issue #93): 960px read as a tablet shell on 1440px+
      monitors. The route skeleton shares this container, so it tracks the
      loaded width automatically. */
-  max-width: 1140px;
+  max-width: var(--page-w);
   /* .main is a column flex container and the auto inline margins below
      suppress flex stretch (same trap chat-page.css documents for the
      transcript) — so this container shrink-wraps to its content. Loaded
@@ -139,7 +139,7 @@
   text-wrap: balance;
 }
 .home-hero__composer {
-  max-width: 760px;
+  max-width: var(--hero-w);
   margin-inline: auto;
   text-align: left;
 }
@@ -169,7 +169,7 @@
 }
 
 .home-hero__chips {
-  max-width: 760px;
+  max-width: var(--hero-w);
   margin: var(--space-3) auto 0;
 }
 /* The bubble stacks its starters full-width in a narrow card; the hero has

--- a/src/app/styles/profile-inline.css
+++ b/src/app/styles/profile-inline.css
@@ -17,17 +17,16 @@
   margin: 0 auto;
   width: 100%;
 }
-/* At desktop, leave a right gutter so the fixed .toc-indicator-host
-   (anchored to right:24px) doesn't overlap the form column or the
-   page-head. Rail is hidden ≤1024px so we restore default padding
-   there. */
+/* At desktop, reserve a SYMMETRIC gutter so the fixed .toc-indicator-host
+   (anchored to right:24px) never overlaps while the column stays truly
+   centered (#93 consistency). Rail is hidden ≤1024px so default padding
+   returns there. */
 @media (min-width: 1025px) {
   .profile-content {
-    padding-right: 88px;
-    padding-left: var(--space-6);
+    padding-inline: 88px;
   }
   body[data-screen-label="Profile"] .page-head {
-    padding-right: 88px;
+    padding-inline: 88px;
   }
 }
 /* On desktop the shared TOC rail (.toc-indicator-host, see toc-rail.css)

--- a/src/app/styles/profile-inline.css
+++ b/src/app/styles/profile-inline.css
@@ -6,11 +6,11 @@
    when navigating between them. */
 /* Match settings.html — same max-width so both pages center the same way
    under the topbar/page-head and the form columns line up vertically when
-   navigating between them. 880px keeps 2-col form rows readable at desktop
+   navigating between them. --page-w keeps 2-col form rows readable at desktop
    without the markdown editors going edge-to-edge. */
 .profile-content {
   padding: var(--space-4) var(--space-6) var(--space-6);
-  max-width: 880px;
+  max-width: var(--page-w);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);

--- a/src/app/styles/settings-inline.css
+++ b/src/app/styles/settings-inline.css
@@ -82,16 +82,15 @@
 }
 /* At desktop, leave room on the right for the fixed .toc-indicator-host
    so it doesn't overlap the content. Rail lives at right:24px and is
-   ~48px wide, so we reserve ~80px of right gutter. Apply to both the
-   page-head (page title sits in here) and the form container. Below
-   1024px the rail is hidden, so we drop back to default padding. */
+   ~48px wide, so reserve the gutter SYMMETRICALLY (both sides) to keep the column
+   truly centered (#93 consistency). Applies to the page-head and the
+   form container; ≤1024px the rail is hidden and default padding returns. */
 @media (min-width: 1025px) {
   .settings-content {
-    padding-right: 88px;
-    padding-left: var(--space-6);
+    padding-inline: 88px;
   }
   body[data-screen-label="Settings"] .page-head {
-    padding-right: 88px;
+    padding-inline: 88px;
   }
 }
 .settings-content .form-section[id] {

--- a/src/app/styles/settings-inline.css
+++ b/src/app/styles/settings-inline.css
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
-  max-width: 880px;
+  max-width: var(--page-w);
   margin: 0 auto;
   width: 100%;
 }
@@ -123,7 +123,7 @@
     gap: var(--space-2);
     margin: 0 auto;
     width: 100%;
-    max-width: 880px;
+    max-width: var(--page-w);
     padding: 0 var(--space-4);
   }
   .settings-theme-row__label {

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -98,6 +98,13 @@
   --space-9: 96px;
   --space-10: 128px;
 
+  /* ─── Page widths (issue #93) — every centered page column shares these,
+     so all routes read as one shell. Full-bleed surfaces (Offers table,
+     Pipeline board) and the report's typographic measures are exempt. ─── */
+  --page-w: 1040px; /* standard page column — home, analytics, settings, profile */
+  --reading-w: 768px; /* conversation column — chat body + composer */
+  --hero-w: 700px; /* home hero composer + starter chips */
+
   /* ─── Icons ─── */
   --icon-size-micro: 10px;
   --icon-size-compact: 12px;

--- a/test/home-layout-contract.test.ts
+++ b/test/home-layout-contract.test.ts
@@ -39,8 +39,8 @@ describe('page width tokens (#93 consistency)', () => {
       ],
       ['src/app/styles/chat-page.css', [/var\(--reading-w\)/]],
       ['src/app/styles/analytics-inline.css', [/var\(--page-w\)/]],
-      ['src/app/styles/settings-inline.css', [/var\(--page-w\)/]],
-      ['src/app/styles/profile-inline.css', [/var\(--page-w\)/]],
+      ['src/app/styles/settings-inline.css', [/var\(--page-w\)/, /padding-inline: 88px/]],
+      ['src/app/styles/profile-inline.css', [/var\(--page-w\)/, /padding-inline: 88px/]],
       ['src/app/styles/chrome.css', [/var\(--page-col,\s*var\(--page-w\)\)/]],
     ];
     for (const [file, patterns] of consumers) {
@@ -51,6 +51,9 @@ describe('page width tokens (#93 consistency)', () => {
       expect(css, `${file} still has a raw page cap`).not.toMatch(
         /max-width:\s*(?:820|880|960|1040|1140)px/,
       );
+      // TOC-rail gutters must be symmetric — a lone right gutter skews the
+      // centered column (the settings/profile 32-vs-88 bug).
+      expect(css, `${file} has an asymmetric rail gutter`).not.toMatch(/padding-right:\s*88px/);
     }
   });
 });

--- a/test/home-layout-contract.test.ts
+++ b/test/home-layout-contract.test.ts
@@ -20,3 +20,37 @@ describe('home layout contract (#93)', () => {
     );
   });
 });
+
+describe('page width tokens (#93 consistency)', () => {
+  const read = (p: string) => readFileSync(join(process.cwd(), p), 'utf-8');
+
+  it('tokens.css owns the three shared page widths', () => {
+    const tokens = read('src/app/styles/tokens.css');
+    expect(tokens).toMatch(/--page-w:\s*1040px/);
+    expect(tokens).toMatch(/--reading-w:\s*768px/);
+    expect(tokens).toMatch(/--hero-w:\s*700px/);
+  });
+
+  it('every centered page column consumes the shared tokens, never a raw cap', () => {
+    const consumers: Array<[string, RegExp[]]> = [
+      [
+        'src/app/styles/home-inline.css',
+        [/\.home\s*\{[^}]*max-width:\s*var\(--page-w\)/, /var\(--hero-w\)/],
+      ],
+      ['src/app/styles/chat-page.css', [/var\(--reading-w\)/]],
+      ['src/app/styles/analytics-inline.css', [/var\(--page-w\)/]],
+      ['src/app/styles/settings-inline.css', [/var\(--page-w\)/]],
+      ['src/app/styles/profile-inline.css', [/var\(--page-w\)/]],
+      ['src/app/styles/chrome.css', [/var\(--page-col,\s*var\(--page-w\)\)/]],
+    ];
+    for (const [file, patterns] of consumers) {
+      const css = read(file);
+      for (const pattern of patterns)
+        expect(css, `${file} should match ${pattern}`).toMatch(pattern);
+      // No page-column magic numbers left behind in these files.
+      expect(css, `${file} still has a raw page cap`).not.toMatch(
+        /max-width:\s*(?:820|880|960|1040|1140)px/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Outcome

Follow-up to #111: the first widen (home 1140 / hero 760 / chat 820) overshot on review, and every centered route carried its own magic width (settings/profile 880, analytics 960). Three shared tokens now own the system so **all pages read as one shell**:

- `--page-w: 1040px` — home, analytics, settings, profile, and their constrained page heads (`--page-col` default now derives from it)
- `--reading-w: 768px` — chat body + composer column
- `--hero-w: 700px` — home hero composer + starter chips

Full-bleed surfaces (Offers table, Pipeline board) and the report's typographic measures stay exempt, deliberately.

## Testing

Contract test extended (watched fail first): tokens defined in `tokens.css`; every consumer file uses the tokens; **no raw page-column caps remain** in any of the six swept files. Full quick gate green at commit.

## AI disclosure

AI-authored (Claude Code); width values chosen by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)