### PR TITLE
fix(modes): nest all interview rounds under one heading depth

### DIFF
--- a/content/modes/interview-prep.md
+++ b/content/modes/interview-prep.md
@@ -34,15 +34,15 @@ Layout:
 
    Difficulty is a **number** (e.g. `3.2`, not `3.2/5` and not stars). Positive % is the share of reviewers who reported a positive experience. If a cell is unknown, write `unknown`.
 
-2. **Round 1 visible.** Show the first round's detail in full, directly after the table, so the reader gets concrete signal without opening anything.
+2. **All rounds under one heading.** Every round lives inside a single `### Rounds` heading that follows the table — no round sits outside a `###` wrapper. Round 1 is the first `####` block inside it, shown in full so the reader gets concrete signal without opening anything; the remaining rounds follow it at the same depth.
 
 3. **The rest in nested headings.** Each of these is a `###` heading under `## Interview Process`, so the reader can fold them on demand:
-   - Rounds 2 to 4 (one `###` heading holding the remaining rounds)
+   - Rounds (one `###` heading holding every round)
    - Likely questions
    - Prep checklist
    - Company signals
 
-   Individual rounds inside that heading are `####` headings (`#### Round 2: technical interview (60 min, virtual)`).
+   Individual rounds inside the `### Rounds` heading are `####` headings (`#### Round 2: technical interview (60 min, virtual)`).
 
    **Stages WITHIN a round (locked format).** When a single round has internal stages (e.g. a half-day onsite with four back-to-back blocks), every stage uses the SAME shape: a bold-label paragraph followed by its bullets —
 
@@ -99,11 +99,13 @@ Difficulty is a plain number (e.g. `3.2`), not `3.2/5` and not stars. Positive %
 
 ## Step 3: rounds
 
-Show **Round 1 in full** directly after the table. Put **Rounds 2 to 4 under a nested `### Rounds 2 to 4` heading** so the reader can fold them on demand. Keep all the round detail you found.
+Put **every round under one nested `### Rounds` heading** after the table so the reader can fold them on demand. **Round 1 comes first inside it, in full**, then the remaining rounds at the same `####` depth. Keep all the round detail you found.
 
-For each round:
+Shape of the block — one `### Rounds` wrapper, one `####` per round:
 
 ```markdown
+### Rounds
+
 #### Round 1: technical phone screen (45 min)
 
 - **Conducted by:** a **senior engineer** on the hiring team.
@@ -114,9 +116,13 @@ For each round:
 - **How to prepare:** drill **medium LeetCode** with a running commentary; have one **production debugging story** ready to tell in two minutes.
 
 sources: [(glassdoor)](https://www.glassdoor.com/Interview/...), [(blind)](https://www.teamblind.com/post/...)
+
+#### Round 2: technical interview (60 min, virtual)
+
+- …
 ```
 
-Duration in parentheses is optional but useful (e.g. `(30 min)`, `(60 to 90 min)`). In the example prose above, bold the facts a candidate should catch fast — the **round name and count**, who runs it, the **bar they screen for**, and the **specific topic or story** to prep — so a skim of the marked spans alone tells them what this round tests (aim for 1-3 anchors per round block). Collect the per-question sources into the single muted `sources:` line at the end of the block rather than tagging each bullet — each named source linked to its page, `inferred` left plain. If round structure is unknown, say so and give the best available read on what rounds to expect from the company's size, stage, and role level.
+Every later round repeats that `####` shape inside the same `### Rounds` heading — Round 1 is never promoted or demoted relative to its siblings. Duration in parentheses is optional but useful (e.g. `(30 min)`, `(60 to 90 min)`). In the example prose above, bold the facts a candidate should catch fast — the **round name and count**, who runs it, the **bar they screen for**, and the **specific topic or story** to prep — so a skim of the marked spans alone tells them what this round tests (aim for 1-3 anchors per round block). Collect the per-question sources into the single muted `sources:` line at the end of the block rather than tagging each bullet — each named source linked to its page, `inferred` left plain. If round structure is unknown, say so and give the best available read on what rounds to expect from the company's size, stage, and role level.
 
 ## Step 4: likely questions
 


### PR DESCRIPTION
Fixes #122

## Problem

`content/modes/interview-prep.md` told the model to render Round 1 as a `####` block **directly after the at-a-glance table**, outside any `###` wrapper, while Rounds 2-4 nested under `### Rounds 2 to 4`. Round 1 therefore sat at a different structural depth than its logical siblings even though it's the same kind of content, and unlike `Overview` / `Likely questions` / `Prep checklist` / `Company signals` it had no h3 of its own.

Before/after validated by hand against a real generated report: https://github.com/arspesk/sur9e/issues/122#issuecomment-5431493716

## Change

- Renamed the wrapper `### Rounds 2 to 4` → `### Rounds` — one heading holding *every* round.
- Moved Round 1 inside that wrapper as the first `####` item. It is still shown in full immediately, so the reader gets concrete signal without opening anything; the remaining rounds follow at the same `####` depth.
- Updated both places that describe the layout: the "Section format" spec (items 2 and 3) and Step 3 "rounds", including the example markdown block, which now shows the `### Rounds` wrapper plus a Round 2 stub so the sibling depth is explicit.
- All other formatting rules are untouched (bold-label stage shape, one muted `sources:` line per block, scan-anchor guidance).

Grepped the repo for `Rounds 2 to 4` / `### Rounds 2 to 4` — the only hits were the two lines in `interview-prep.md`; no docs, tests, batch specs, or renderer code depend on the literal string. `buildTocFromMarkdown()` keeps its intentional h1-h3 cap (unchanged). `artifacts/` is gitignored and absent from this checkout, so there was no committed report to patch.

## Verification

- `npm run test:quick` → 99 passed, 0 failed (1 pre-existing warning: `cv-sync-check` without user data).
- `npm run build` → compiled successfully.
- Content-only mode-spec change: no React/TS component touched, so the 3-width screenshot rule does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
