### PR TITLE
fix(providers): discover user-installed CLIs

### DIFF
--- a/scripts/diagnose-providers.mjs
+++ b/scripts/diagnose-providers.mjs
@@ -10,8 +10,11 @@
 //
 //   npm run diagnose > diag.txt 2>&1
 //
-// Prints: env + PATH, a direct `<cli> --version` probe with timing + error
-// codes, a `which` lookup, and the wizard's own nested provider probe.
+// Prints: env + PATH, a raw inherited-PATH `<cli> --version` probe with timing
+// + error codes, a `which` lookup, and the provider adapters' nested probe.
+// The final probe appends sur9e's standard user install directories and is the
+// authoritative result; the raw probes explain why a shell/server mismatch
+// existed in the first place.
 
 import { execFileSync } from 'node:child_process';
 
@@ -35,7 +38,7 @@ for (const p of (process.env.PATH || '').split(':')) {
   console.log('  ', p);
 }
 
-section('direct `<cli> --version` probe (this is what checkInstalled does)');
+section('raw inherited-PATH `<cli> --version` probe');
 for (const bin of CLIS) {
   const start = process.hrtime.bigint();
   try {
@@ -62,7 +65,7 @@ for (const bin of CLIS) {
   }
 }
 
-section('wizard nested probe (node -> npx tsx providers-probe.mjs)');
+section('provider adapter probe (includes standard user install directories)');
 try {
   const out = execFileSync(
     'npx',

--- a/src/lib/server/jobs/runner.ts
+++ b/src/lib/server/jobs/runner.ts
@@ -15,6 +15,7 @@ import { type JobRecord } from '../../schemas/jobs';
 import { ProviderId } from '../../schemas/providers';
 import { cleanErrorLine, stripTerminalNoise } from '../../terminal-noise';
 import { atomicWrite } from '../atomic-write';
+import { withProviderCliPath } from '../providers/cli-path';
 import {
   getProvider,
   type ModeRuntime,
@@ -452,7 +453,7 @@ export async function spawnJob(
   // bypass the config.yml fallthrough. The runner already used the
   // override above for the JOB RECORD stamping; this propagates it to
   // the subprocess so the actual CLI invocation matches.
-  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  const childEnv = withProviderCliPath();
   if (runOverride) {
     childEnv.SUR9E_OVERRIDE_PLATFORM = runOverride.platform;
     childEnv.SUR9E_OVERRIDE_MODEL = runOverride.model;

--- a/src/lib/server/providers/__tests__/claude.test.ts
+++ b/src/lib/server/providers/__tests__/claude.test.ts
@@ -19,7 +19,8 @@
 // proven against the real fixture data, not a stripped-down version.
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import claudeProvider, { __testing } from '../claude';
 
@@ -63,12 +64,13 @@ claude-sonnet-4@20250514
 describe('claude provider', () => {
   describe('buildHeadlessArgs', () => {
     it('produces the same command shape as today', () => {
-      const { cmd, args } = claudeProvider.buildHeadlessArgs({
+      const { cmd, args, env } = claudeProvider.buildHeadlessArgs({
         prompt: 'Evaluate offer #42',
         model: 'claude-sonnet-4-6',
       });
       expect(cmd).toBe('/bin/bash');
       expect(args).toMatchSnapshot();
+      expect(env?.PATH?.split(delimiter)).toContain(join(homedir(), '.local', 'bin'));
     });
   });
 

--- a/src/lib/server/providers/__tests__/cli-path.test.ts
+++ b/src/lib/server/providers/__tests__/cli-path.test.ts
@@ -1,0 +1,28 @@
+import { delimiter } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { providerCliPath } from '../cli-path';
+
+describe('providerCliPath', () => {
+  it('preserves inherited precedence and appends every supported provider install location', () => {
+    const path = providerCliPath(
+      { PATH: '/custom/bin:/usr/bin' },
+      { home: '/home/jobseeker', execPath: '/runtime/node/bin/node', platform: 'linux' },
+    ).split(delimiter);
+
+    expect(path.slice(0, 2)).toEqual(['/custom/bin', '/usr/bin']);
+    expect(path).toContain('/home/jobseeker/.local/bin'); // Claude Code + Codex standalone
+    expect(path).toContain('/home/jobseeker/.opencode/bin'); // OpenCode installer
+    expect(path).toContain('/home/jobseeker/.npm-global/bin'); // npm global prefix
+    expect(path).toContain('/runtime/node/bin'); // npm global beside the active Node runtime
+  });
+
+  it('deduplicates locations already present in PATH', () => {
+    const path = providerCliPath(
+      { PATH: '/home/jobseeker/.local/bin:/usr/bin' },
+      { home: '/home/jobseeker', execPath: '/usr/bin/node', platform: 'linux' },
+    ).split(delimiter);
+
+    expect(path.filter(entry => entry === '/home/jobseeker/.local/bin')).toHaveLength(1);
+    expect(path.filter(entry => entry === '/usr/bin')).toHaveLength(1);
+  });
+});

--- a/src/lib/server/providers/__tests__/codex.test.ts
+++ b/src/lib/server/providers/__tests__/codex.test.ts
@@ -11,8 +11,8 @@
 // either would produce surprising runs.
 
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import codex from '../codex';
 
@@ -30,6 +30,7 @@ describe('codex provider', () => {
       expect(args[1]).toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(args[1]).toContain('--model gpt-5.5');
       expect(env).toMatchObject({ CODEX_QUIET_MODE: '1' });
+      expect(env?.PATH?.split(delimiter)).toContain(join(homedir(), '.local', 'bin'));
     });
 
     it('respects outputFormat: "text" by omitting --json', () => {

--- a/src/lib/server/providers/__tests__/opencode.test.ts
+++ b/src/lib/server/providers/__tests__/opencode.test.ts
@@ -21,14 +21,15 @@
 //     installed locally (falls back to a small curated static list).
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import opencode from '../opencode';
 
 describe('opencode provider', () => {
   describe('buildHeadlessArgs', () => {
     it('prints OpenCode error logs while preserving the plain-text report stream', () => {
-      const { cmd, args } = opencode.buildHeadlessArgs({
+      const { cmd, args, env } = opencode.buildHeadlessArgs({
         prompt: 'Evaluate offer #42',
         model: 'anthropic/claude-3-haiku',
       });
@@ -38,6 +39,7 @@ describe('opencode provider', () => {
       expect(args[1]).toContain('--print-logs');
       expect(args[1]).toContain('--log-level ERROR');
       expect(args[1]).toContain('-m anthropic/claude-3-haiku');
+      expect(env?.PATH?.split(delimiter)).toContain(join(homedir(), '.opencode', 'bin'));
     });
 
     it('throws on outputFormat other than "text"', () => {

--- a/src/lib/server/providers/chat-capabilities.ts
+++ b/src/lib/server/providers/chat-capabilities.ts
@@ -11,6 +11,7 @@
 import 'server-only';
 import { execFileSync } from 'node:child_process';
 import type { ProviderId } from '../../schemas/providers';
+import { withProviderCliPath } from './cli-path';
 import type { Provider } from './types';
 
 export type ChatCapabilities = { resume: boolean };
@@ -18,7 +19,12 @@ export type ChatCapabilities = { resume: boolean };
 type ExecImpl = (cmd: string, args: string[]) => string;
 
 const defaultExec: ExecImpl = (cmd, args) =>
-  execFileSync(cmd, args, { encoding: 'utf-8', timeout: 5000, maxBuffer: 4 * 1024 * 1024 });
+  execFileSync(cmd, args, {
+    encoding: 'utf-8',
+    timeout: 5000,
+    maxBuffer: 4 * 1024 * 1024,
+    env: withProviderCliPath(),
+  });
 
 let execImpl: ExecImpl = defaultExec;
 

--- a/src/lib/server/providers/claude.ts
+++ b/src/lib/server/providers/claude.ts
@@ -46,6 +46,7 @@ import { dirname, join } from 'node:path';
 import { classifyProviderError } from '../../../../cli/classify-error.mjs';
 import type { UnifiedStreamEvent } from '../../schemas/providers';
 import { PLAYWRIGHT_CHAT_TOOLS } from '../chat/mcp-config';
+import { providerCliEnv, withProviderCliPath } from './cli-path';
 import { escapeForBash } from './shell';
 import type { ExitClassification, ModelChoice, Provider } from './types';
 
@@ -139,7 +140,11 @@ function _pickClaudeBinaryFromReal(real: string, fs: BinaryProbes): string | nul
 // STATIC_MODELS rather than crashing the Settings dropdown.
 function _resolveClaudeBinary(): string | null {
   try {
-    const which = execFileSync('which', ['claude'], { encoding: 'utf-8', timeout: 2000 }).trim();
+    const which = execFileSync('which', ['claude'], {
+      encoding: 'utf-8',
+      timeout: 2000,
+      env: withProviderCliPath(),
+    }).trim();
     if (!which) return null;
     const real = realpathSync(which);
     return _pickClaudeBinaryFromReal(real, {
@@ -296,7 +301,7 @@ const claude: Provider = {
     const pipe = usePipe ? ' | node cli/stream-claude-parser.mjs' : '';
 
     const cmdline = `claude -p ${parts.join(' ')} ${escapeForBash(prompt)}${pipe}`;
-    return { cmd: '/bin/bash', args: ['-c', cmdline] };
+    return { cmd: '/bin/bash', args: ['-c', cmdline], env: providerCliEnv() };
   },
 
   buildInteractiveLaunch({ promptFilePath, model }) {
@@ -306,6 +311,7 @@ const claude: Provider = {
     return {
       cmd: '/bin/bash',
       args: ['-c', `claude --model ${model} < ${promptFilePath}`],
+      env: providerCliEnv(),
     };
   },
 
@@ -343,7 +349,7 @@ const claude: Provider = {
     // unambiguous — claude consumes the whole file then hits EOF and proceeds.
     // (Headless jobs never saw this: they attach no MCP server.)
     const cmdline = `claude -p ${parts.join(' ')} < ${escapeForBash(promptFile)}`;
-    return { cmd: '/bin/bash', args: ['-c', cmdline] };
+    return { cmd: '/bin/bash', args: ['-c', cmdline], env: providerCliEnv() };
   },
 
   extractSessionId(streamLine) {
@@ -501,7 +507,11 @@ const claude: Provider = {
 
   async checkInstalled() {
     try {
-      const out = execFileSync('claude', ['--version'], { encoding: 'utf-8', timeout: 3000 });
+      const out = execFileSync('claude', ['--version'], {
+        encoding: 'utf-8',
+        timeout: 3000,
+        env: withProviderCliPath(),
+      });
       const m = out.match(/(\d+\.\d+\.\d+)/);
       return { ok: true, version: m?.[1] };
     } catch (err) {

--- a/src/lib/server/providers/cli-path.ts
+++ b/src/lib/server/providers/cli-path.ts
@@ -1,0 +1,62 @@
+// Provider CLIs are often installed into user-owned bin directories that a
+// long-running web server did not inherit (or that did not exist when it
+// started). Keep the inherited PATH first so existing command precedence is
+// unchanged, then append the standard install locations used by Claude Code,
+// Codex, OpenCode, and common package managers.
+
+import { homedir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+
+type CliPathOptions = {
+  home?: string;
+  execPath?: string;
+  platform?: NodeJS.Platform;
+};
+
+type PathEnvironment = Readonly<Record<string, string | undefined>>;
+
+function currentPath(env: PathEnvironment): string {
+  if (env.PATH) return env.PATH;
+  const key = Object.keys(env).find(name => name.toLowerCase() === 'path');
+  return key ? (env[key] ?? '') : '';
+}
+
+/** Build a PATH that can discover provider CLIs installed after server start. */
+export function providerCliPath(
+  env: PathEnvironment = process.env,
+  options: CliPathOptions = {},
+): string {
+  const home = options.home ?? homedir();
+  const execPath = options.execPath ?? process.execPath;
+  const platform = options.platform ?? process.platform;
+  const inherited = currentPath(env).split(delimiter).filter(Boolean);
+  const userBins = [
+    dirname(execPath),
+    join(home, '.local', 'bin'),
+    join(home, '.opencode', 'bin'),
+    join(home, '.npm-global', 'bin'),
+    join(home, '.bun', 'bin'),
+    join(home, '.volta', 'bin'),
+    join(home, '.local', 'share', 'pnpm'),
+  ];
+  const candidates =
+    platform === 'win32'
+      ? [
+          ...userBins,
+          env.APPDATA ? join(env.APPDATA, 'npm') : '',
+          env.LOCALAPPDATA ? join(env.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links') : '',
+        ]
+      : [...userBins, join(home, 'Library', 'pnpm'), '/opt/homebrew/bin', '/usr/local/bin'];
+
+  return [...new Set([...inherited, ...candidates.filter(Boolean)])].join(delimiter);
+}
+
+/** Minimal environment fragment for a provider spawn built by an adapter. */
+export function providerCliEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return { ...extra, PATH: providerCliPath() };
+}
+
+/** Full process environment for workers that may spawn a provider later. */
+export function withProviderCliPath(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return { ...env, PATH: providerCliPath(env) };
+}

--- a/src/lib/server/providers/codex.ts
+++ b/src/lib/server/providers/codex.ts
@@ -82,6 +82,7 @@ import { execFileSync } from 'node:child_process';
 import { classifyProviderError } from '../../../../cli/classify-error.mjs';
 import type { UnifiedStreamEvent } from '../../schemas/providers';
 import { PLAYWRIGHT_CHAT_TOOLS, readTurnMcpServers } from '../chat/mcp-config';
+import { providerCliEnv, withProviderCliPath } from './cli-path';
 import { escapeForBash } from './shell';
 import type { ExitClassification, Provider } from './types';
 
@@ -198,7 +199,7 @@ const codex: Provider = {
       // Collapse any double-spaces from flag-group omission to keep argv tidy
       // and the test substring assertions stable.
       args: ['-c', cmdline.replace(/\s+/g, ' ').trim()],
-      env: { CODEX_QUIET_MODE: '1' },
+      env: providerCliEnv({ CODEX_QUIET_MODE: '1' }),
     };
   },
 
@@ -209,6 +210,7 @@ const codex: Provider = {
     return {
       cmd: '/bin/bash',
       args: ['-c', `codex --model ${model} < ${promptFilePath}`],
+      env: providerCliEnv(),
     };
   },
 
@@ -323,7 +325,11 @@ const codex: Provider = {
 
     parts.push(`--model ${escapeForBash(model)}`);
     const cmdline = `${parts.join(' ')} "$(cat ${escapeForBash(promptFile)})"`;
-    return { cmd: '/bin/bash', args: ['-c', cmdline], env: { CODEX_QUIET_MODE: '1' } };
+    return {
+      cmd: '/bin/bash',
+      args: ['-c', cmdline],
+      env: providerCliEnv({ CODEX_QUIET_MODE: '1' }),
+    };
   },
 
   extractSessionId(_streamLine) {
@@ -523,7 +529,11 @@ const codex: Provider = {
 
   async checkInstalled() {
     try {
-      const out = execFileSync('codex', ['--version'], { encoding: 'utf-8', timeout: 3000 });
+      const out = execFileSync('codex', ['--version'], {
+        encoding: 'utf-8',
+        timeout: 3000,
+        env: withProviderCliPath(),
+      });
       const m = out.match(/(\d+\.\d+\.\d+)/);
       return { ok: true, version: m?.[1] };
     } catch (err) {

--- a/src/lib/server/providers/opencode.ts
+++ b/src/lib/server/providers/opencode.ts
@@ -57,6 +57,7 @@ import { getEncoding } from 'js-tiktoken';
 import { classifyProviderError } from '../../../../cli/classify-error.mjs';
 import type { UnifiedStreamEvent } from '../../schemas/providers';
 import { PLAYWRIGHT_CHAT_TOOLS, readTurnMcpConfig, readTurnMcpServers } from '../chat/mcp-config';
+import { providerCliEnv, withProviderCliPath } from './cli-path';
 import { escapeForBash } from './shell';
 import type { ExitClassification, Provider } from './types';
 
@@ -174,7 +175,7 @@ const opencode: Provider = {
     // it OpenCode can log the terminal error privately and remain alive until
     // sur9e's outer timeout instead of triggering the configured fallback.
     const cmdline = `opencode run --pure --print-logs --log-level ERROR -m ${model} ${escapeForBash(prompt)}`;
-    return { cmd: '/bin/bash', args: ['-c', cmdline] };
+    return { cmd: '/bin/bash', args: ['-c', cmdline], env: providerCliEnv() };
   },
 
   buildInteractiveLaunch({ promptFilePath, model }) {
@@ -185,6 +186,7 @@ const opencode: Provider = {
     return {
       cmd: '/bin/bash',
       args: ['-c', `opencode run -m ${model} "$(cat ${promptFilePath})"`],
+      env: providerCliEnv(),
     };
   },
 
@@ -296,7 +298,7 @@ const opencode: Provider = {
     return {
       cmd: '/bin/bash',
       args: ['-c', cmdline],
-      env: { OPENCODE_CONFIG: configPath },
+      env: providerCliEnv({ OPENCODE_CONFIG: configPath }),
     };
   },
 
@@ -376,7 +378,11 @@ const opencode: Provider = {
     // version doesn't ship the subcommand, timeout, etc.). The timeout
     // is intentionally short — model-picker UI must not block.
     try {
-      const out = execFileSync('opencode', ['models'], { encoding: 'utf-8', timeout: 5000 });
+      const out = execFileSync('opencode', ['models'], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        env: withProviderCliPath(),
+      });
       const ids = out
         .split('\n')
         .map(l => l.trim())
@@ -390,7 +396,11 @@ const opencode: Provider = {
 
   async checkInstalled() {
     try {
-      const out = execFileSync('opencode', ['--version'], { encoding: 'utf-8', timeout: 3000 });
+      const out = execFileSync('opencode', ['--version'], {
+        encoding: 'utf-8',
+        timeout: 3000,
+        env: withProviderCliPath(),
+      });
       const m = out.match(/(\d+\.\d+\.\d+)/);
       return { ok: true, version: m?.[1] };
     } catch (err) {

--- a/test/unit/chat/provider-chat-args.test.ts
+++ b/test/unit/chat/provider-chat-args.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { writeMcpConfigForTurn } from '@/lib/server/chat/mcp-config';
 import claude from '@/lib/server/providers/claude';
@@ -160,7 +161,8 @@ describe('codex chat surface', () => {
     expect(args[1]).not.toContain('--dangerously-bypass-approvals-and-sandbox');
     expect(args[1]).toContain("--model 'gpt-5.5'");
     expect(args[1]).toContain(`"$(cat '/tmp/turn.md')"`);
-    expect(env).toEqual({ CODEX_QUIET_MODE: '1' });
+    expect(env).toMatchObject({ CODEX_QUIET_MODE: '1' });
+    expect(env?.PATH?.split(delimiter)).toContain(join(homedir(), '.local', 'bin'));
   });
 
   it('throws when asked to resume (probe gates this off)', () => {


### PR DESCRIPTION
## Summary

- preserve the inherited PATH while appending standard user CLI install locations
- use the shared PATH for Claude Code, Codex, and OpenCode health/model/capability probes and all adapter launch modes
- propagate the same PATH to background workers so detection and execution cannot disagree
- clarify provider diagnostics and add regression coverage for all three providers

## Verification

- `npm run test:quick` (100 checks passed)
- `npm run build`
- stripped-PATH provider probe: Claude Code 2.1.251, Codex 0.151.0, OpenCode 1.18.25 all detected
- rebuilt and restarted the production Tailscale LaunchAgent; local and tailnet health endpoints pass, and `/api/providers` reports all three installed/authenticated

## AI assistance

Implemented and reviewed with Codex assistance.