### PR TITLE
fix(providers): classify an expired Claude OAuth session as auth in chat and job error banners

### DIFF
--- a/cli/classify-error.mjs
+++ b/cli/classify-error.mjs
@@ -33,7 +33,12 @@ const SHARED = {
 const PROVIDER_SIGNATURES = {
   claude: {
     install: [],
-    quota: ['session limit', 'credit balance is too low', 'monthly spend limit', 'usage-credits'],
+    // NOT 'usage-credits': the org spend-limit message mentions the
+    // `/usage-credits` slash command, but so does the stream-json `system/init`
+    // handshake's slash_commands list on claude-code 2.1.x — every failed turn
+    // whose stdout carried the handshake mis-classified as quota (issue #120).
+    // 'monthly spend limit' already catches the real message.
+    quota: ['session limit', 'credit balance is too low', 'monthly spend limit'],
     auth: [
       'oauth token revoked',
       'not logged in',

--- a/src/features/chat/chat-jobs-lib.ts
+++ b/src/features/chat/chat-jobs-lib.ts
@@ -3,7 +3,12 @@
 // no store imports: safe from any client module.
 
 import { JOB_TYPES_BY_TYPE } from '@/lib/job-types';
-import { sanitizeJobLogLines } from '@/lib/terminal-noise';
+import {
+  describeProviderFailure,
+  isActionableCategory,
+  providerErrorMessage,
+} from '@/lib/provider-error-message';
+import { cleanErrorLine, sanitizeJobLogLines } from '@/lib/terminal-noise';
 
 /** 83 → "1:23". */
 export function fmtElapsed(seconds: number): string {
@@ -59,4 +64,29 @@ export function reportTarget(entry: {
   snapshot: { params?: { num?: number; id?: string } } | null;
 }): number | string | undefined {
   return entry.snapshot?.params?.num ?? entry.snapshot?.params?.id ?? entry.num;
+}
+
+/**
+ * The failed-job card's subtitle. The runner already persists a humanized
+ * cause (plus its `errorCategory`) when it recognised a provider failure, so a
+ * known category renders that category's template directly. A record WITHOUT a
+ * category — legacy on-disk records, or a raw value set by the poll layer — is
+ * run through the same classifier here so an expired-session error still reads
+ * "log back in" instead of leaking the raw provider line (issue #120). Anything
+ * unrecognised falls back to the scrubbed worker cause (never ANSI, never a
+ * `<<<SUR9E_*>>>` sentinel).
+ */
+export function jobErrorText(snapshot: {
+  error?: string;
+  errorCategory?: string;
+  provider?: string;
+}): string {
+  const raw = snapshot.error ?? '';
+  if (!raw) return '';
+  const provider = snapshot.provider ?? 'claude';
+  if (isActionableCategory(snapshot.errorCategory)) {
+    return providerErrorMessage(provider, snapshot.errorCategory);
+  }
+  const { message, category } = describeProviderFailure(provider, raw);
+  return isActionableCategory(category) ? message : cleanErrorLine(raw);
 }

--- a/src/features/chat/chat-jobs-slot.tsx
+++ b/src/features/chat/chat-jobs-slot.tsx
@@ -19,9 +19,15 @@ import { useState } from 'react';
 import { useDeleteConfirmStore } from '@/components/delete-confirm-modal';
 import { useToastStore } from '@/components/toast/toast-store';
 import type { JobType } from '@/lib/server/jobs';
-import { cleanErrorLine } from '@/lib/terminal-noise';
 import { cancelJobAction, startJobAction } from '@/server/actions/jobs';
-import { fmtElapsed, jobTitle, parseLogLines, reportTarget, timePercent } from './chat-jobs-lib';
+import {
+  fmtElapsed,
+  jobErrorText,
+  jobTitle,
+  parseLogLines,
+  reportTarget,
+  timePercent,
+} from './chat-jobs-lib';
 import { useChatJobsStore } from './chat-jobs-store';
 import { useJobElapsed } from './use-chat-job-poll';
 
@@ -65,11 +71,12 @@ function ChatJobsRow({ jobId, total }: { jobId: string; total: number }) {
   const target = reportTarget(entry);
   const logLines = parseLogLines(snapshot?.output ?? '');
   const fallback = snapshot?.fallback;
-  // Scrub the persisted error one more time before it hits the DOM: the runner
-  // already writes a clean cause via workerErrorFromOutput, but the poll layer
-  // can set a raw fallback (e.g. the 404 "outcome unknown" path) and legacy
-  // records predate the sanitize — never render ANSI or a `<<<SUR9E_*>>>` leak.
-  const errorText = isError && snapshot?.error ? cleanErrorLine(snapshot.error) : '';
+  // Humanize + scrub the persisted error before it hits the DOM: the runner
+  // already writes a classified cause via describeWorkerFailure, but the poll
+  // layer can set a raw fallback (e.g. the 404 "outcome unknown" path) and
+  // legacy records predate both passes — never render a raw provider error,
+  // ANSI, or a `<<<SUR9E_*>>>` leak.
+  const errorText = isError && snapshot ? jobErrorText(snapshot) : '';
   // Terminal-state announcement for SR users — mirrors chat-card's
   // stream-status live region. Non-terminal states stay silent; the
   // spinner + elapsed tick would spam an aria-live region every second.

--- a/src/features/chat/chat-jobs-store.ts
+++ b/src/features/chat/chat-jobs-store.ts
@@ -15,6 +15,9 @@ export interface JobSnapshot {
    * elapsed timer at the real duration instead of ticking wall-clock. */
   finishedAt?: string | null;
   error?: string;
+  /** classify-error category behind `error` when the runner recognised a
+   * provider failure (see JobRecord.errorCategory). */
+  errorCategory?: string;
   /**
    * Per-job parameters mirrored from `/api/jobs/[id]`. `num` is the
    * application number for any offer-scoped job (evaluate, interview-prep,

--- a/src/lib/provider-error-message.ts
+++ b/src/lib/provider-error-message.ts
@@ -1,0 +1,158 @@
+// src/lib/provider-error-message.ts
+//
+// Framework-neutral half of provider-failure humanizing: the category →
+// actionable one-liner templates, the provider labels, and the pre-filter
+// that reduces a raw CLI stdout/stderr blob to the text that actually
+// describes the failure before it reaches cli/classify-error.mjs.
+//
+// No Node, React, or `server-only` imports — usable from the chat turn runner
+// (src/lib/server/providers/humanize-error.ts), the job runner
+// (src/lib/server/jobs/runner.ts), AND the client-side jobs strip
+// (src/features/chat/chat-jobs-slot.tsx), so every surface that shows a
+// provider failure renders the same sentence for the same category.
+//
+// Every returned message is a STATIC template — the failure text is only ever
+// read for classification, never spliced into the output — so no raw provider
+// text (ANSI, sentinels, stack frames, HTML tails) can leak to the user.
+
+import { classifyProviderError } from '../../cli/classify-error.mjs';
+import { stripTerminalNoise } from './terminal-noise';
+
+export type ProviderFailureDescription = {
+  /** Clean, user-facing sentence — safe to render verbatim. */
+  message: string;
+  /** The classify-error category ('auth'|'quota'|…|'unknown'). */
+  category: string;
+};
+
+// Friendly display names for the message body. Kept local (rather than
+// reading Provider.displayName) so this stays a pure string→string module.
+// Unknown ids degrade gracefully.
+const PROVIDER_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  opencode: 'OpenCode',
+};
+
+export function providerLabel(provider: string): string {
+  return PROVIDER_LABELS[provider] ?? 'the AI provider';
+}
+
+// Auth failures are CLI-session failures: each provider CLI has its own login
+// command, and that — not an API key field — is the remediation (issue #120:
+// an expired Claude OAuth session needs `claude auth login`).
+const AUTH_MESSAGE_BY_PROVIDER: Record<string, string> = {
+  claude:
+    'Your Claude session has expired or is signed out — run "claude auth login" in a terminal, then try again.',
+  codex: 'Your Codex session is signed out — run "codex login" in a terminal, then try again.',
+  opencode:
+    'OpenCode couldn\'t authenticate with its provider — run "opencode auth login" (or set the provider\'s API key env var), then try again.',
+};
+
+// Category → actionable one-liner. Every entry is a static template; the raw
+// failure text is NEVER interpolated.
+const MESSAGE_BY_CATEGORY: Record<string, (provider: string, label: string) => string> = {
+  auth: (provider, label) =>
+    AUTH_MESSAGE_BY_PROVIDER[provider] ??
+    `Your ${label} credentials aren't working — sign in to its CLI again, then try again.`,
+  quota: (_p, label) => `You've hit ${label}'s rate limit or quota — wait a bit or switch model.`,
+  rate_limit: (_p, label) =>
+    `You've hit ${label}'s rate limit or quota — wait a bit or switch model.`,
+  model_not_found: () => `That model isn't available — pick another from the model menu.`,
+  overloaded: (_p, label) => `${label} returned an error — try again or switch model.`,
+  context_overflow: () =>
+    `This conversation got too long for the model — start a new chat or switch to a bigger-context model.`,
+  install: (_p, label) =>
+    `Couldn't launch the ${label} CLI — make sure it's installed and on your PATH.`,
+  unknown: (_p, label) => `${label} couldn't complete this reply — try again or switch model.`,
+};
+
+/** True for a category that has a specific (non-`unknown`) template. */
+export function isActionableCategory(category: string | undefined | null): category is string {
+  return typeof category === 'string' && category !== 'unknown' && category in MESSAGE_BY_CATEGORY;
+}
+
+/** The static template for a classify-error category (unknown ids/categories degrade gracefully). */
+export function providerErrorMessage(provider: string, category: string): string {
+  const build = MESSAGE_BY_CATEGORY[category] ?? MESSAGE_BY_CATEGORY.unknown;
+  return build(provider, providerLabel(provider));
+}
+
+const SENTINEL_RE = /<<<SUR9E_[A-Z_]*>>>/g;
+
+/** A string field, or the `message` of an error object, as text. */
+function errorText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value && typeof value === 'object') {
+    const msg = (value as { message?: unknown }).message;
+    if (typeof msg === 'string') return msg;
+  }
+  return '';
+}
+
+/**
+ * Reduce a provider CLI's captured output to the lines that can describe a
+ * FAILURE. Structured (JSON-per-line) stream events are pure infrastructure
+ * unless they carry model text or an error: the claude `system/init`
+ * handshake, for instance, lists the CLI's slash commands (`usage-credits`
+ * among them on 2.1.x), which used to trip the quota needle ahead of the real
+ * auth failure (issue #120). Keep, per JSON line: `result`, `error`, `message`
+ * strings and assistant text parts; drop everything else. Plain (non-JSON)
+ * lines — stderr prose, `❌`/`ERROR:` worker lines — pass through untouched.
+ * Terminal escapes and `<<<SUR9E_*>>>` sentinels are stripped so an escape
+ * spliced mid-token can't hide a signature.
+ */
+export function failureTextForClassification(text: string): string {
+  const out: string[] = [];
+  for (const line of stripTerminalNoise(text).replace(SENTINEL_RE, '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (!trimmed.startsWith('{')) {
+      out.push(trimmed);
+      continue;
+    }
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      out.push(trimmed); // not actually JSON — keep as prose
+      continue;
+    }
+    if (!obj || typeof obj !== 'object') continue;
+    const kept: string[] = [];
+    if (typeof obj.result === 'string') kept.push(obj.result);
+    kept.push(errorText(obj.error));
+    // Top-level `message` (codex `{"type":"error","message":…}`), or a claude
+    // `assistant` envelope whose message.content carries text parts.
+    if (typeof obj.message === 'string') kept.push(obj.message);
+    else if (obj.message && typeof obj.message === 'object') {
+      const content = (obj.message as { content?: unknown }).content;
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (
+            part &&
+            typeof part === 'object' &&
+            typeof (part as { text?: unknown }).text === 'string'
+          ) {
+            kept.push((part as { text: string }).text);
+          }
+        }
+      }
+    }
+    const joined = kept.filter(Boolean).join('\n');
+    if (joined) out.push(joined);
+  }
+  return out.join('\n');
+}
+
+/**
+ * Classify a provider failure from its captured text (stdout, stderr, or a
+ * persisted error line) and return the matching template + category.
+ */
+export function describeProviderFailure(
+  provider: string,
+  text: string,
+): ProviderFailureDescription {
+  const category = classifyProviderError(provider, failureTextForClassification(text));
+  return { message: providerErrorMessage(provider, category), category };
+}

--- a/src/lib/schemas/jobs.ts
+++ b/src/lib/schemas/jobs.ts
@@ -109,6 +109,11 @@ export const JobRecord = z.object({
   finishedAt: z.string().nullable(),
   output: z.string().default(''),
   error: z.string().nullable(),
+  // classify-error category of the failure behind `error` ('auth'|'quota'|…)
+  // when the runner recognised a provider failure in the worker output; the
+  // UI branches on it (e.g. "log back in"). Absent for worker-level causes
+  // (missing input, parse failure) and for records that predate it.
+  errorCategory: z.string().optional(),
   exitCode: z.number().int().nullable(),
   // Optional workflow parent metadata. Legacy standalone records omit it;
   // workflow children carry both ids so the UI and recovery path can group

--- a/src/lib/server/jobs/__tests__/worker-error.test.ts
+++ b/src/lib/server/jobs/__tests__/worker-error.test.ts
@@ -5,7 +5,7 @@
 // (UI/UX audit 2026-06-10, "Failed job card surfaces only 'exit 1'").
 
 import { describe, expect, it } from 'vitest';
-import { workerErrorFromOutput } from '../runner';
+import { describeWorkerFailure, workerErrorFromOutput } from '../runner';
 
 describe('workerErrorFromOutput', () => {
   it("surfaces the worker's ERROR line with the exit code appended", () => {
@@ -64,6 +64,38 @@ describe('workerErrorFromOutput', () => {
       '\n',
     );
     expect(workerErrorFromOutput(output, 1)).toBe('artifact write failed: ENOSPC (exit 1)');
+  });
+
+  it("an expired Claude OAuth session in the tee'd provider stream → the auth template (issue #120)", () => {
+    // A failed mode run: the worker tees the provider's stream-json (whose
+    // init handshake lists `usage-credits` among the slash commands), the CLI
+    // reports the expired session, and mode-runner prints its generic ❌ line.
+    // The card must say "log back in", not the opaque cause line and not quota.
+    const oauth = 'Failed to authenticate: OAuth session expired and could not be refreshed';
+    const output = [
+      'mode=cover-letter provider=claude model=claude-opus (resolved from mode_default)',
+      '{"type":"system","subtype":"init","session_id":"s1","slash_commands":["compact","usage-credits","usage"],"model":"claude-opus-4-6"}',
+      `{"type":"result","subtype":"error_during_execution","is_error":true,"result":"${oauth}"}`,
+      oauth,
+      '❌ LLM run failed: exit 1',
+    ].join('\n');
+    const { error, category } = describeWorkerFailure(output, 1, 'claude');
+    expect(category).toBe('auth');
+    expect(error).toBe(
+      'Your Claude session has expired or is signed out — run "claude auth login" in a terminal, then try again.',
+    );
+    expect(error).not.toContain('rate limit or quota');
+    expect(workerErrorFromOutput(output, 1, 'claude')).toBe(error);
+  });
+
+  it('a non-provider failure keeps the worker cause line and reports no category', () => {
+    const output = ['mode=cover-letter provider=claude', '❌ artifact write failed: ENOSPC'].join(
+      '\n',
+    );
+    expect(describeWorkerFailure(output, 1, 'claude')).toEqual({
+      error: 'artifact write failed: ENOSPC (exit 1)',
+      category: undefined,
+    });
   });
 
   it('extracts a clean cause from a REAL failed run (ANSI + sentinels + HTML tail)', () => {

--- a/src/lib/server/jobs/runner.ts
+++ b/src/lib/server/jobs/runner.ts
@@ -10,6 +10,7 @@ import 'server-only';
 import { type ChildProcess, type SpawnOptions, spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describeProviderFailure, isActionableCategory } from '../../provider-error-message';
 import { type JobRecord } from '../../schemas/jobs';
 import { ProviderId } from '../../schemas/providers';
 import { cleanErrorLine, stripTerminalNoise } from '../../terminal-noise';
@@ -155,27 +156,45 @@ function resolveReportNumByUrl(rootPath: string, url: string): number | null {
 }
 
 /**
- * Human-readable failure cause for a non-zero exit. Workers print their
- * actionable cause in one of two shapes:
- *   - batch/screen.mjs (and the CLI arg guards) emit 'ERROR: …' lines
- *     (e.g. 'ERROR: …/cv.md missing');
- *   - batch/mode-runner.mjs emits '❌ …' lines for every failure branch
- *     (runtime/input/LLM-run/parse/write), e.g.
- *     '❌ output parse failed on retry: no <<<SUR9E_OUTPUT>>> sentinel…'.
- * Surface the LAST such line as the persisted error — it becomes the failed
- * card's subtitle — instead of the opaque 'exit 1'. ANSI escapes are stripped
- * and leaked `<<<SUR9E_*>>>` sentinel tokens scrubbed (via cleanErrorLine) so
- * the subtitle is a clean human sentence, never a raw terminal dump. Falls
- * back to 'exit N' when no marker is present. Capped to one subtitle-sized
- * line; the full text stays in the captured logs.
+ * Human-readable failure cause for a non-zero exit, plus the provider-error
+ * category when the worker's captured output carries a recognisable provider
+ * failure. Two tiers:
+ *
+ *   1. Provider failure (expired OAuth session, quota, model not found, …):
+ *      the tee'd CLI stream in `output` is run through the SAME classifier and
+ *      templates as a chat turn (src/lib/provider-error-message.ts), so a job
+ *      that died on `Failed to authenticate: OAuth session expired…` gets the
+ *      "run claude auth login" line rather than that raw text or the generic
+ *      `❌ LLM run failed: exit 1` (issue #120). `category` is set.
+ *   2. Otherwise, the worker's own actionable cause line. Workers print it in
+ *      one of two shapes: batch/screen.mjs (and the CLI arg guards) emit
+ *      'ERROR: …' lines (e.g. 'ERROR: …/cv.md missing'); batch/mode-runner.mjs
+ *      emits '❌ …' lines for every failure branch, e.g. '❌ output parse failed
+ *      on retry: no <<<SUR9E_OUTPUT>>> sentinel…'. The LAST such line becomes
+ *      the failed card's subtitle instead of the opaque 'exit 1'. ANSI escapes
+ *      are stripped and leaked `<<<SUR9E_*>>>` sentinel tokens scrubbed (via
+ *      cleanErrorLine); falls back to 'exit N' when no marker is present.
+ *      Capped to one subtitle-sized line; the full text stays in the logs.
+ *
+ * A null exit code = the worker was killed by a signal (OOM / crash / an
+ * external kill), not a normal non-zero exit. Say so plainly instead of the
+ * opaque "exit null" — and don't classify its partial output (mirrors
+ * humanize-error.ts's 'interrupted' short-circuit on the chat-turn side).
  */
-export function workerErrorFromOutput(output: string, code: number | null): string {
-  // A null exit code = the worker was killed by a signal (OOM / crash / an
-  // external kill), not a normal non-zero exit. Say so plainly instead of the
-  // opaque "exit null".
+export function describeWorkerFailure(
+  output: string,
+  code: number | null,
+  provider: string = 'claude',
+): { error: string; category: string | undefined } {
   const codeLabel = code === null ? 'interrupted' : `exit ${code}`;
   const noMarkerFallback =
     code === null ? 'The job was interrupted before it finished.' : `exit ${code}`;
+
+  if (code !== null && output) {
+    const { message, category } = describeProviderFailure(provider, output);
+    if (isActionableCategory(category)) return { error: message, category };
+  }
+
   // Strip terminal noise first so a cause line rendered mid-stream (or carrying
   // color codes) matches on its ERROR:/❌ prefix and doesn't leak escapes.
   const line = stripTerminalNoise(output)
@@ -185,14 +204,37 @@ export function workerErrorFromOutput(output: string, code: number | null): stri
       const t = l.trim();
       return t.startsWith('ERROR:') || t.startsWith('❌');
     });
-  if (!line) return noMarkerFallback;
+  if (!line) return { error: noMarkerFallback, category: undefined };
   const stripped = line
     .trim()
     .replace(/^ERROR:\s*/, '')
     .replace(/^❌️?\s*/, '');
   const msg = cleanErrorLine(stripped);
-  if (!msg) return noMarkerFallback;
-  return `${msg} (${codeLabel})`;
+  if (!msg) return { error: noMarkerFallback, category: undefined };
+  return { error: `${msg} (${codeLabel})`, category: undefined };
+}
+
+/**
+ * describeWorkerFailure shaped for a JobRecord spread: `error` always, and
+ * `errorCategory` only when a provider failure was recognised (so a worker-
+ * level cause never carries an explicit `undefined` field on the record).
+ */
+function describeFailureForRecord(
+  output: string,
+  code: number | null,
+  provider: string | undefined,
+): { error: string; errorCategory?: string } {
+  const { error, category } = describeWorkerFailure(output, code, provider ?? 'claude');
+  return category ? { error, errorCategory: category } : { error };
+}
+
+/** The subtitle string alone — see describeWorkerFailure. */
+export function workerErrorFromOutput(
+  output: string,
+  code: number | null,
+  provider: string = 'claude',
+): string {
+  return describeWorkerFailure(output, code, provider).error;
 }
 
 /**
@@ -538,7 +580,9 @@ export async function spawnJob(
             ...current,
             exitCode: code,
             status: code === 0 ? 'done' : 'error',
-            error: code === 0 ? null : workerErrorFromOutput(current.output, code),
+            ...(code === 0
+              ? { error: null }
+              : describeFailureForRecord(current.output, code, current.provider)),
             finishedAt: new Date().toISOString(),
           };
     // Fallback re-stamp: when the worker retried on the fallback pair, the

--- a/src/lib/server/providers/humanize-error.ts
+++ b/src/lib/server/providers/humanize-error.ts
@@ -6,14 +6,14 @@
 // dump, a bare Node error, terminal escape noise, a `<<<SUR9E_*>>>` sentinel,
 // or an HTML error tail.
 //
-// It leans on cli/classify-error.mjs — the single source of truth for "what
-// kind of failure was this" (auth/quota/rate_limit/model_not_found/…) — and
-// maps each category to one clean line. Because every returned message is a
-// STATIC template (the failure text is only ever read for classification,
-// never spliced into the output), no raw provider text can leak to the user.
+// The templates and the stdout pre-filter live in the framework-neutral
+// src/lib/provider-error-message.ts (shared with the job runner and the
+// client-side jobs strip); this module adds the chat-turn specifics: the
+// stdout+stderr assembly and the signal-kill short-circuit. Every returned
+// message is a STATIC template, so no raw provider text can leak to the user.
 
 import 'server-only';
-import { classifyProviderError } from '../../../../cli/classify-error.mjs';
+import { describeProviderFailure, providerLabel } from '../../provider-error-message';
 
 export type HumanizedError = {
   /** Clean, user-facing sentence — safe to render verbatim in the chat bubble. */
@@ -31,57 +31,16 @@ export type ProviderFailure = {
   code?: number | null;
 };
 
-// Friendly display names for the message body. Kept local (rather than reading
-// Provider.displayName) so this module stays a pure string→string function the
-// tests can exercise with just a provider id. Unknown ids degrade gracefully.
-const PROVIDER_LABELS: Record<string, string> = {
-  claude: 'Claude',
-  codex: 'Codex',
-  opencode: 'OpenCode',
-};
-
-function providerLabel(provider: string): string {
-  return PROVIDER_LABELS[provider] ?? 'the AI provider';
-}
-
-// Category → actionable one-liner. Every entry is a static template; the raw
-// failure text is NEVER interpolated, so ANSI/sentinel/HTML noise can't leak.
-const MESSAGE_BY_CATEGORY: Record<string, (label: string) => string> = {
-  auth: label => `Your ${label} credentials aren't working — check the API key in Settings.`,
-  quota: label => `You've hit ${label}'s rate limit or quota — wait a bit or switch model.`,
-  rate_limit: label => `You've hit ${label}'s rate limit or quota — wait a bit or switch model.`,
-  model_not_found: () => `That model isn't available — pick another from the model menu.`,
-  overloaded: label => `${label} returned an error — try again or switch model.`,
-  context_overflow: () =>
-    `This conversation got too long for the model — start a new chat or switch to a bigger-context model.`,
-  install: label => `Couldn't launch the ${label} CLI — make sure it's installed and on your PATH.`,
-  unknown: label => `${label} couldn't complete this reply — try again or switch model.`,
-};
-
-// Terminal pollution some CLIs interleave with their output — CSI color codes
-// (`ESC[0m`), OSC sequences (`ESC]777;…BEL`), and ESC-stripped remnants. Mirror
-// of batch/lib/output-parser.mjs's stripTerminalNoise, inlined here so the chat
-// server bundle doesn't pull that module's js-yaml dependency in. Stripped
-// BEFORE classification so an escape code spliced mid-token can't hide a
-// signature — the RETURNED message is a static template regardless, so this is
-// purely to sharpen the category match.
-const ANSI_CSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
-const ANSI_OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
-const SENTINEL_RE = /<<<SUR9E_[A-Z_]*>>>/g;
-
-function cleanForClassification(text: string): string {
-  return text
-    .replace(ANSI_OSC_RE, '')
-    .replace(ANSI_CSI_RE, '')
-    .replace(/\[[0-9;]{1,6}m/g, '')
-    .replace(SENTINEL_RE, '');
-}
-
 /**
  * Classify a chat-turn failure and return a clean, actionable message + its
  * category. `provider` is the provider id ('claude'|'codex'|'opencode');
  * `stdout`/`stderr`/`code` are whatever the turn captured (on a spawn or
  * prologue failure, pass the Error.message as `stderr`).
+ *
+ * stdout is a stream-json event log, most of which is infrastructure (the
+ * `system/init` handshake, hook events, usage). describeProviderFailure keeps
+ * only the failure-bearing text — result/error/assistant strings plus plain
+ * lines — so a handshake field can never out-rank the real error (issue #120).
  */
 export function humanizeProviderError(provider: string, failure: ProviderFailure): HumanizedError {
   // A null exit code means the child was killed by a SIGNAL (OOM, crash, an
@@ -98,8 +57,5 @@ export function humanizeProviderError(provider: string, failure: ProviderFailure
       category: 'interrupted',
     };
   }
-  const combined = cleanForClassification(`${failure.stdout ?? ''}\n${failure.stderr ?? ''}`);
-  const category = classifyProviderError(provider, combined);
-  const build = MESSAGE_BY_CATEGORY[category] ?? MESSAGE_BY_CATEGORY.unknown;
-  return { message: build(providerLabel(provider)), category };
+  return describeProviderFailure(provider, `${failure.stdout ?? ''}\n${failure.stderr ?? ''}`);
 }

--- a/test/classify-error.test.ts
+++ b/test/classify-error.test.ts
@@ -39,6 +39,14 @@ describe('classifyProviderError', () => {
       'context_overflow',
     ],
     ['some totally unrelated crash', 'unknown'],
+    [
+      // The stream-json `system/init` handshake lists the CLI's built-in slash
+      // commands — including `usage-credits` on claude-code 2.1.x (issue #120).
+      // Pure infrastructure, not a failure: it must NOT read as quota, or every
+      // failed chat turn whose stdout carries the handshake becomes "quota".
+      '{"type":"system","subtype":"init","session_id":"s1","slash_commands":["compact","usage-credits","extra-usage","usage","insights"],"model":"claude-opus-4-6"}',
+      'unknown',
+    ],
   ])('claude: %s → %s', (text, expected) => {
     expect(classifyProviderError('claude', text)).toBe(expected);
   });

--- a/test/components/chat-jobs-slot.test.tsx
+++ b/test/components/chat-jobs-slot.test.tsx
@@ -271,6 +271,50 @@ describe('ChatJobsSlot', () => {
     expect(preText).not.toContain('<body');
   });
 
+  it('renders the auth template for a job the runner classified as auth (issue #120)', async () => {
+    act(() => {
+      useChatJobsStore.getState().startJob('job-auth', 'cover-letter', 6);
+      useChatJobsStore.getState().setSnapshot('job-auth', {
+        status: 'error',
+        output: 'Failed to authenticate: OAuth session expired and could not be refreshed',
+        error:
+          'Your Claude session has expired or is signed out — run "claude auth login" in a terminal, then try again.',
+        errorCategory: 'auth',
+        provider: 'claude',
+        startedAt: new Date(Date.now() - 10_000).toISOString(),
+        finishedAt: new Date().toISOString(),
+        params: { num: 6 },
+      });
+    });
+    const { container } = render(<ChatJobsSlot />);
+    await waitFor(() => expect(container.querySelector('.chat-jobs__error')).toBeTruthy());
+    const errText = container.querySelector('.chat-jobs__error')?.textContent ?? '';
+    expect(errText).toContain('claude auth login');
+    expect(errText).not.toContain('rate limit or quota');
+  });
+
+  it('classifies a legacy/raw provider error string itself (no errorCategory) instead of leaking it', async () => {
+    // Records written before the runner humanized failures — or set raw by the
+    // poll layer — still get the same "log back in" line, never the raw text.
+    act(() => {
+      useChatJobsStore.getState().startJob('job-legacy', 'cover-letter', 7);
+      useChatJobsStore.getState().setSnapshot('job-legacy', {
+        status: 'error',
+        output: '',
+        error: 'Failed to authenticate: OAuth session expired and could not be refreshed (exit 1)',
+        provider: 'claude',
+        startedAt: new Date(Date.now() - 10_000).toISOString(),
+        finishedAt: new Date().toISOString(),
+        params: { num: 7 },
+      });
+    });
+    const { container } = render(<ChatJobsSlot />);
+    await waitFor(() => expect(container.querySelector('.chat-jobs__error')).toBeTruthy());
+    const errText = container.querySelector('.chat-jobs__error')?.textContent ?? '';
+    expect(errText).toContain('claude auth login');
+    expect(errText).not.toContain('could not be refreshed');
+  });
+
   it('Retry re-spawns the same mode with the same params and swaps in the fresh job', async () => {
     mockStartJobAction.mockResolvedValue(jobRecord('freshjob00000000'));
     act(() => {

--- a/test/unit/chat/turn-runner.test.ts
+++ b/test/unit/chat/turn-runner.test.ts
@@ -223,6 +223,23 @@ function errorEvent(turnId: string): { message: string; category?: string } {
 
 const ESC_RE = /\x1b/;
 
+/** The claude `auth` template — what an expired/signed-out session must render. */
+const AUTH_MESSAGE =
+  'Your Claude session has expired or is signed out — run "claude auth login" in a terminal, then try again.';
+
+/** Live claude-code 2.1.x `system/init` handshake: its slash_commands list
+ * carries `usage-credits`, a former `quota` needle (issue #120). */
+const realInitLine = (sid: string) =>
+  JSON.stringify({
+    type: 'system',
+    subtype: 'init',
+    session_id: sid,
+    model: 'claude-opus-4-6',
+    slash_commands: ['compact', 'security-review', 'usage-credits', 'extra-usage', 'usage'],
+    apiKeySource: 'none',
+  });
+const OAUTH_EXPIRED = 'Failed to authenticate: OAuth session expired and could not be refreshed';
+
 describe('humanizeProviderError', () => {
   it('a raw stderr dump becomes a clean one-liner (no ANSI, not the verbatim stderr)', () => {
     const rawDump =
@@ -247,7 +264,26 @@ describe('humanizeProviderError', () => {
       code: 1,
     });
     expect(category).toBe('auth');
-    expect(message).toBe("Your Claude credentials aren't working — check the API key in Settings.");
+    expect(message).toBe(AUTH_MESSAGE);
+  });
+
+  it('stream-json init noise on stdout does not out-rank an OAuth expiry (issue #120)', () => {
+    // The whole failed turn: init handshake (with `usage-credits` in its
+    // slash-command list) + an is_error result carrying the auth failure.
+    const stdout = `${realInitLine('s1')}\n${JSON.stringify({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      result: OAUTH_EXPIRED,
+    })}\n`;
+    const { message, category } = humanizeProviderError('claude', {
+      stdout,
+      stderr: `${OAUTH_EXPIRED}\n`,
+      code: 1,
+    });
+    expect(category).toBe('auth');
+    expect(message).toBe(AUTH_MESSAGE);
+    expect(message).not.toContain('rate limit or quota');
   });
 
   it('a spawn ENOENT → a friendly install message', () => {
@@ -639,7 +675,38 @@ describe('startTurn', () => {
 
     const { message, category } = errorEvent(turnId);
     expect(category).toBe('auth');
-    expect(message).toBe("Your Claude credentials aren't working — check the API key in Settings.");
+    expect(message).toBe(AUTH_MESSAGE);
+  });
+
+  it('expired OAuth session behind a real init handshake → auth card, not "rate limit or quota" (issue #120)', async () => {
+    _setSpawnImpl(
+      () =>
+        fakeChild(c => {
+          c.stdout.emit(
+            'data',
+            Buffer.from(
+              `${realInitLine('sess-120')}\n${JSON.stringify({
+                type: 'result',
+                subtype: 'error_during_execution',
+                is_error: true,
+                num_turns: 0,
+                result: OAUTH_EXPIRED,
+              })}\n`,
+            ),
+          );
+          c.stderr.emit('data', Buffer.from(`${OAUTH_EXPIRED}\n`));
+          c.emit('close', 1);
+        }) as never,
+    );
+    const conv = createConversation(root);
+    const { turnId } = await startTurn(root, { conversationId: conv.id, userMessage: 'hi' });
+    await waitForTerminal(turnId);
+
+    expect(getTurn(turnId)?.status).toBe('error');
+    const { message, category } = errorEvent(turnId);
+    expect(category).toBe('auth');
+    expect(message).toBe(AUTH_MESSAGE);
+    expect(message).not.toContain('rate limit or quota');
   });
 
   it('exit 0 with empty output → a clean empty-reply error, not an empty bubble', async () => {


### PR DESCRIPTION
Fixes #120

## Root cause

`humanizeProviderError()` classified the **whole** stream-json stdout of a failed chat turn. The `system/init` handshake line lists the CLI's built-in slash commands, which on claude-code 2.1.x include `usage-credits` — one of the claude `quota` needles in `cli/classify-error.mjs`. Since `CATEGORY_ORDER` checks `quota` before `auth`, every failed turn whose stdout carried the handshake rendered *"You've hit Claude's rate limit or quota"*, even when the real failure was `Failed to authenticate: OAuth session expired and could not be refreshed`. (Reproduced against the live CLI 2.1.241: the init line was the only `quota` hit in the blob.)

The raw un-humanized line in the screenshot comes from a different path: the error `result` event lands in `resultText`, and `persistPartial()` saves it as the assistant bubble before the error card; and the job path (`cleanErrorLine`) never classified at all.

## Fix

- **`cli/classify-error.mjs`** — drop the `'usage-credits'` needle. `'monthly spend limit'` already catches the real org spend-limit message (existing test keeps asserting that).
- **`src/lib/provider-error-message.ts`** (new, framework-neutral) — category templates, per-provider auth remediation (`claude auth login` / `codex login` / `opencode auth login` — Settings has no API-key field, so the old "check the API key in Settings" text pointed nowhere), and `failureTextForClassification()`, which keeps only failure-bearing text from a stream-json blob (`result` / `error` / assistant text + plain lines) so a handshake field can never out-rank the real error.
- **`humanize-error.ts`** — delegates to the shared module; keeps the chat-turn signal-kill short-circuit.
- **Jobs runner** — `describeWorkerFailure()` runs the worker output through the same classifier, persists a new optional `errorCategory` on the job record, and falls back to the existing `ERROR:`/`❌` cause line for non-provider failures.
- **Chat jobs strip** — `jobErrorText()` renders the category template (or classifies a legacy/raw error string itself) instead of leaking the raw provider line; `cleanErrorLine` remains the fallback for unknown causes.

## Tests

- `test/classify-error.test.ts`: a realistic init line (with `usage-credits`) → `unknown`, not `quota`.
- `test/unit/chat/turn-runner.test.ts`: **end-to-end `startTurn`** with a real init handshake + `is_error` result + stderr for the exact #120 string → error event category `auth`, message is the auth template, not "rate limit or quota". Plus a `humanizeProviderError` unit for the same blob.
- `src/lib/server/jobs/__tests__/worker-error.test.ts`: tee'd stream-json + OAuth expiry + `❌ LLM run failed: exit 1` → auth template; non-provider failure keeps the cause line with no category.
- `test/components/chat-jobs-slot.test.tsx`: renders the auth template for `errorCategory: 'auth'`, and for a legacy raw auth string without a category.

`npm run test:quick` — 99 passed, 0 failed (1 pre-existing Biome suppression warning in `activity-stream.tsx`, untouched). `npm run build` — passes.

No rendered markup changed (error text plumbing only), so no screenshots.

## Notes for review

- The classifier remains substring-based; the SHARED `429` needle can still match inside base64 blobs (seen in a hook payload on my machine). Harmless for #120 after the pre-filter, but worth a follow-up if a `rate_limit` mis-read shows up on an `unknown` failure.
- `docs/architecture.md`'s retry table still lists `auth` as non-retryable, which #119 changed — left alone here to keep this PR to one outcome.

Substantially AI-authored (Claude) under maintainer dispatch; every line reviewed against CLAUDE.md/CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)