### PR TITLE
fix(chat): keep a tool detail hugging its name in the activity timeline

### DIFF
--- a/src/app/styles/chat.css
+++ b/src/app/styles/chat.css
@@ -123,12 +123,21 @@
   padding-left: var(--space-3);
   border-left: 2px solid var(--border);
   display: grid;
-  grid-template-columns: 12px auto 1fr;
+  /* Two columns only — glyph + step. Name and detail share the step cell so
+     a detail always hugs its own name; a shared `auto` name column pushed a
+     short name's detail out to the widest name in the burst. */
+  grid-template-columns: 12px 1fr;
   gap: 4px var(--space-2);
   font-family: var(--font-mono);
   font-size: 10.5px;
   align-items: baseline;
   max-width: 100%;
+}
+.chat-activity__step {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
 }
 .chat-activity__name {
   color: var(--text-2);
@@ -179,7 +188,7 @@ button.chat-activity__think-toggle:focus-visible {
   color: var(--text-2);
 }
 .chat-activity__think-body {
-  grid-column: 1 / 4;
+  grid-column: 1 / -1;
   font-family: var(--font-sans);
   font-size: 12px;
   color: var(--text-3);

--- a/src/features/chat/activity-stream.tsx
+++ b/src/features/chat/activity-stream.tsx
@@ -114,7 +114,6 @@ function ThinkingRow({ entry, followTs }: { entry: ActivityEntry; followTs?: num
           {span ? `Thought for ${span}` : 'Thought'}
         </span>
       )}
-      <span />
       {open && hasText && (
         <div className="chat-activity__think-body" id={bodyId}>
           {/* Same safety contract as ChatMarkdownView (message-view.tsx):
@@ -173,16 +172,21 @@ function Timeline({ entries, streaming }: { entries: ActivityEntry[]; streaming:
         }
         if (entry.type === 'stage') {
           return (
-            <span key={key} className="chat-activity__stage" style={{ gridColumn: '2 / 4' }}>
+            <span key={key} className="chat-activity__stage" style={{ gridColumn: '2 / -1' }}>
               {entry.label}
             </span>
           );
         }
+        // Name + detail share ONE cell so the detail always hugs its name —
+        // a shared `auto` name column would push a short name's detail out to
+        // the widest name in the burst (`read` vs `sur9e-app_get_tracker`).
         return (
           <span key={key} style={{ display: 'contents' }}>
             <EntryGlyph entry={entry} streaming={streaming} />
-            <span className="chat-activity__name">{bareName(entry.name)}</span>
-            {entry.detail ? <DetailText detail={entry.detail} /> : <span />}
+            <span className="chat-activity__step">
+              <span className="chat-activity__name">{bareName(entry.name)}</span>
+              {entry.detail ? <DetailText detail={entry.detail} /> : null}
+            </span>
           </span>
         );
       })}

--- a/test/components/activity-stream.test.tsx
+++ b/test/components/activity-stream.test.tsx
@@ -210,6 +210,33 @@ describe('ActivityStream', () => {
     expect(lit()).toBeNull();
   });
 
+  it('keeps a tool detail hugging its name in one cell (no shared name column)', () => {
+    // A burst mixing a short and a long tool name: with a shared `auto` name
+    // column, `read`'s detail would be pushed to the long name's width. Name
+    // and detail must live in ONE cell so the detail always hugs the name.
+    const { container } = render(
+      <ActivityStream
+        streaming={false}
+        activity={activity({
+          status: 'done',
+          steps: 2,
+          entries: [
+            { type: 'tool', name: 'sur9e-app_get_tracker', status: 'done' },
+            { type: 'tool', name: 'read', status: 'done', detail: '/tmp/tool_output.json' },
+          ],
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Worked/ }));
+    const steps = container.querySelectorAll('.chat-activity__step');
+    expect(steps.length).toBe(2);
+    const readStep = steps[1];
+    expect(readStep.querySelector('.chat-activity__name')?.textContent).toBe('read');
+    expect(readStep.querySelector('.chat-activity__detail')?.textContent).toContain(
+      '/tmp/tool_output.json',
+    );
+  });
+
   it('renders nothing for a settled burst with no steps and no thinking text', () => {
     const { container } = render(
       <ActivityStream


### PR DESCRIPTION
## Outcome

In the activity timeline, the grid gave all rows a shared auto-sized name column — so a short tool name (`read`) stranded its detail (a long output path) way out at the widest name's edge (maintainer screenshot). Name and detail now share one cell: the detail always hugs its own name.

## Changes

- Timeline grid drops to two columns (glyph + step); `.chat-activity__step` holds name + detail inline (baseline-aligned, min-width 0 so long details still truncate).
- Thinking bodies and stage rows span with `-1` end lines, so the layout is column-count agnostic.

## Testing

TDD: a mixed short/long-name burst asserts both live in `.chat-activity__step` cells with the detail adjacent (watched fail on the old three-column grid first). Full activity + style-contract suites green (19 tests).

## AI disclosure

AI-authored (Claude Code) from a maintainer bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)