### PR TITLE
fix(providers): classify Claude OAuth session expiry as retryable auth error

### DIFF
--- a/cli/classify-error.mjs
+++ b/cli/classify-error.mjs
@@ -34,7 +34,15 @@ const PROVIDER_SIGNATURES = {
   claude: {
     install: [],
     quota: ['session limit', 'credit balance is too low', 'monthly spend limit', 'usage-credits'],
-    auth: ['oauth token revoked', 'not logged in', 'authentication_error'],
+    auth: [
+      'oauth token revoked',
+      'not logged in',
+      'authentication_error',
+      // Expired CLI session (issue #118), observed live: "Failed to
+      // authenticate: OAuth session expired and could not be refreshed"
+      'oauth session expired',
+      'could not be refreshed',
+    ],
     model_not_found: [
       'issue with the selected model',
       'model not found',

--- a/test/classify-error.test.ts
+++ b/test/classify-error.test.ts
@@ -23,6 +23,12 @@ describe('classifyProviderError', () => {
     ],
     ['OAuth token revoked. Please run /login', 'auth'],
     ['Not logged in. Please run `claude login`', 'auth'],
+    [
+      // Expired CLI session (issue #118) — must retry the fallback provider,
+      // not classify as unknown. Exact provider wording.
+      'Failed to authenticate: OAuth session expired and could not be refreshed',
+      'auth',
+    ],
     ['claude: command not found', 'install'],
     [
       '{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}',

--- a/test/llm-fallback-retry.test.ts
+++ b/test/llm-fallback-retry.test.ts
@@ -256,6 +256,14 @@ describe('runModeLLM fallback retry', () => {
 
   it.each([
     ['claude', 'claude-sonnet-4-6', 'OAuth token revoked', 'codex', 'gpt-5.4-mini'],
+    // Expired CLI session (issue #118) — exact provider wording.
+    [
+      'claude',
+      'claude-opus-4-7',
+      'Failed to authenticate: OAuth session expired and could not be refreshed',
+      'codex',
+      'gpt-5.6-sol',
+    ],
     ['codex', 'gpt-5.4-mini', 'refresh token expired', 'claude', 'claude-sonnet-4-6'],
     [
       'opencode',


### PR DESCRIPTION
## Problem

When a Claude Code CLI session's OAuth token expires mid-run, every mode fails outright instead of retrying on the configured fallback provider, even with a global fallback set in `inputs/config/config.yml`.

## Root cause

`cli/classify-error.mjs`'s `PROVIDER_SIGNATURES.claude.auth` needle list (`oauth token revoked`, `not logged in`, `authentication_error`, plus the shared needles) matches nothing in Claude Code's actual expired-session message — "Failed to authenticate: OAuth session expired and could not be refreshed" — so it classifies as `unknown`, which is excluded from `RETRYABLE`, and `batch/lib/llm.mjs`'s one-shot fallback never fires.

## Fix

Added `oauth session expired` and `could not be refreshed` to the claude `auth` signature list. `auth` is already in `RETRYABLE`, so no other change is needed.

## Tests

- `test/classify-error.test.ts`: the exact expired-session string classifies as `auth` for provider `claude` (retryability of `auth` was already asserted).
- `test/llm-fallback-retry.test.ts`: added an integration row to the terminal-auth-failure `it.each` — a claude primary failing with the exact expired-session text falls back to `codex/gpt-5.6-sol` with `usedFallback.reason === 'auth'`.

## Verification (sabotage check)

Both new tests were written first and run against the unpatched classifier: both failed (classifier returned `unknown`; `runModeLLM` returned `ok: false` with no fallback spawn). After adding the needles, both pass. Full `npm run test:quick` (99 passed, 0 failed) and `npm run build` pass.

## Provider sweep (acceptance item 4)

Checked codex and opencode for the same shape of gap. Codex's observed expired-session wording ("refresh token expired") already matches the existing `refresh token` needle, and opencode auth failures surface `ProviderAuthError`, which is already covered. No real unmatched error text was found in the repo or issue, so no speculative needles were added.

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)